### PR TITLE
[pom] Bring back source plugin to the default build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -294,20 +294,6 @@
 							</execution>
 						</executions>
 					</plugin>
-					<!-- Generates a source code JAR during package -->
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-source-plugin</artifactId>
-						<version>2.4</version>
-						<executions>
-							<execution>
-								<id>attach-sources</id>
-								<goals>
-									<goal>jar</goal>
-								</goals>
-							</execution>
-						</executions>
-					</plugin>
 
 					<!-- Generates a Javadoc JAR during package -->
 					<plugin>
@@ -372,6 +358,7 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+
 		<plugins>
 			<!-- Ensure compilation is done under Java 6 in all environments -->
 			<plugin>
@@ -384,6 +371,21 @@
 					<showDeprecation>true</showDeprecation>
 					<showWarnings>true</showWarnings>
 				</configuration>
+			</plugin>
+
+			<!-- Generates a source code JAR during package -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.4</version>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 
 			<!-- for deploying to Maven Central -->


### PR DESCRIPTION
I't useful and unlike javadoc, doesn't influence build time