### PR TITLE
Support Huobi trading in BitVc adapter

### DIFF
--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcAdapters.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcAdapters.java
@@ -19,6 +19,7 @@ import java.util.Locale;
 
 import com.xeiam.xchange.ExchangeException;
 import com.xeiam.xchange.bitvc.dto.account.BitVcAccountInfo;
+import com.xeiam.xchange.bitvc.dto.account.HuobiAccountInfo;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcDepth;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcOrderBookTAS;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcTicker;
@@ -115,6 +116,21 @@ public final class BitVcAdapters {
     List<Wallet> wallets = Arrays.asList(cny, btc, ltc, cnyLoan, btcLoan, ltcLoan);
     return new AccountInfo(null, wallets);
   }
+  
+  public static AccountInfo adaptHuobiAccountInfo(HuobiAccountInfo a) {
+
+    Wallet cny = new Wallet(CNY, a.getAvailableCnyDisplay().add(a.getFrozenCnyDisplay()).subtract(a.getLoanCnyDisplay()), "available");
+    Wallet btc = new Wallet(BTC, a.getAvailableBtcDisplay().add(a.getFrozenBtcDisplay()).subtract(a.getLoanBtcDisplay()), "available");
+    Wallet ltc = new Wallet(LTC, a.getAvailableLtcDisplay().add(a.getFrozenLtcDisplay()).subtract(a.getLoanLtcDisplay()), "available");
+
+    // loaned wallets
+    Wallet cnyLoan = new Wallet(CNY, a.getLoanCnyDisplay(), "loan");
+    Wallet btcLoan = new Wallet(BTC, a.getLoanBtcDisplay(), "loan");
+    Wallet ltcLoan = new Wallet(LTC, a.getLoanLtcDisplay(), "loan");
+
+    List<Wallet> wallets = Arrays.asList(cny, btc, ltc, cnyLoan, btcLoan, ltcLoan);
+    return new AccountInfo(null, wallets);
+  }
 
   public static String adaptPlaceOrderResult(BitVcPlaceOrderResult result) {
 
@@ -129,8 +145,8 @@ public final class BitVcAdapters {
   public static List<LimitOrder> adaptOpenOrders(BitVcOrder[] orders, CurrencyPair currencyPair) {
 
     List<LimitOrder> openOrders = new ArrayList<LimitOrder>(orders.length);
-    for (BitVcOrder order : orders) {
-      openOrders.add(adaptOpenOrder(order, currencyPair));
+    for (int i = 0; i < orders.length; i++) {
+      openOrders.add(adaptOpenOrder(orders[i], currencyPair));
     }
     return openOrders;
   }

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcExchange.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/BitVcExchange.java
@@ -9,13 +9,19 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.bitvc.service.polling.BitVcAccountService;
 import com.xeiam.xchange.bitvc.service.polling.BitVcMarketDataService;
 import com.xeiam.xchange.bitvc.service.polling.BitVcTradeService;
+import com.xeiam.xchange.bitvc.service.polling.BitVcTradeServiceRaw;
 import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.huobi.service.polling.HuobiAccountService;
+import com.xeiam.xchange.huobi.service.polling.HuobiTradeServiceRaw;
 
 public class BitVcExchange extends BaseExchange implements Exchange {
 
   public static final String SYMBOLS_PARAMETER = "symbols";
   public static final String TRADE_PASSWORD_PARAMETER = "trade_password";
-
+  public static final String URI_HUOBI = "huobi_uri";
+  public static final String URI_HUOBI_MARKETDATA = "huobi_uri_marketdata";
+  public static final String USE_HUOBI = "use_huobi";
+ 
   private static final List<CurrencyPair> SYMBOLS = Arrays.asList(CurrencyPair.BTC_CNY, CurrencyPair.LTC_CNY);
 
   @Override
@@ -24,8 +30,15 @@ public class BitVcExchange extends BaseExchange implements Exchange {
     super.applySpecification(exchangeSpecification);
     pollingMarketDataService = new BitVcMarketDataService(exchangeSpecification);
     if (exchangeSpecification.getApiKey() != null) {
-      pollingAccountService = new BitVcAccountService(exchangeSpecification);
-      pollingTradeService = new BitVcTradeService(exchangeSpecification);
+      if((Boolean) exchangeSpecification.getExchangeSpecificParametersItem(USE_HUOBI)) {
+        pollingAccountService = new HuobiAccountService(exchangeSpecification);
+        pollingTradeService = new BitVcTradeService(new HuobiTradeServiceRaw(exchangeSpecification));
+        
+      } else {
+        
+        pollingAccountService = new BitVcAccountService(exchangeSpecification);
+        pollingTradeService = new BitVcTradeService(new BitVcTradeServiceRaw(exchangeSpecification));
+      }
     }
   }
 
@@ -37,10 +50,18 @@ public class BitVcExchange extends BaseExchange implements Exchange {
 
     ExchangeSpecification spec = new ExchangeSpecification(getClass());
     spec.setExchangeName("BitVc");
-    spec.setExchangeDescription("BitVC");
+    spec.setExchangeDescription("BitVC and Huobi");
+    
+    /* by default we request market data from huobi and execute on bitvc */
     spec.setPlainTextUri("http://market.huobi.com/staticmarket");
     spec.setSslUri("https://api.bitvc.com");
     spec.setExchangeSpecificParametersItem(SYMBOLS_PARAMETER, SYMBOLS);
+
+    /* set to true if trade and account service should be from Huobi too */
+    spec.setExchangeSpecificParametersItem(USE_HUOBI, false);
+    spec.setExchangeSpecificParametersItem(URI_HUOBI, "https://api.huobi.com/apiv3");
+    spec.setExchangeSpecificParametersItem(URI_HUOBI_MARKETDATA, "http://market.huobi.com/staticmarket");
+    
     return spec;
   }
 }

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/Huobi.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/Huobi.java
@@ -1,0 +1,41 @@
+package com.xeiam.xchange.bitvc;
+
+import java.io.IOException;
+
+import javax.ws.rs.FormParam;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.xeiam.xchange.bitvc.dto.account.HuobiAccountInfo;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcCancelOrderResult;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcOrder;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcPlaceOrderResult;
+
+import si.mazi.rescu.ParamsDigest;
+
+
+@Path("")
+@Produces(MediaType.APPLICATION_JSON)
+public interface Huobi {
+
+  @POST
+  public HuobiAccountInfo getAccountInfo(@FormParam("access_key") String accessKey, @FormParam("created") long created, @FormParam("method") String method, @FormParam("sign") ParamsDigest sign) throws IOException;
+
+  @POST
+  public BitVcOrder[] getOrders(@FormParam("access_key") String accessKey, @FormParam("coin_type") int coinType, @FormParam("created") long created, @FormParam("method") String method, @FormParam("sign") ParamsDigest sign)
+      throws IOException;
+
+  @POST
+  public BitVcPlaceOrderResult placeLimitOrder(@FormParam("access_key") String accessKey, @FormParam("amount") String amount, @FormParam("coin_type") int coinType, @FormParam("created") long created,
+      @FormParam("price") String price, @FormParam("method") String method, @FormParam("sign") ParamsDigest sign) throws IOException;
+
+  @POST
+  public BitVcPlaceOrderResult placeMarketOrder(@FormParam("access_key") String accessKey, @FormParam("amount") String amount, @FormParam("coin_type") int coinType,
+      @FormParam("created") long created, @FormParam("method") String method, @FormParam("sign") ParamsDigest sign) throws IOException;
+
+  @POST
+  public BitVcCancelOrderResult cancelOrder(@FormParam("access_key") String accessKey, @FormParam("coin_type") int coinType, @FormParam("created") long created, @FormParam("id") long id,
+      @FormParam("method") String method, @FormParam("sign") ParamsDigest sign) throws IOException;
+}

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/dto/account/HuobiAccountInfo.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/dto/account/HuobiAccountInfo.java
@@ -1,0 +1,87 @@
+package com.xeiam.xchange.bitvc.dto.account;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class HuobiAccountInfo {
+
+  private final BigDecimal availableCny;
+  private final BigDecimal availableBtc;
+  private final BigDecimal availableLtc;
+  private final BigDecimal frozenCny;
+  private final BigDecimal frozenBtc;
+  private final BigDecimal frozenLtc;
+  private final BigDecimal loanCny;
+  private final BigDecimal loanBtc;
+  private final BigDecimal loanLtc;
+  
+  private final String message;
+  
+  public HuobiAccountInfo(@JsonProperty("available_cny_display") final BigDecimal availableCnyDisplay, @JsonProperty("available_btc_display") final BigDecimal availableBtcDisplay,
+      @JsonProperty("available_ltc_display") final BigDecimal availableLtcDisplay, @JsonProperty("frozen_cny_display") final BigDecimal frozenCnyDisplay,
+      @JsonProperty("frozen_btc_display") final BigDecimal frozenBtcDisplay, @JsonProperty("frozen_ltc_display") final BigDecimal frozenLtcDisplay, @JsonProperty("loan_cny_display") final BigDecimal loanCnyDisplay,
+      @JsonProperty("loan_btc_display") final BigDecimal loanBtcDisplay, @JsonProperty("loan_ltc_display") final BigDecimal loanLtcDisplay, @JsonProperty("message") String message) {
+
+    this.availableCny = availableCnyDisplay;
+    this.availableBtc = availableBtcDisplay;
+    this.availableLtc = availableLtcDisplay;
+    this.frozenCny = frozenCnyDisplay;
+    this.frozenBtc = frozenBtcDisplay;
+    this.frozenLtc = frozenLtcDisplay;
+    this.loanCny = loanCnyDisplay;
+    this.loanBtc = loanBtcDisplay;
+    this.loanLtc = loanLtcDisplay;
+    
+    this.message = message;
+  }
+
+  public BigDecimal getAvailableCnyDisplay() {
+
+    return availableCny == null ? BigDecimal.ZERO : availableCny;
+  }
+
+  public BigDecimal getAvailableBtcDisplay() {
+
+    return availableBtc == null ? BigDecimal.ZERO : availableBtc;
+  }
+
+  public BigDecimal getAvailableLtcDisplay() {
+
+    return availableLtc == null ? BigDecimal.ZERO : availableLtc;
+  }
+
+  public BigDecimal getFrozenCnyDisplay() {
+
+    return frozenCny == null ? BigDecimal.ZERO : frozenCny;
+  }
+
+  public BigDecimal getFrozenBtcDisplay() {
+
+    return frozenBtc == null ? BigDecimal.ZERO : frozenBtc;
+  }
+
+  public BigDecimal getFrozenLtcDisplay() {
+
+    return frozenLtc == null ? BigDecimal.ZERO : frozenLtc;
+  }
+
+  public BigDecimal getLoanCnyDisplay() {
+
+    return loanCny == null ? BigDecimal.ZERO : loanCny;
+  }
+
+  public BigDecimal getLoanBtcDisplay() {
+
+    return loanBtc == null ? BigDecimal.ZERO : loanBtc;
+  }
+
+  public BigDecimal getLoanLtcDisplay() {
+
+    return loanLtc == null ? BigDecimal.ZERO : loanLtc;
+  }
+  
+  public String getMessage() {
+    return message;
+  }
+}

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/service/polling/BitVcMarketDataServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/service/polling/BitVcMarketDataServiceRaw.java
@@ -6,6 +6,7 @@ import si.mazi.rescu.RestProxyFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.bitvc.BitVc;
+import com.xeiam.xchange.bitvc.BitVcExchange;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcDepth;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcOrderBookTAS;
 import com.xeiam.xchange.bitvc.dto.marketdata.BitVcTicker;
@@ -18,7 +19,7 @@ public class BitVcMarketDataServiceRaw extends BitVcBasePollingService {
 
     super(exchangeSpecification);
 
-    final String baseUrl = exchangeSpecification.getPlainTextUri();
+    final String baseUrl = (String) exchangeSpecification.getExchangeSpecificParametersItem(BitVcExchange.URI_HUOBI_MARKETDATA);
     bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl);
   }
 

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/service/polling/BitVcTradeServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/service/polling/BitVcTradeServiceRaw.java
@@ -11,11 +11,11 @@ import com.xeiam.xchange.bitvc.dto.trade.BitVcOrder;
 import com.xeiam.xchange.bitvc.dto.trade.BitVcOrderResult;
 import com.xeiam.xchange.bitvc.dto.trade.BitVcPlaceOrderResult;
 import com.xeiam.xchange.dto.Order.OrderType;
+import com.xeiam.xchange.huobi.service.polling.TradeServiceRaw;
 
-public class BitVcTradeServiceRaw extends BitVcBaseTradeService {
+public class BitVcTradeServiceRaw extends BitVcBaseTradeService implements TradeServiceRaw {
 
-  protected BitVcTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
-
+  public BitVcTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
     super(exchangeSpecification);
   }
 

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountService.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountService.java
@@ -1,4 +1,4 @@
-package com.xeiam.xchange.bitvc.service.polling;
+package com.xeiam.xchange.huobi.service.polling;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -9,26 +9,25 @@ import com.xeiam.xchange.bitvc.BitVcAdapters;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.service.polling.PollingAccountService;
 
-public class BitVcAccountService extends BitVcAccountServiceRaw implements PollingAccountService {
+public class HuobiAccountService extends HuobiAccountServiceRaw implements PollingAccountService {
 
-  public BitVcAccountService(ExchangeSpecification exchangeSpecification) {
+  public HuobiAccountService(ExchangeSpecification exchangeSpecification) {
+
     super(exchangeSpecification);
   }
 
   @Override
   public AccountInfo getAccountInfo() throws IOException {
-    return BitVcAdapters.adaptAccountInfo(getBitVcAccountInfo());
+    return BitVcAdapters.adaptHuobiAccountInfo(getHuobiAccountInfo());
   }
 
   @Override
   public String withdrawFunds(String currency, BigDecimal amount, String address) {
-
     throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public String requestDepositAddress(String currency, String... args) {
-
     throw new NotAvailableFromExchangeException();
   }
 

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountServiceRaw.java
@@ -1,0 +1,26 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import java.io.IOException;
+
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.bitvc.dto.account.HuobiAccountInfo;
+
+public class HuobiAccountServiceRaw extends HuobiBaseTradeService {
+
+  public HuobiAccountServiceRaw(ExchangeSpecification exchangeSpecification) {
+
+    super(exchangeSpecification);
+  }
+
+  public HuobiAccountInfo getHuobiAccountInfo() throws IOException {
+    HuobiAccountInfo accountInfo = huobi.getAccountInfo(accessKey, nextCreated(), "get_account_info", digest);
+
+    if (accountInfo.getMessage() != null) {
+      throw new ExchangeException(accountInfo.getMessage());
+    }
+    else {
+      return accountInfo;
+    }
+  }
+}

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiBaseTradeService.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiBaseTradeService.java
@@ -1,0 +1,29 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import si.mazi.rescu.RestProxyFactory;
+
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.bitvc.BitVcExchange;
+import com.xeiam.xchange.bitvc.Huobi;
+import com.xeiam.xchange.bitvc.service.BitVcDigest;
+import com.xeiam.xchange.bitvc.service.polling.BitVcBasePollingService;
+
+
+public class HuobiBaseTradeService extends BitVcBasePollingService {
+  protected final Huobi huobi;
+  protected final String accessKey;
+  protected final BitVcDigest digest;
+
+  protected HuobiBaseTradeService(ExchangeSpecification exchangeSpecification) {
+
+    super(exchangeSpecification);
+    
+    huobi = RestProxyFactory.createProxy(Huobi.class, (String) exchangeSpecification.getExchangeSpecificParametersItem(BitVcExchange.URI_HUOBI));
+    accessKey = exchangeSpecification.getApiKey();
+    digest = new BitVcDigest(exchangeSpecification.getSecretKey());
+  }
+
+  protected long nextCreated() {
+    return System.currentTimeMillis() / 1000;
+  }
+}

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiTradeServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiTradeServiceRaw.java
@@ -1,0 +1,39 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import static com.xeiam.xchange.dto.Order.OrderType.BID;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcCancelOrderResult;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcOrder;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcPlaceOrderResult;
+import com.xeiam.xchange.dto.Order.OrderType;
+
+
+public class HuobiTradeServiceRaw extends HuobiBaseTradeService implements TradeServiceRaw {
+  public HuobiTradeServiceRaw(ExchangeSpecification exchangeSpecification) {
+    super(exchangeSpecification);  
+  }
+  
+  public BitVcOrder[] getBitVcOrders(int coinType) throws IOException {
+    return huobi.getOrders(accessKey, coinType, nextCreated(), "get_orders", digest);
+  }
+  
+  public BitVcPlaceOrderResult placeBitVcLimitOrder(OrderType type, int coinType, BigDecimal price, BigDecimal amount) throws IOException {
+    String method = type == BID ? "buy" : "sell";
+   
+    return huobi.placeLimitOrder(accessKey, amount.toPlainString(), coinType, nextCreated(), price.toPlainString(), method, digest);
+  }
+  
+  public BitVcPlaceOrderResult placeBitVcMarketOrder(OrderType type, int coinType, BigDecimal amount) throws IOException {
+    final String method = type == BID ? "buy_market" : "sell_market";
+
+    return huobi.placeMarketOrder(accessKey, amount.toPlainString(), coinType, nextCreated(), method, digest);
+  }
+  
+  public BitVcCancelOrderResult cancelBitVcOrder(int coinType, long id) throws IOException {
+    return huobi.cancelOrder(accessKey, coinType, nextCreated(), id, "cancel_order", digest);
+  }
+}

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/TradeServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/TradeServiceRaw.java
@@ -1,0 +1,20 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collection;
+
+import com.xeiam.xchange.bitvc.dto.trade.BitVcCancelOrderResult;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcOrder;
+import com.xeiam.xchange.bitvc.dto.trade.BitVcPlaceOrderResult;
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.Order.OrderType;
+
+public interface TradeServiceRaw {
+  public BitVcOrder[] getBitVcOrders(int coinType) throws IOException;
+  public BitVcPlaceOrderResult placeBitVcLimitOrder(OrderType type, int coinType, BigDecimal price, BigDecimal amount) throws IOException;
+  public BitVcPlaceOrderResult placeBitVcMarketOrder(OrderType type, int coinType, BigDecimal amount) throws IOException;
+  public BitVcCancelOrderResult cancelBitVcOrder(int coinType, long id) throws IOException;
+  
+  public Collection<CurrencyPair> getExchangeSymbols() throws IOException;
+}


### PR DESCRIPTION
BitVc is already using Huobi market data, with the new configurable param `use_huobi` you can switch to Huobi completely, for market data, account and trading. The APIs are extremely similar, that's why this merge makes sense, sharing the adapter methods almost completely.