### PR TITLE
Apply exch. spec. params before instantiating MDS due to refactor

### DIFF
--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/OkCoinExchange.java
@@ -25,6 +25,14 @@ public class OkCoinExchange extends BaseExchange {
         && exchangeSpecification.getExchangeSpecificParametersItem("Use_Futures").equals(true)) {
       throw new RuntimeException("Futures only available on international version. Set `Use_Intl` to true.");
     }
+    
+    // set SSL URL and HOST accordingly
+
+    if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true)) {
+      exchangeSpecification.setSslUri("https://www.okcoin.com/api");
+      exchangeSpecification.setHost("www.okcoin.com");
+      exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okcoin.com:10440/websocket/okcoinapi");
+    }
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null
         && exchangeSpecification.getExchangeSpecificParametersItem("Use_Futures").equals(true)) {
@@ -40,15 +48,6 @@ public class OkCoinExchange extends BaseExchange {
         this.pollingTradeService = new OkCoinTradeService(this);
       }
     }
-
-    // set SSL URL and HOST accordingly
-
-    if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true)) {
-      exchangeSpecification.setSslUri("https://www.okcoin.com/api");
-      exchangeSpecification.setHost("www.okcoin.com");
-      exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okcoin.com:10440/websocket/okcoinapi");
-    }
-
   }
 
   @Override


### PR DESCRIPTION
Refactor of exchange spec. params broke the `Use_Intl` switching of OkCoin. This should fix it.

Addresses https://github.com/timmolter/XChange/issues/860#issuecomment-75395198