### PR TITLE
Added a more robust integer nonce factory. Use it for BTC-e.

### DIFF
--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEExchange.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/BTCEExchange.java
@@ -8,11 +8,11 @@ import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.btce.v3.service.polling.BTCEAccountService;
 import com.xeiam.xchange.btce.v3.service.polling.BTCEMarketDataService;
 import com.xeiam.xchange.btce.v3.service.polling.BTCETradeService;
-import com.xeiam.xchange.utils.nonce.AtomicLongIncrementalTime2013NonceFactory;
+import com.xeiam.xchange.utils.nonce.TimestampIncrementingNonceFactory;
 
 public class BTCEExchange extends BaseExchange implements Exchange {
 
-  private SynchronizedValueFactory<Long> nonceFactory = new AtomicLongIncrementalTime2013NonceFactory();
+  private SynchronizedValueFactory<Long> nonceFactory = new TimestampIncrementingNonceFactory();
 
   @Override
   public void applySpecification(ExchangeSpecification exchangeSpecification) {

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/BTCEExchangeTest.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/BTCEExchangeTest.java
@@ -1,0 +1,46 @@
+package com.xeiam.xchange.btce.v3;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class BTCEExchangeTest {
+
+  private int prevNonce;
+
+  @Test
+  public void testNonceSuccession() throws Exception {
+
+    SynchronizedValueFactory<Long> nf1 = new BTCEExchange().getNonceFactory();
+
+    // Get a few nonces from the same factory in quick succession.
+    assertNonceLarger(nf1);
+    assertNonceLarger(nf1);
+    assertNonceLarger(nf1);
+    assertNonceLarger(nf1);
+
+
+    // A nonce factory created a bit later should return compatible nonces.
+    Thread.sleep(1500);
+
+    SynchronizedValueFactory<Long> nf2 = new BTCEExchange().getNonceFactory();
+
+    assertNonceLarger(nf2);
+    assertNonceLarger(nf2);
+    assertNonceLarger(nf2);
+    assertNonceLarger(nf2);
+
+    // After a short pause, the first nonce factory should again return valid nonces.
+    Thread.sleep(1500);
+    assertNonceLarger(nf1);
+    assertNonceLarger(nf1);
+    assertNonceLarger(nf1);
+  }
+
+  private void assertNonceLarger(SynchronizedValueFactory<Long> nonceFactory) {
+    final int nonce = nonceFactory.createValue().intValue();
+    Assert.assertTrue(nonce > prevNonce);
+    prevNonce = nonce;
+  }
+}

--- a/xchange-core/src/main/java/com/xeiam/xchange/utils/nonce/TimestampIncrementingNonceFactory.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/utils/nonce/TimestampIncrementingNonceFactory.java
@@ -1,0 +1,17 @@
+package com.xeiam.xchange.utils.nonce;
+
+import si.mazi.rescu.SynchronizedValueFactory;
+
+public class TimestampIncrementingNonceFactory implements SynchronizedValueFactory<Long> {
+
+  private static final long START_MILLIS = 1356998400000L; // Jan 1st, 2013 in milliseconds from epoch
+
+  private int lastNonce = 0;
+
+  @Override
+  public Long createValue() {
+
+    lastNonce = Math.max(lastNonce + 1, (int) ((System.currentTimeMillis() - START_MILLIS) / 250L));
+    return (long) lastNonce;
+  }
+}


### PR DESCRIPTION
I'm hoping to end the BTC-e nonce troubles once and for all. This is a v3 / SynchronizedValueFactory re-implementation of the nonce factory I implemented and described in #756. (Please see that issue or/and the test included in this PR if you're interested why this PR is necessary. Tl;dr: it supports several exchange instances operating at the same time.)

I've reviewed the many previous BTCE nonce issues and pull requests and I believe this should resolve all of them. (It doesn't resolve my GAE issue 100%, but it's good enough.)

This PR includes a test that fails with the `AtomicLongIncrementalTime2013NonceFactory` that is currently used for BTC-e, and passes with the new `TimestampIncrementingNonceFactory`.

A few notes:

* I think the new `TimestampIncrementingNonceFactory` is the best choice for any exchange that uses an integer nonce. (For long nonces, I think `CurrentTimeNonceFactory` is the best choice.)
* Correct me if I'm wrong but I don't think AtomicInteger (or AtomicLong) is necessary since the nonce factories are used in a synchronized manner anyway.
* This nonce factory is compatible with the one that was previously used for BTC-e so people won't have to drop and re-create the API keys they are already using. (The exception to this could be if someone _constantly_ (as opposed to occasionally) makes more than 4 requests per second, which I think is impossible anyway.)
