### PR TITLE
OkCoin: Instantiate FuturesContract via valueOf

### DIFF
--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinFuturesMarketDataService.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinFuturesMarketDataService.java
@@ -26,7 +26,9 @@ public class OkCoinFuturesMarketDataService extends OkCoinMarketDataServiceRaw i
 
     if (exchange.getExchangeSpecification().getExchangeSpecificParameters().containsKey("Futures_Contract")) {
       futuresContract = (FuturesContract) exchange.getExchangeSpecification().getExchangeSpecificParameters().get("Futures_Contract");
-    } else {
+    } else if (exchange.getExchangeSpecification().getExchangeSpecificParameters().containsKey("Futures_Contract_String")) {
+      futuresContract = FuturesContract.valueOf((String)exchange.getExchangeSpecification().getExchangeSpecificParameters().get("Futures_Contract_String"));
+    } else { 
       futuresContract = null;
     }
   }


### PR DESCRIPTION
To instantiate a futures market data service on Okcoin.com you will have to pass an instance of `FuturesContract` instead of a string value. I leave this in for backwards compatibility, and added the exchange specific param `Futures_Contract_String` to instantiate the enum via a string (e.g. via config file) more easily.