### PR TITLE
Account getInfo integration test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ META-INF/
 
 # Misc.
 .DS_Store
+
+# externalized configuration file for keys
+exchangeConfiguration.json

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeConfiguration.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeConfiguration.java
@@ -1,0 +1,14 @@
+package com.xeiam.xchange.btce.v3;
+
+/**
+ * Configuration for a BTC-E exchange.
+ *
+ * @author Peter N. Steinmetz
+ *         Date: 3/30/15
+ *         Time: 4:07 PM
+ */
+public class ExchangeConfiguration {
+  public String secretKey;
+  public String apiKey;
+  public String sslUri;
+}

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeUtils.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeUtils.java
@@ -30,6 +30,10 @@ public class ExchangeUtils {
     ExchangeSpecification exSpec = new ExchangeSpecification(BTCEExchange.class);
     ObjectMapper mapper = new ObjectMapper();
     InputStream is = ExchangeUtils.class.getClassLoader().getResourceAsStream("v3/exchangeConfiguration.json");
+    if (is==null) {
+      logger.warn("No v3/exchangeConfiguration.json file found. Returning null exchange.");
+      return null;
+    }
     try {
       ExchangeConfiguration conf = mapper.readValue(is, ExchangeConfiguration.class);
       logger.debug(conf.toString());
@@ -38,8 +42,8 @@ public class ExchangeUtils {
       if (conf.secretKey != null) exSpec.setSecretKey(conf.secretKey);
       if (conf.sslUri != null) exSpec.setSslUri(conf.sslUri);
     } catch (Exception e) {
-      logger.error("An exception occured while loading the exchangeConfiguration.json file from the classpath. " +
-         "Return null exchange.", e);
+      logger.warn("An exception occured while loading the v3/exchangeConfiguration.json file from the classpath. " +
+         "Returning null exchange.", e);
       return null;
     }
 

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeUtils.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/ExchangeUtils.java
@@ -1,0 +1,49 @@
+package com.xeiam.xchange.btce.v3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.ExchangeSpecification;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+
+/**
+ * @author Peter N. Steinmetz
+ * Date: 3/30/15
+ * Time: 4:28 PM
+ */
+public class ExchangeUtils {
+  private final static Logger logger = LoggerFactory.getLogger(ExchangeUtils.class);
+
+  /**
+   * Create a BTC-e exchange using the keys provided in a v3/exchangeConfiguration.json
+   * file on the classpath.
+   *
+   * See the v3/sampleExchangeConfiguration.json file for format of required file.
+   *
+   * @return Create exchange or null if .json file was not on classpath.
+   */
+  public static Exchange createExchangeFromJsonConfiguration() {
+
+    ExchangeSpecification exSpec = new ExchangeSpecification(BTCEExchange.class);
+    ObjectMapper mapper = new ObjectMapper();
+    InputStream is = ExchangeUtils.class.getClassLoader().getResourceAsStream("v3/exchangeConfiguration.json");
+    try {
+      ExchangeConfiguration conf = mapper.readValue(is, ExchangeConfiguration.class);
+      logger.debug(conf.toString());
+
+      if (conf.apiKey != null) exSpec.setApiKey(conf.apiKey);
+      if (conf.secretKey != null) exSpec.setSecretKey(conf.secretKey);
+      if (conf.sslUri != null) exSpec.setSslUri(conf.sslUri);
+    } catch (Exception e) {
+      logger.error("An exception occured while loading the exchangeConfiguration.json file from the classpath. " +
+         "Return null exchange.", e);
+      return null;
+    }
+
+    return ExchangeFactory.INSTANCE.createExchange(exSpec);
+  }
+
+}

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/polling/AccountInfoFetchIntegration.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/polling/AccountInfoFetchIntegration.java
@@ -1,0 +1,31 @@
+package com.xeiam.xchange.btce.v3.service.polling;
+
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.btce.v3.BTCEExchange;
+import com.xeiam.xchange.btce.v3.dto.account.BTCEAccountInfo;
+import com.xeiam.xchange.dto.account.AccountInfo;
+import com.xeiam.xchange.service.polling.account.PollingAccountService;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Peter N. Steinmetz
+ *         Date: 3/30/15
+ *         Time: 7:15 PM
+ */
+public class AccountInfoFetchIntegration {
+
+  @Test
+  public void fetchAccountInfoTest() throws Exception {
+    ExchangeSpecification exSpec = new ExchangeSpecification(BTCEExchange.class);
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exSpec);
+    assertNotNull(exchange);
+    PollingAccountService service = exchange.getPollingAccountService();
+    assertNotNull(service);
+    AccountInfo info = service.getAccountInfo();
+    assertNotNull(info);
+  }
+}

--- a/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/polling/AccountInfoFetchIntegration.java
+++ b/xchange-btce/src/test/java/com/xeiam/xchange/btce/v3/service/polling/AccountInfoFetchIntegration.java
@@ -4,14 +4,21 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeFactory;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.btce.v3.BTCEExchange;
+import com.xeiam.xchange.btce.v3.ExchangeUtils;
 import com.xeiam.xchange.btce.v3.dto.account.BTCEAccountInfo;
 import com.xeiam.xchange.dto.account.AccountInfo;
+import com.xeiam.xchange.exceptions.NonceException;
 import com.xeiam.xchange.service.polling.account.PollingAccountService;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
 
 /**
+ * Integration tests for AccountInfo retrieval.
+ *
+ * For these tests to function, a file 'v3/exchangeConfiguration.json' must be on the
+ * classpath and contain valid api and secret keys.
+ *
  * @author Peter N. Steinmetz
  *         Date: 3/30/15
  *         Time: 7:15 PM
@@ -20,8 +27,8 @@ public class AccountInfoFetchIntegration {
 
   @Test
   public void fetchAccountInfoTest() throws Exception {
-    ExchangeSpecification exSpec = new ExchangeSpecification(BTCEExchange.class);
-    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exSpec);
+    Exchange exchange = ExchangeUtils.createExchangeFromJsonConfiguration();
+    if (exchange==null) return;  // forces pass if not configuration is available
     assertNotNull(exchange);
     PollingAccountService service = exchange.getPollingAccountService();
     assertNotNull(service);

--- a/xchange-btce/src/test/resources/v3/sampleExchangeConfiguration.json
+++ b/xchange-btce/src/test/resources/v3/sampleExchangeConfiguration.json
@@ -1,0 +1,5 @@
+{
+  "_comment" : "You need to replace these values with working keys and rename file to exchangeConfiguration.json",
+  "secretKey" : "123456789352bb5effccd87597a0690bd97292ed980ceab19490c6ecf1a6deb0",
+  "apiKey" : "GHGHGHGHG-S3GM4UYP-CFPPQJF9-J1OJ7FIH-FWBR7R6Y"
+}


### PR DESCRIPTION
This adds an integration test for the BTCE getInfo call as well as an ExchangeConfiguration which can be loaded from a json file in the resources folder. The test passes if no such configuration is present.

I am providing this in preparation for work providing the TransHistory API call. Trying to provide smaller chunks of work to pull.