### PR TITLE
[Poloniex] add CurrencyPair param to cancelOrder() raw method

### DIFF
--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeServiceRaw.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeServiceRaw.java
@@ -90,4 +90,18 @@ public class PoloniexTradeServiceRaw extends PoloniexBasePollingService<Poloniex
 
   }
 
+  public boolean cancel(String orderId, CurrencyPair currencyPair) throws IOException {
+
+    /*
+     * No need to look up CurrencyPair associated with orderId,
+     * as the caller will provide it.
+     */
+    HashMap<String, String> response = poloniex.cancelOrder(apiKey, signatureCreator, String.valueOf(nextNonce()),
+        orderId, PoloniexUtils.toPairString(currencyPair));
+    if (response.containsKey("error")) {
+      throw new ExchangeException(response.get("error"));
+    }
+    return response.get("success").toString().equals(new Integer(1).toString()) ? true : false;
+  }
+
 }


### PR DESCRIPTION
Typically an exchange only requires an `orderId` parameter to cancel an order.
The Poloniex cancelOrder API method requires 2 parameters: `orderId` and `currencyPair`

The current `xchange-poloniex` implementation will make an extra call to getOpenOrders() to find the CurrencyPair of an order; the order is then cancelled by providing `orderId` + `currencyPair` to the Poloniex API.

I've added an override to Poloniex's cancelOrder raw method to avoid the extra getOpenOrders() API call (if the caller already knows the CurrencyPair).

