### PR TITLE
Adjust HuobiAccountInfo parsing of error messages

### DIFF
--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/dto/account/HuobiAccountInfo.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/bitvc/dto/account/HuobiAccountInfo.java
@@ -16,12 +16,13 @@ public class HuobiAccountInfo {
   private final BigDecimal loanBtc;
   private final BigDecimal loanLtc;
   
-  private final String message;
+  private final String msg;
+  private final String result;
   
   public HuobiAccountInfo(@JsonProperty("available_cny_display") final BigDecimal availableCnyDisplay, @JsonProperty("available_btc_display") final BigDecimal availableBtcDisplay,
       @JsonProperty("available_ltc_display") final BigDecimal availableLtcDisplay, @JsonProperty("frozen_cny_display") final BigDecimal frozenCnyDisplay,
       @JsonProperty("frozen_btc_display") final BigDecimal frozenBtcDisplay, @JsonProperty("frozen_ltc_display") final BigDecimal frozenLtcDisplay, @JsonProperty("loan_cny_display") final BigDecimal loanCnyDisplay,
-      @JsonProperty("loan_btc_display") final BigDecimal loanBtcDisplay, @JsonProperty("loan_ltc_display") final BigDecimal loanLtcDisplay, @JsonProperty("message") String message) {
+      @JsonProperty("loan_btc_display") final BigDecimal loanBtcDisplay, @JsonProperty("loan_ltc_display") final BigDecimal loanLtcDisplay, @JsonProperty("msg") String msg, @JsonProperty("result") String result) {
 
     this.availableCny = availableCnyDisplay;
     this.availableBtc = availableBtcDisplay;
@@ -33,7 +34,8 @@ public class HuobiAccountInfo {
     this.loanBtc = loanBtcDisplay;
     this.loanLtc = loanLtcDisplay;
     
-    this.message = message;
+    this.msg = msg;
+    this.result = result;
   }
 
   public BigDecimal getAvailableCnyDisplay() {
@@ -81,7 +83,11 @@ public class HuobiAccountInfo {
     return loanLtc == null ? BigDecimal.ZERO : loanLtc;
   }
   
-  public String getMessage() {
-    return message;
+  public String getMsg() {
+    return msg;
+  }
+  
+  public String getResult() {
+    return result;
   }
 }

--- a/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountServiceRaw.java
+++ b/xchange-bitvc/src/main/java/com/xeiam/xchange/huobi/service/polling/HuobiAccountServiceRaw.java
@@ -16,8 +16,8 @@ public class HuobiAccountServiceRaw extends HuobiBaseTradeService {
   public HuobiAccountInfo getHuobiAccountInfo() throws IOException {
     HuobiAccountInfo accountInfo = huobi.getAccountInfo(accessKey, nextCreated(), "get_account_info", digest);
 
-    if (accountInfo.getMessage() != null) {
-      throw new ExchangeException(accountInfo.getMessage());
+    if (accountInfo.getResult().equals("fail")) {
+      throw new ExchangeException(accountInfo.getMsg());
     }
     else {
       return accountInfo;


### PR DESCRIPTION
HuobiAccountInfo is using "msg" instead of "message" for returning failure reasons.