### PR TITLE
Add trading fee to AccountInfo @ BTC-e and Hitbtc

### DIFF
--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXAdapters.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/ANXAdapters.java
@@ -51,7 +51,7 @@ public final class ANXAdapters {
   public static AccountInfo adaptAccountInfo(ANXAccountInfo anxAccountInfo) {
 
     // Adapt to XChange DTOs
-    AccountInfo accountInfo = new AccountInfo(anxAccountInfo.getLogin(), anxAccountInfo.getTradeFee(), ANXAdapters.adaptWallets(anxAccountInfo.getWallets()));
+    AccountInfo accountInfo = new AccountInfo(anxAccountInfo.getLogin(), percentToFactor(anxAccountInfo.getTradeFee()), ANXAdapters.adaptWallets(anxAccountInfo.getWallets()));
     return accountInfo;
   }
 

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEAdapters.java
@@ -142,7 +142,7 @@ public final class BTCEAdapters {
     return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).volume(volume).timestamp(timestamp).build();
   }
 
-  public static AccountInfo adaptAccountInfo(BTCEAccountInfo btceAccountInfo) {
+  public static AccountInfo adaptAccountInfo(BTCEAccountInfo btceAccountInfo, BigDecimal tradingFee) {
 
     List<Wallet> wallets = new ArrayList<Wallet>();
     Map<String, BigDecimal> funds = btceAccountInfo.getFunds();
@@ -152,7 +152,7 @@ public final class BTCEAdapters {
 
       wallets.add(new Wallet(currency, funds.get(lcCurrency)));
     }
-    return new AccountInfo(null, wallets);
+    return new AccountInfo(null, tradingFee, wallets);
   }
 
   public static OpenOrders adaptOrders(Map<Long, BTCEOrder> btceOrderMap) {
@@ -215,6 +215,6 @@ public final class BTCEAdapters {
     // convert percent to factor
     BigDecimal orderFeeFactor = pairInfo.getFee().movePointLeft(2);
 
-    return new BTCETradeServiceHelper(minAmount, pairInfo.getDecimals(), orderFeeFactor, pairInfo.getMinPrice(), pairInfo.getMaxPrice());
+    return new BTCETradeServiceHelper(minAmount, pairInfo.getDecimals(), pairInfo.getMinPrice(), pairInfo.getMaxPrice());
   }
 }

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEExchange.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEExchange.java
@@ -1,5 +1,8 @@
 package com.xeiam.xchange.btce.v3;
 
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.btce.v3.dto.marketdata.BTCEExchangeInfo;
+import com.xeiam.xchange.btce.v3.service.polling.BTCETradeServiceRaw;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.BaseExchange;
@@ -9,6 +12,8 @@ import com.xeiam.xchange.btce.v3.service.polling.BTCEAccountService;
 import com.xeiam.xchange.btce.v3.service.polling.BTCEMarketDataService;
 import com.xeiam.xchange.btce.v3.service.polling.BTCETradeService;
 import com.xeiam.xchange.utils.nonce.IntTimeNonceFactory;
+
+import java.io.IOException;
 
 /**
  * <p>
@@ -50,5 +55,13 @@ public class BTCEExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setExchangeDescription("BTC-e is a Bitcoin exchange registered in Russia.");
 
     return exchangeSpecification;
+  }
+
+  @Override
+  public void init() throws IOException, ExchangeException {
+    super.init();
+
+    BTCEExchangeInfo info = ((BTCETradeServiceRaw) pollingTradeService).getExchangeInfo();
+    ((BTCEAccountService) pollingAccountService).setTradingFeeFromExchangeInfo(info);
   }
 }

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/dto/marketdata/BTCETradeServiceHelper.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/dto/marketdata/BTCETradeServiceHelper.java
@@ -9,7 +9,7 @@ public class BTCETradeServiceHelper extends BaseTradeServiceHelper {
   final private BigDecimal minPrice;
   final private BigDecimal maxPrice;
 
-  public BTCETradeServiceHelper(BigDecimal amountMinimum, int priceScale, BigDecimal orderFeeFactor, BigDecimal minPrice, BigDecimal maxPrice) {
+  public BTCETradeServiceHelper(BigDecimal amountMinimum, int priceScale, BigDecimal minPrice, BigDecimal maxPrice) {
 
     super(amountMinimum, priceScale);
     assert minPrice != null;

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCEAccountService.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCEAccountService.java
@@ -2,11 +2,15 @@ package com.xeiam.xchange.btce.v3.service.polling;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.Map;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.NotAvailableFromExchangeException;
 import com.xeiam.xchange.btce.v3.BTCEAdapters;
 import com.xeiam.xchange.btce.v3.dto.account.BTCEAccountInfo;
+import com.xeiam.xchange.btce.v3.dto.marketdata.BTCEExchangeInfo;
+import com.xeiam.xchange.btce.v3.dto.marketdata.BTCEPairInfo;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.service.polling.PollingAccountService;
 import si.mazi.rescu.SynchronizedValueFactory;
@@ -16,9 +20,11 @@ import si.mazi.rescu.SynchronizedValueFactory;
  */
 public class BTCEAccountService extends BTCEAccountServiceRaw implements PollingAccountService {
 
+  private BigDecimal tradingFee;
+
   /**
    * Constructor
-   * 
+   *
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
   public BTCEAccountService(ExchangeSpecification exchangeSpecification, SynchronizedValueFactory<Integer> nonceFactory) {
@@ -30,7 +36,7 @@ public class BTCEAccountService extends BTCEAccountServiceRaw implements Polling
   public AccountInfo getAccountInfo() throws IOException {
 
     BTCEAccountInfo info = getBTCEAccountInfo(null, null, null, null, null, null, null);
-    return BTCEAdapters.adaptAccountInfo(info);
+    return BTCEAdapters.adaptAccountInfo(info, tradingFee);
   }
 
   @Override
@@ -43,5 +49,12 @@ public class BTCEAccountService extends BTCEAccountServiceRaw implements Polling
   public String requestDepositAddress(String currency, String... args) throws IOException {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  public void setTradingFeeFromExchangeInfo(BTCEExchangeInfo info) {
+    Map<String, BTCEPairInfo> pairs = info.getPairs();
+    Iterator<BTCEPairInfo> iter = pairs.values().iterator();
+    if(iter.hasNext())
+      tradingFee = iter.next().getFee();
   }
 }

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCEAccountService.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCEAccountService.java
@@ -54,7 +54,7 @@ public class BTCEAccountService extends BTCEAccountServiceRaw implements Polling
   public void setTradingFeeFromExchangeInfo(BTCEExchangeInfo info) {
     Map<String, BTCEPairInfo> pairs = info.getPairs();
     Iterator<BTCEPairInfo> iter = pairs.values().iterator();
-    if(iter.hasNext())
-      tradingFee = iter.next().getFee();
+    if (iter.hasNext())
+      tradingFee = iter.next().getFee().movePointLeft(2);
   }
 }

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeService.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeService.java
@@ -201,7 +201,7 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
     Map<CurrencyPair, BTCETradeServiceHelper>result = new HashMap<CurrencyPair, BTCETradeServiceHelper>();
     int amountScale = CFG.getIntProperty(KEY_ORDER_SIZE_SCALE_DEFAULT);
 
-    Map<String, BTCEPairInfo> pairInfos = btce.getInfo().getPairs();
+    Map<String, BTCEPairInfo> pairInfos = getExchangeInfo().getPairs();
     for (Map.Entry<String, BTCEPairInfo> e : pairInfos.entrySet()) {
       CurrencyPair pair = BTCEAdapters.adaptCurrencyPair(e.getKey());
       BTCETradeServiceHelper meta = BTCEAdapters.createMarketMetadata(e.getValue(), amountScale);

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeServiceRaw.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeServiceRaw.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.btce.v3.BTCEAuthenticated;
+import com.xeiam.xchange.btce.v3.dto.marketdata.BTCEExchangeInfo;
 import com.xeiam.xchange.btce.v3.dto.trade.BTCECancelOrderResult;
 import com.xeiam.xchange.btce.v3.dto.trade.BTCECancelOrderReturn;
 import com.xeiam.xchange.btce.v3.dto.trade.BTCEOpenOrdersReturn;
@@ -102,4 +103,7 @@ public class BTCETradeServiceRaw extends BTCEBasePollingService<BTCEAuthenticate
     return btceTradeHistory.getReturnValue();
   }
 
+  public BTCEExchangeInfo getExchangeInfo() throws IOException {
+    return btce.getInfo();
+  }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/currency/CurrencyPair.java
@@ -182,6 +182,18 @@ public class CurrencyPair {
     this.counterSymbol = counterSymbol;
   }
 
+  /**
+   * Parse currency pair from a string in the same format as returned by toString() method - XXX/YYY
+   */
+  public static CurrencyPair fromString(String currencyPair) {
+    int split = currencyPair.indexOf("/");
+    if (split < 1)
+      throw new IllegalArgumentException("Could not parse currency pair from '" + currencyPair + "'");
+    String base = currencyPair.substring(0, split);
+    String counter = currencyPair.substring(split + 1);
+    return new CurrencyPair(base, counter);
+  }
+
   @Override
   public String toString() {
 
@@ -229,5 +241,4 @@ public class CurrencyPair {
     }
     return true;
   }
-
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/account/AccountInfo.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/account/AccountInfo.java
@@ -73,7 +73,7 @@ public final class AccountInfo {
   /**
    * Utility method to locate an exchange balance in the given currency
    * 
-   * @param currencyUnit A valid currency unit (e.g. CurrencyUnit.USD or CurrencyUnit.of("BTC"))
+   * @param currency A valid currency unit (e.g. CurrencyUnit.USD or CurrencyUnit.of("BTC"))
    * @return The balance, or zero if not found
    */
   public BigDecimal getBalance(String currency) {
@@ -91,7 +91,7 @@ public final class AccountInfo {
   @Override
   public String toString() {
 
-    return "AccountInfo [username=" + username + ", wallets=" + wallets + "]";
+    return "AccountInfo [username=" + username + ", fee=" + tradingFee + ", wallets=" + wallets + "]";
   }
 
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/BaseExchangeService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/BaseExchangeService.java
@@ -18,6 +18,8 @@ public abstract class BaseExchangeService {
   protected static final String SUF_ORDER_SIZE_MIN_DEFAULT = IN_ORDER_SIZE_MIN + SUF_DEFAULT;
   protected static final String SUF_ORDER_SIZE_SCALE_DEFAULT = ".order.size.scale." + SUF_DEFAULT;
   protected static final String SUF_ORDER_PRICE_SCALE_DEFAULT = ".order.price.scale." + SUF_DEFAULT;
+  protected static final String ORDER_FEE_LISTING = ".order.fee.listing.";
+  protected static final String XCHANGE_ORDER_FEE_LISTING_DEFAULT = "xchange" + ORDER_FEE_LISTING + SUF_DEFAULT;
 
   /**
    * The exchange specification containing session-specific information

--- a/xchange-core/src/main/resources/xchange.properties
+++ b/xchange-core/src/main/resources/xchange.properties
@@ -2,6 +2,9 @@
 #
 # Please keep exchanges in alphabetical order for easier navigation
 
+# for exchanges that have varying trading fees for listings, select which value will be put in AccountInfo
+xchange.order.fee.defaultListing=BTC/USD
+
 # ANX
 anx.order.size.min.BTC=.01
 anx.order.size.min.LTC=.1
@@ -28,6 +31,12 @@ kraken.order.size.min.default=.01
 
 # BTC-e
 btce.order.size.scale.default=8
+
+
+# Hitbtc
+# the defaults:
+#hitbtc.order.fee.defaultListing=BTC/USD
+#hitbtc.order.feePolicy.maker=false
 
 
 #...

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyAdapters.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyAdapters.java
@@ -366,8 +366,7 @@ public final class CryptsyAdapters {
 
   public static CurrencyPair adaptCurrencyPair(String cryptsyLabel) {
 
-    String[] marketCurrencies = cryptsyLabel.split("/");
-    return new CurrencyPair(marketCurrencies[0], marketCurrencies[1]);
+    return CurrencyPair.fromString(cryptsyLabel);
   }
 
   /**

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcAdapters.java
@@ -15,12 +15,7 @@ import com.xeiam.xchange.dto.trade.UserTrade;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.dto.trade.Wallet;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalance;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcOrderBook;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcSymbol;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcSymbols;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTicker;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTrade;
-import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTrades;
+import com.xeiam.xchange.hitbtc.dto.marketdata.*;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOrder;
 import com.xeiam.xchange.hitbtc.dto.trade.HitbtcOwnTrade;
 
@@ -152,7 +147,7 @@ public class HitbtcAdapters {
     return side.equals("buy") ? OrderType.BID : OrderType.ASK;
   }
 
-  public static UserTrades adaptTradeHistory(HitbtcOwnTrade[] tradeHistoryRaw, Map<CurrencyPair, TradeServiceHelper> metadata) {
+  public static UserTrades adaptTradeHistory(HitbtcOwnTrade[] tradeHistoryRaw, Map<CurrencyPair, ? extends TradeServiceHelper> metadata) {
 
     List<UserTrade> trades = new ArrayList<UserTrade>(tradeHistoryRaw.length);
     for (int i = 0; i < tradeHistoryRaw.length; i++) {
@@ -171,7 +166,7 @@ public class HitbtcAdapters {
     return new UserTrades(trades, TradeSortType.SortByTimestamp);
   }
 
-  public static AccountInfo adaptAccountInfo(HitbtcBalance[] accountInfoRaw) {
+  public static AccountInfo adaptAccountInfo(HitbtcBalance[] accountInfoRaw, BigDecimal tradingFee) {
 
     List<Wallet> wallets = new ArrayList<Wallet>(accountInfoRaw.length);
 
@@ -182,7 +177,7 @@ public class HitbtcAdapters {
       wallets.add(wallet);
 
     }
-    return new AccountInfo(null, wallets);
+    return new AccountInfo(null, tradingFee, wallets);
   }
 
   public static String adaptCurrencyPair(CurrencyPair pair) {
@@ -216,14 +211,14 @@ public class HitbtcAdapters {
     return type == OrderType.BID ? "buy" : "sell";
   }
 
-  public static Map<CurrencyPair, TradeServiceHelper> adaptSymbolsToMetadata(HitbtcSymbols symbols) {
+  public static Map<CurrencyPair, HitbtcTradeServiceHelper> adaptSymbolsToMetadata(HitbtcSymbols symbols) {
 
-    Map<CurrencyPair, TradeServiceHelper> result = new HashMap<CurrencyPair, TradeServiceHelper>();
+    Map<CurrencyPair, HitbtcTradeServiceHelper> result = new HashMap<CurrencyPair, HitbtcTradeServiceHelper>();
     for (HitbtcSymbol symbol : symbols.getHitbtcSymbols()) {
       CurrencyPair pair = adaptSymbol(symbol);
 
       BigDecimal lot = symbol.getLot();
-      BaseTradeServiceHelper tradeServiceHelper = new BaseTradeServiceHelper(lot, symbol.getStep().scale());
+      HitbtcTradeServiceHelper tradeServiceHelper = new HitbtcTradeServiceHelper(lot, symbol.getStep().scale(), symbol.getTakeLiquidityRate(), symbol.getProvideLiquidityRate());
 
       result.put(pair, tradeServiceHelper);
     }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcExchange.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/HitbtcExchange.java
@@ -1,16 +1,19 @@
 package com.xeiam.xchange.hitbtc;
 
+import java.io.IOException;
+import java.util.Map;
+
 import com.xeiam.xchange.BaseExchange;
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeException;
 import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTradeServiceHelper;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcAccountService;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcMarketDataService;
 import com.xeiam.xchange.hitbtc.service.polling.HitbtcTradeService;
 import com.xeiam.xchange.utils.nonce.LongTimeNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
-
-import java.io.IOException;
 
 public class HitbtcExchange extends BaseExchange implements Exchange {
 
@@ -45,6 +48,7 @@ public class HitbtcExchange extends BaseExchange implements Exchange {
   public void init() throws IOException, ExchangeException {
     super.init();
 
-    ((HitbtcTradeService) pollingTradeService).init();
+    Map<CurrencyPair, HitbtcTradeServiceHelper> map = ((HitbtcTradeService) pollingTradeService).getTradeServiceHelperMap();
+    ((HitbtcAccountService)pollingAccountService).setTradingFeeFromTradeHelpers(map);
   }
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/dto/marketdata/HitbtcTradeServiceHelper.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/dto/marketdata/HitbtcTradeServiceHelper.java
@@ -1,0 +1,24 @@
+package com.xeiam.xchange.hitbtc.dto.marketdata;
+
+import com.xeiam.xchange.dto.marketdata.BaseTradeServiceHelper;
+
+import java.math.BigDecimal;
+
+public class HitbtcTradeServiceHelper extends BaseTradeServiceHelper {
+  private final BigDecimal takeLiquidityRate;
+  private final BigDecimal provideLiquidityRate;
+
+  public HitbtcTradeServiceHelper(BigDecimal amountMinimum, int priceScale, BigDecimal takeLiquidityRate, BigDecimal provideLiquidityRate) {
+    super(amountMinimum, priceScale);
+    this.takeLiquidityRate = takeLiquidityRate;
+    this.provideLiquidityRate = provideLiquidityRate;
+  }
+
+  public BigDecimal getTakeLiquidityRate() {
+    return takeLiquidityRate;
+  }
+
+  public BigDecimal getProvideLiquidityRate() {
+    return provideLiquidityRate;
+  }
+}

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountService.java
@@ -2,7 +2,11 @@ package com.xeiam.xchange.hitbtc.service.polling;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Properties;
 
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTradeServiceHelper;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
@@ -12,7 +16,11 @@ import com.xeiam.xchange.hitbtc.HitbtcAdapters;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalance;
 import com.xeiam.xchange.service.polling.PollingAccountService;
 
+import static com.xeiam.xchange.utils.TradeServiceHelperConfigurer.CFG;
+
 public class HitbtcAccountService extends HitbtcAccountServiceRaw implements PollingAccountService {
+
+  private BigDecimal tradingFee;
 
   public HitbtcAccountService(ExchangeSpecification exchangeSpecification, SynchronizedValueFactory<Long> nonceFactory) {
 
@@ -24,7 +32,7 @@ public class HitbtcAccountService extends HitbtcAccountServiceRaw implements Pol
 
     HitbtcBalance[] accountInfoRaw = getAccountInfoRaw();
 
-    return HitbtcAdapters.adaptAccountInfo(accountInfoRaw);
+    return HitbtcAdapters.adaptAccountInfo(accountInfoRaw, tradingFee);
   }
 
   @Override
@@ -39,4 +47,17 @@ public class HitbtcAccountService extends HitbtcAccountServiceRaw implements Pol
     throw new NotYetImplementedForExchangeException();
   }
 
+  public void setTradingFeeFromTradeHelpers(Map<CurrencyPair, HitbtcTradeServiceHelper> metadata){
+    boolean makerFee = CFG.getBoolProperty(HITBTC_ORDER_FEE_POLICY_MAKER);
+    Properties config = CFG.getProperties();
+
+    String currencyPair = config.getProperty(HITBTC_ORDER_FEE_LISTING_DEFAULT);
+    if (currencyPair == null)
+      currencyPair = config.getProperty(XCHANGE_ORDER_FEE_LISTING_DEFAULT, CurrencyPair.BTC_USD.toString());
+
+    CurrencyPair pair = CurrencyPair.fromString(currencyPair);
+
+    HitbtcTradeServiceHelper listingHelper = metadata.get(pair);
+    tradingFee= makerFee ? listingHelper.getProvideLiquidityRate() : listingHelper.getTakeLiquidityRate();
+  }
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcBasePollingService.java
@@ -17,10 +17,11 @@ import com.xeiam.xchange.hitbtc.service.HitbtcHmacDigest;
 import com.xeiam.xchange.service.BaseExchangeService;
 import com.xeiam.xchange.service.polling.BasePollingService;
 
-/**
- * @author kpysniak, piotr.ladyzynski
- */
 public abstract class HitbtcBasePollingService<T extends Hitbtc> extends BaseExchangeService implements BasePollingService {
+
+  protected static final String HITBTC = "hitbtc";
+  protected static final String HITBTC_ORDER_FEE_POLICY_MAKER = HITBTC + ".order.feePolicy.maker";
+  protected static final String HITBTC_ORDER_FEE_LISTING_DEFAULT = HITBTC + ORDER_FEE_LISTING + "default";
 
   protected final SynchronizedValueFactory<Long> valueFactory;
 

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import com.xeiam.xchange.currency.CurrencyPair;
-import com.xeiam.xchange.dto.marketdata.TradeServiceHelper;
+import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTradeServiceHelper;
 import com.xeiam.xchange.service.polling.trade.*;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -113,13 +113,10 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
    * @return Map of currency pairs to their corresponding metadata.
    * @see com.xeiam.xchange.dto.marketdata.TradeServiceHelper
    */
-  @Override public Map<CurrencyPair, ? extends TradeServiceHelper> getTradeServiceHelperMap() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  @Override
+  public Map<CurrencyPair, HitbtcTradeServiceHelper> getTradeServiceHelperMap() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     metadata = HitbtcAdapters.adaptSymbolsToMetadata(hitbtc.getSymbols());
     return metadata;
-  }
-
-  public void init() throws IOException {
-    getTradeServiceHelperMap();
   }
 
   public static class HitbtcTradeHistoryParams extends DefaultTradeHistoryParamPaging implements TradeHistoryParamCurrencyPair {

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
@@ -5,8 +5,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Map;
 
-import com.xeiam.xchange.dto.marketdata.TradeServiceHelper;
 import com.xeiam.xchange.hitbtc.HitbtcAdapters;
+import com.xeiam.xchange.hitbtc.dto.marketdata.HitbtcTradeServiceHelper;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.ExchangeException;
@@ -28,7 +28,7 @@ import com.xeiam.xchange.hitbtc.dto.trade.HitbtcTradeResponse;
 
 public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthenticated> {
 
-  protected Map<CurrencyPair, TradeServiceHelper> metadata;
+  protected Map<CurrencyPair, HitbtcTradeServiceHelper> metadata;
 
   public HitbtcTradeServiceRaw(ExchangeSpecification exchangeSpecification, SynchronizedValueFactory<Long> nonceFactory) {
 

--- a/xchange-hitbtc/src/test/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceTest.java
+++ b/xchange-hitbtc/src/test/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceTest.java
@@ -24,7 +24,7 @@ public class HitbtcAccountServiceTest {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     HitbtcSymbols hitBtcSymbols = mapper.readValue(is, HitbtcSymbols.class);
-    Map<CurrencyPair, TradeServiceHelper> metaMap = HitbtcAdapters.adaptSymbolsToMetadata(hitBtcSymbols);
+    Map<CurrencyPair, ? extends TradeServiceHelper> metaMap = HitbtcAdapters.adaptSymbolsToMetadata(hitBtcSymbols);
 
     TradeServiceHelper eur = metaMap.get(CurrencyPair.BTC_EUR);
 


### PR DESCRIPTION
BTC-e API currently reports fee of .002 (.2%) for all listings, so I put one of the values in the AccountInfo.

Hitbtc fees vary between listings, so AccountInfo.getTradingFee() return value is configurable through xchange.properties.
All the fees are available through HitbtcTradingServiceHelper

ANX: make AccountInfo.getTradingFee() return fraction instead of percent.