### PR TITLE
Introduce exception types for nonce error, throttling

### DIFF
--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXAccountServiceRaw.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXAccountServiceRaw.java
@@ -3,10 +3,10 @@ package com.xeiam.xchange.anx.v2.service.polling;
 import java.io.IOException;
 import java.math.BigDecimal;
 
+import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
-import com.xeiam.xchange.ExchangeException;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.anx.ANXUtils;
 import com.xeiam.xchange.anx.v2.ANXV2;
@@ -45,7 +45,9 @@ public class ANXAccountServiceRaw extends ANXBasePollingService {
       ANXAccountInfoWrapper anxAccountInfoWrapper = anxV2.getAccountInfo(exchangeSpecification.getApiKey(), signatureCreator, getNonce());
       return anxAccountInfoWrapper.getANXAccountInfo();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getAccountInfo(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -57,7 +59,9 @@ public class ANXAccountServiceRaw extends ANXBasePollingService {
               .intValue(), 1, false, false);
       return anxWithdrawalResponseWrapper.getAnxWithdrawalResponse();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling withdrawFunds(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -67,7 +71,9 @@ public class ANXAccountServiceRaw extends ANXBasePollingService {
       ANXBitcoinDepositAddressWrapper anxBitcoinDepositAddressWrapper = anxV2.requestDepositAddress(exchangeSpecification.getApiKey(), signatureCreator, getNonce(), currency);
       return anxBitcoinDepositAddressWrapper.getAnxBitcoinDepositAddress();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling requestBitcoinDepositAddress(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 }

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXBasePollingService.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXBasePollingService.java
@@ -1,8 +1,14 @@
 package com.xeiam.xchange.anx.v2.service.polling;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import com.xeiam.xchange.ExchangeException;
+import com.xeiam.xchange.FundsExceededException;
+import com.xeiam.xchange.NonceException;
+import com.xeiam.xchange.anx.v2.dto.ANXException;
+import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
@@ -168,6 +174,20 @@ public class ANXBasePollingService extends BaseExchangeService implements BasePo
   protected SynchronizedValueFactory<Long> getNonce() {
 
     return nonceFactory;
+  }
+
+  protected RuntimeException handleHttpError(HttpStatusIOException exception) throws IOException {
+    if (exception.getHttpStatusCode() == 304)
+      return new NonceException(exception.getHttpBody());
+    else
+      throw exception;
+  }
+
+  protected RuntimeException handleError(ANXException exception) {
+    if ("Insufficient Funds".equals(exception.getError()))
+      return new FundsExceededException();
+    else
+      return new ExchangeException(exception.getError(), exception);
   }
 
 }

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXBasePollingService.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXBasePollingService.java
@@ -185,7 +185,7 @@ public class ANXBasePollingService extends BaseExchangeService implements BasePo
 
   protected RuntimeException handleError(ANXException exception) {
     if ("Insufficient Funds".equals(exception.getError()))
-      return new FundsExceededException();
+      return new FundsExceededException(exception.getError());
     else
       return new ExchangeException(exception.getError(), exception);
   }

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXMarketDataServiceRaw.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXMarketDataServiceRaw.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.RestProxyFactory;
 
 import com.xeiam.xchange.ExchangeException;
@@ -46,7 +47,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
       ANXTickerWrapper anxTickerWrapper = anxV2.getTicker(currencyPair.baseSymbol, currencyPair.counterSymbol);
       return anxTickerWrapper.getAnxTicker();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getTicker(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -76,7 +79,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
       ANXTickersWrapper anxTickerWrapper = anxV2.getTickers(pathCurrencyPair.baseSymbol, pathCurrencyPair.counterSymbol, extraCurrencyPairs.toString());
       return anxTickerWrapper.getAnxTickers();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getTicker(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -86,7 +91,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
       ANXDepthWrapper anxDepthWrapper = anxV2.getFullDepth(currencyPair.baseSymbol, currencyPair.counterSymbol);
       return anxDepthWrapper;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getANXFullOrderBook(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -116,7 +123,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
       ANXDepthsWrapper anxDepthWrapper = anxV2.getFullDepths(pathCurrencyPair.baseSymbol, pathCurrencyPair.counterSymbol, extraCurrencyPairs.toString());
       return anxDepthWrapper.getAnxDepths();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getANXFullOrderBook(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -126,7 +135,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
       ANXDepthWrapper anxDepthWrapper = anxV2.getPartialDepth(currencyPair.baseSymbol, currencyPair.counterSymbol);
       return anxDepthWrapper;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getANXPartialOrderBook(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -135,7 +146,9 @@ public class ANXMarketDataServiceRaw extends ANXBasePollingService {
     try {
       return anxV2.getTrades(currencyPair.baseSymbol, currencyPair.counterSymbol, sinceTimeStamp).getANXTrades();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getTrades(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 }

--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeServiceRaw.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeServiceRaw.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.anx.v2.service.polling;
 import java.io.IOException;
 import java.math.BigDecimal;
 
+import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -47,7 +48,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
       ANXOpenOrderWrapper anxOpenOrderWrapper = anxV2.getOpenOrders(ANXUtils.urlEncode(exchangeSpecification.getApiKey()), signatureCreator, getNonce(), baseCurrency, counterCurrency);
       return anxOpenOrderWrapper.getANXOpenOrders();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getOpenOrders(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -57,7 +60,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
       ANXOpenOrderWrapper anxOpenOrderWrapper = anxV2.getOpenOrders(ANXUtils.urlEncode(exchangeSpecification.getApiKey()), signatureCreator, getNonce());
       return anxOpenOrderWrapper.getANXOpenOrders();
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getOpenOrders(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -69,7 +74,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
               .getType().equals(Order.OrderType.BID) ? "bid" : "ask", marketOrder.getTradableAmount(), null);
       return anxGenericResponse;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling placeMarketOrder(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -81,7 +88,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
 
       return anxGenericResponse;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling placeLimitOrder(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e) {
+      throw handleHttpError(e);
     }
   }
 
@@ -92,7 +101,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
       ANXGenericResponse anxGenericResponse = anxV2.cancelOrder(exchangeSpecification.getApiKey(), signatureCreator, getNonce(), orderId, baseCurrency, counterCurrency);
       return anxGenericResponse;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling cancelOrder(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -103,7 +114,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
       ANXTradeResultWrapper anxTradeResultWrapper = anxV2.getExecutedTrades(exchangeSpecification.getApiKey(), signatureCreator, getNonce(), from, to);
       return anxTradeResultWrapper;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getExecutedANXTrades(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 
@@ -114,7 +127,9 @@ public class ANXTradeServiceRaw extends ANXBasePollingService {
       ANXOrderResultWrapper anxOrderResultWrapper = anxV2.getOrderResult(exchangeSpecification.getApiKey(), signatureCreator, getNonce(), baseCurrency, counterCurrency, orderId, type);
       return anxOrderResultWrapper;
     } catch (ANXException e) {
-      throw new ExchangeException("Error calling getANXOrderResult(): " + e.getError(), e);
+      throw handleError(e);
+    } catch (HttpStatusIOException e){
+      throw handleHttpError(e);
     }
   }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/FrequencyLimitExceededException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/FrequencyLimitExceededException.java
@@ -1,10 +1,7 @@
 package com.xeiam.xchange;
 
-public class FrequencyLimitExceededException extends IllegalStateException {
+public class FrequencyLimitExceededException extends ExchangeException {
   private static final long serialVersionUID = 2058332277163798808L;
-
-  public FrequencyLimitExceededException() {
-  }
 
   public FrequencyLimitExceededException(String s) {
     super(s);
@@ -14,7 +11,4 @@ public class FrequencyLimitExceededException extends IllegalStateException {
     super(message, cause);
   }
 
-  public FrequencyLimitExceededException(Throwable cause) {
-    super(cause);
-  }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/FrequencyLimitExceededException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/FrequencyLimitExceededException.java
@@ -1,0 +1,20 @@
+package com.xeiam.xchange;
+
+public class FrequencyLimitExceededException extends IllegalStateException {
+  private static final long serialVersionUID = 2058332277163798808L;
+
+  public FrequencyLimitExceededException() {
+  }
+
+  public FrequencyLimitExceededException(String s) {
+    super(s);
+  }
+
+  public FrequencyLimitExceededException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FrequencyLimitExceededException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/xchange-core/src/main/java/com/xeiam/xchange/FundsExceededException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/FundsExceededException.java
@@ -1,0 +1,20 @@
+package com.xeiam.xchange;
+
+public class FundsExceededException extends IllegalArgumentException {
+  private static final long serialVersionUID = 2406896439418334853L;
+
+  public FundsExceededException() {
+  }
+
+  public FundsExceededException(String s) {
+    super(s);
+  }
+
+  public FundsExceededException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public FundsExceededException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/xchange-core/src/main/java/com/xeiam/xchange/FundsExceededException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/FundsExceededException.java
@@ -1,10 +1,7 @@
 package com.xeiam.xchange;
 
-public class FundsExceededException extends IllegalArgumentException {
+public class FundsExceededException extends ExchangeException {
   private static final long serialVersionUID = 2406896439418334853L;
-
-  public FundsExceededException() {
-  }
 
   public FundsExceededException(String s) {
     super(s);
@@ -14,7 +11,4 @@ public class FundsExceededException extends IllegalArgumentException {
     super(message, cause);
   }
 
-  public FundsExceededException(Throwable cause) {
-    super(cause);
-  }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/NonceException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/NonceException.java
@@ -1,10 +1,7 @@
 package com.xeiam.xchange;
 
-public class NonceException extends IllegalArgumentException {
+public class NonceException extends ExchangeException {
   private static final long serialVersionUID = 565212065616860570L;
-
-  public NonceException() {
-  }
 
   public NonceException(String s) {
     super(s);
@@ -14,7 +11,4 @@ public class NonceException extends IllegalArgumentException {
     super(message, cause);
   }
 
-  public NonceException(Throwable cause) {
-    super(cause);
-  }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/NonceException.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/NonceException.java
@@ -1,0 +1,20 @@
+package com.xeiam.xchange;
+
+public class NonceException extends IllegalArgumentException {
+  private static final long serialVersionUID = 565212065616860570L;
+
+  public NonceException() {
+  }
+
+  public NonceException(String s) {
+    super(s);
+  }
+
+  public NonceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public NonceException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcAccountServiceRaw.java
@@ -2,12 +2,9 @@ package com.xeiam.xchange.hitbtc.service.polling;
 
 import java.io.IOException;
 
+import com.xeiam.xchange.*;
 import si.mazi.rescu.SynchronizedValueFactory;
 
-import com.xeiam.xchange.ExchangeException;
-import com.xeiam.xchange.ExchangeSpecification;
-import com.xeiam.xchange.NotAvailableFromExchangeException;
-import com.xeiam.xchange.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.hitbtc.HitbtcAuthenticated;
 import com.xeiam.xchange.hitbtc.dto.HitbtcException;
 import com.xeiam.xchange.hitbtc.dto.account.HitbtcBalance;
@@ -26,7 +23,7 @@ public class HitbtcAccountServiceRaw extends HitbtcBasePollingService<HitbtcAuth
       HitbtcBalanceResponse hitbtcBalance = hitbtc.getHitbtcBalance(signatureCreator, valueFactory, apiKey);
       return hitbtcBalance.getBalances();
     } catch (HitbtcException e) {
-      throw new ExchangeException(e.getMessage());
+      throw handleException(e);
     }
   }
 
@@ -36,7 +33,7 @@ public class HitbtcAccountServiceRaw extends HitbtcBasePollingService<HitbtcAuth
       HitbtcBalanceResponse hitbtcBalanceResponse = hitbtc.getHitbtcBalance(signatureCreator, valueFactory, apiKey);
       return hitbtcBalanceResponse;
     } catch (HitbtcException e) {
-      throw new ExchangeException(e.getMessage());
+      throw handleException(e);
     }
   }
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcMarketDataServiceRaw.java
@@ -2,6 +2,8 @@ package com.xeiam.xchange.hitbtc.service.polling;
 
 import java.io.IOException;
 
+import com.xeiam.xchange.hitbtc.HitbtcAdapters;
+import com.xeiam.xchange.hitbtc.dto.HitbtcException;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.ExchangeSpecification;
@@ -29,18 +31,30 @@ public abstract class HitbtcMarketDataServiceRaw extends HitbtcBasePollingServic
 
   public HitbtcTicker getHitbtcTicker(CurrencyPair currencyPair) throws IOException {
 
-    return hitbtc.getHitbtcTicker(currencyPair.baseSymbol.toUpperCase() + currencyPair.counterSymbol.toString());
+    try {
+      return hitbtc.getHitbtcTicker(HitbtcAdapters.adaptCurrencyPair(currencyPair));
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcOrderBook getHitbtcOrderBook(CurrencyPair currencyPair) throws IOException {
 
-    return hitbtc.getOrderBook(currencyPair.baseSymbol.toUpperCase() + currencyPair.counterSymbol.toString());
+    try {
+      return hitbtc.getOrderBook(HitbtcAdapters.adaptCurrencyPair(currencyPair));
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcTrades getHitbtcTrades(CurrencyPair currencyPair, long from, HitbtcTrades.HitbtcTradesSortOrder sortBy, long startIndex, long maxResults) throws IOException {
 
-    return hitbtc.getTrades(currencyPair.baseSymbol.toUpperCase() + currencyPair.counterSymbol.toString(), String.valueOf(from), sortBy.toString(), "desc", String.valueOf(startIndex), String
-        .valueOf(maxResults), "object");
+    try {
+      return hitbtc.getTrades(HitbtcAdapters.adaptCurrencyPair(currencyPair), String.valueOf(from), sortBy.toString(), "desc", String.valueOf(startIndex), String
+          .valueOf(maxResults), "object");
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcSymbols getHitbtcSymbols() throws IOException {

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -148,10 +148,4 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
     }
   }
 
-  private void checkRejected(HitbtcExecutionReport executionReport) {
-
-    if ("rejected".equals(executionReport.getExecReportType()))
-      throw new ExchangeException("Order rejected, " + executionReport.getOrderRejectReason());
-  }
-
 }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeServiceRaw.java
@@ -37,8 +37,12 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
 
   public HitbtcOrdersResponse getOpenOrdersRawBaseResponse() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
-    HitbtcOrdersResponse hitbtcActiveOrders = hitbtc.getHitbtcActiveOrders(signatureCreator, valueFactory, apiKey);
-    return hitbtcActiveOrders;
+    try {
+      HitbtcOrdersResponse hitbtcActiveOrders = hitbtc.getHitbtcActiveOrders(signatureCreator, valueFactory, apiKey);
+      return hitbtcActiveOrders;
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcOrder[] getOpenOrdersRaw() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
@@ -49,8 +53,12 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
 
   public HitbtcOrdersResponse getRecentOrdersRawBaseResponse(int max_results) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
-    HitbtcOrdersResponse hitbtcActiveOrders = hitbtc.getHitbtcRecentOrders(signatureCreator, valueFactory, apiKey, max_results);
-    return hitbtcActiveOrders;
+    try {
+      HitbtcOrdersResponse hitbtcActiveOrders = hitbtc.getHitbtcRecentOrders(signatureCreator, valueFactory, apiKey, max_results);
+      return hitbtcActiveOrders;
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcOrder[] getRecentOrdersRaw(int max_results) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
@@ -68,9 +76,13 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
     String side = HitbtcAdapters.getSide(marketOrder.getType());
     String orderId = HitbtcAdapters.createOrderId(marketOrder, nonce);
 
-    HitbtcExecutionReportResponse response = hitbtc.postHitbtcNewOrder(signatureCreator, valueFactory, apiKey, orderId, symbol, side, null, getLots(marketOrder), "market", "IOC");
+    try {
+      HitbtcExecutionReportResponse response = hitbtc.postHitbtcNewOrder(signatureCreator, valueFactory, apiKey, orderId, symbol, side, null, getLots(marketOrder), "market", "IOC");
 
-    return response;
+      return response;
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcExecutionReport placeMarketOrderRaw(MarketOrder marketOrder) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
@@ -85,7 +97,7 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
       HitbtcExecutionReportResponse postHitbtcNewOrder = fillHitbtcExecutionReportResponse(limitOrder);
       return postHitbtcNewOrder.getExecutionReport();
     } catch (HitbtcException e) {
-      throw new ExchangeException(e.getMessage());
+      throw handleException(e);
     }
   }
 
@@ -103,7 +115,11 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
     String side = HitbtcAdapters.getSide(limitOrder.getType());
     String orderId = HitbtcAdapters.createOrderId(limitOrder, nonce);
 
-    return hitbtc.postHitbtcNewOrder(signatureCreator, valueFactory, apiKey, orderId, symbol, side, limitOrder.getLimitPrice(), getLots(limitOrder), "limit", "GTC");
+    try {
+      return hitbtc.postHitbtcNewOrder(signatureCreator, valueFactory, apiKey, orderId, symbol, side, limitOrder.getLimitPrice(), getLots(limitOrder), "limit", "GTC");
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcExecutionReportResponse cancelOrderRaw(String orderId) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
@@ -112,20 +128,32 @@ public class HitbtcTradeServiceRaw extends HitbtcBasePollingService<HitbtcAuthen
     String originalSide = HitbtcAdapters.getSide(HitbtcAdapters.readOrderType(orderId));
     String symbol = HitbtcAdapters.readSymbol(orderId);
 
-    return hitbtc.postHitbtcCancelOrder(signatureCreator, valueFactory, apiKey, orderId, orderId, symbol, originalSide);
+    try {
+      return hitbtc.postHitbtcCancelOrder(signatureCreator, valueFactory, apiKey, orderId, orderId, symbol, originalSide);
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcExecutionReportResponse cancelOrderRaw(String clientOrderId, String cancelRequestClientOrderId, String symbol, String side) throws ExchangeException, NotAvailableFromExchangeException,
       NotYetImplementedForExchangeException, IOException {
 
-    return hitbtc.postHitbtcCancelOrder(signatureCreator, valueFactory, apiKey, clientOrderId, cancelRequestClientOrderId, symbol, side);
+    try {
+      return hitbtc.postHitbtcCancelOrder(signatureCreator, valueFactory, apiKey, clientOrderId, cancelRequestClientOrderId, symbol, side);
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcTradeResponse getTradeHistoryRawBaseResponse(int startIndex, int maxResults, String symbols) throws ExchangeException, NotAvailableFromExchangeException,
       NotYetImplementedForExchangeException, IOException {
 
-    HitbtcTradeResponse hitbtcTrades = hitbtc.getHitbtcTrades(signatureCreator, valueFactory, apiKey, "ts", startIndex, maxResults, symbols, "desc", null, null);
-    return hitbtcTrades;
+    try {
+      HitbtcTradeResponse hitbtcTrades = hitbtc.getHitbtcTrades(signatureCreator, valueFactory, apiKey, "ts", startIndex, maxResults, symbols, "desc", null, null);
+      return hitbtcTrades;
+    } catch (HitbtcException e) {
+      throw handleException(e);
+    }
   }
 
   public HitbtcOwnTrade[] getTradeHistoryRaw(int startIndex, int maxResults, String symbols) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException,


### PR DESCRIPTION
and insufficient funds.

I'd like to push issue #684 forward.

I can handle programatically nonce error and throttling. @mmazi's example with insufficient funds is a good one too.

Until all the exchanges are modified, some of the exchanges will throw exceptions that don't extend ExchangeException - we break the generic interface.
I guess we will have to live with `catch(ExchangeException | IllegalArgumentException e)` for the time being.

`FrequencyLimitExceededException extends IllegalStateException` because It represents a transient state of the exchange - internal counter that at some point exceeds some threshold.
`FundsExceededException extends IllegalArgumentException` - it could bee seen as illegal argument (requested order exceeds the funds) or illegal state (funds are insufficient to place the order), so it's either this or `InsufficientFundsException extends IllegalStateException`.