### PR TITLE
Huobi: remove sorting of ask side of orderbook

### DIFF
--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/HuobiAdapters.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/HuobiAdapters.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
@@ -54,8 +53,6 @@ public final class HuobiAdapters {
   public static OrderBook adaptOrderBook(HuobiDepth BitVcDepth, CurrencyPair currencyPair) {
 
     List<LimitOrder> asks = adaptOrderBook(BitVcDepth.getAsks(), ASK, currencyPair);
-    Collections.reverse(asks);
-
     List<LimitOrder> bids = adaptOrderBook(BitVcDepth.getBids(), BID, currencyPair);
 
     return new OrderBook(null, asks, bids);


### PR DESCRIPTION
Huobi changed the sort order of the ask side of their orderbook at `http://market.huobi.com/staticmarket/depth_btc_json.js`

Sorting is not necessary anymore.