### PR TITLE
Bitstamp: Ripple stuff: deposit address, withdraw to ripple.

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAuthenticated.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAuthenticated.java
@@ -2,7 +2,6 @@ package com.xeiam.xchange.bitstamp;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.List;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
@@ -16,6 +15,7 @@ import si.mazi.rescu.ParamsDigest;
 
 import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampDepositAddress;
+import com.xeiam.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import com.xeiam.xchange.bitstamp.dto.account.DepositTransaction;
 import com.xeiam.xchange.bitstamp.dto.account.WithdrawalRequest;
@@ -84,6 +84,21 @@ public interface BitstampAuthenticated {
   @POST
   @Path("withdrawal_requests/")
   public WithdrawalRequest[] getWithdrawalRequests(@FormParam("key") String apiKey, @FormParam("signature") ParamsDigest signer, @FormParam("nonce") long nonce)
+      throws BitstampException, IOException;
+
+  /**
+   * Note that due to a bug on Bitstamp's side, withdrawal always fails if two-factor authentication
+   * is enabled for the account.
+   */
+  @POST
+  @Path("ripple_withdrawal/")
+  public boolean withdrawToRipple(@FormParam("key") String apiKey, @FormParam("signature") ParamsDigest signer, @FormParam("nonce") long nonce, @FormParam("amount") BigDecimal amount,
+                                  @FormParam("currency") String currency, @FormParam("address") String rippleAddress)
+      throws BitstampException, IOException;
+
+  @POST
+  @Path("ripple_address/")
+  public BitstampRippleDepositAddress getRippleDepositAddress(@FormParam("key") String apiKey, @FormParam("signature") ParamsDigest signer, @FormParam("nonce") long nonce)
       throws BitstampException, IOException;
 
 }

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/account/BitstampRippleDepositAddress.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/dto/account/BitstampRippleDepositAddress.java
@@ -1,0 +1,47 @@
+package com.xeiam.xchange.bitstamp.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitstampRippleDepositAddress {
+
+  @JsonProperty("address")
+  private final String addressAndDt;
+
+  @JsonIgnore
+  private String address = null;
+
+  @JsonIgnore
+  private Long destinationTag = null;
+
+  protected BitstampRippleDepositAddress(@JsonProperty("address") String addressAndDt) {
+
+    this.addressAndDt = addressAndDt;
+    final String[] split = addressAndDt.split("\\?dt=");
+    if (split.length == 2) {
+      address = split[0];
+      destinationTag = Long.parseLong(split[1]);
+    }
+  }
+
+  public String getAddressAndDt() {
+
+    return addressAndDt;
+  }
+
+  public String getAddress() {
+
+    return address;
+  }
+
+  public Long getDestinationTag() {
+
+    return destinationTag;
+  }
+
+  @Override
+  public String toString() {
+
+    return (address == null ? addressAndDt : String.format("RippleAddress[%s, dt=%s]", address, destinationTag));
+  }
+}

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountServiceRaw.java
@@ -13,6 +13,7 @@ import com.xeiam.xchange.bitstamp.BitstampAuthenticated;
 import com.xeiam.xchange.bitstamp.BitstampUtils;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampDepositAddress;
+import com.xeiam.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import com.xeiam.xchange.bitstamp.dto.account.DepositTransaction;
 import com.xeiam.xchange.bitstamp.dto.account.WithdrawalRequest;
@@ -65,6 +66,23 @@ public class BitstampAccountServiceRaw extends BitstampBasePollingService {
       throw new ExchangeException("Requesting Bitcoin deposit address failed: " + response.getError());
     }
     return response;
+  }
+
+  public BitstampRippleDepositAddress getRippleDepositAddress() throws IOException {
+
+    return bitstampAuthenticated.getRippleDepositAddress(exchangeSpecification.getApiKey(), signatureCreator, BitstampUtils.getNonce());
+  }
+
+  /**
+   * @return true if withdrawal was successfull.
+   *
+   * Note that due to a bug on Bitstamp's side, withdrawal always fails if two-factor authentication
+   * is enabled for the account.
+   */
+  public boolean withdrawToRipple(BigDecimal amount, String currency, String rippleAddress) throws IOException {
+
+    return bitstampAuthenticated.withdrawToRipple(
+        exchangeSpecification.getApiKey(), signatureCreator, BitstampUtils.getNonce(), amount, currency, rippleAddress);
   }
 
   public List<DepositTransaction> getUnconfirmedDeposits() throws IOException {


### PR DESCRIPTION
Note that due to a bug in Bitstamp's implementation, ripple withdrawal only works if Google Authenticator authentication is disabled for the Bitstamp account.