### PR TITLE
Fix ArrayList initial capacity in BTCTrade wallets adpating.

### DIFF
--- a/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
+++ b/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/BTCTradeAdapters.java
@@ -146,7 +146,7 @@ public final class BTCTradeAdapters {
 
     checkException(balance);
 
-    List<Wallet> wallets = new ArrayList<Wallet>(4);
+    List<Wallet> wallets = new ArrayList<Wallet>(5);
     wallets.add(new Wallet(Currencies.BTC, nullSafeSum(balance.getBtcBalance(), balance.getBtcReserved())));
     wallets.add(new Wallet(Currencies.LTC, nullSafeSum(balance.getLtcBalance(), balance.getLtcReserved())));
     wallets.add(new Wallet(Currencies.DOGE, nullSafeSum(balance.getDogeBalance(), balance.getDogeReserved())));


### PR DESCRIPTION
The initial capacity should be 5:
1. BTC
2. LTC
3. DOGE
4. YBC
5. CNY.