### PR TITLE
Huobi: Support for futures market data

### DIFF
--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/huobi/marketdata/polling/HuobiDepthDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/huobi/marketdata/polling/HuobiDepthDemo.java
@@ -7,8 +7,11 @@ import com.xeiam.xchange.ExchangeFactory;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
+import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.huobi.HuobiExchange;
 import com.xeiam.xchange.huobi.dto.marketdata.HuobiDepth;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcExchangeRate;
+import com.xeiam.xchange.huobi.service.polling.BitVcFuturesMarketDataServiceRaw;
 import com.xeiam.xchange.huobi.service.polling.HuobiMarketDataServiceRaw;
 import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
 
@@ -17,10 +20,32 @@ public class HuobiDepthDemo {
   public static void main(String[] args) throws IOException {
 
     ExchangeSpecification exSpec = new ExchangeSpecification(HuobiExchange.class);
+    exSpec.setExchangeSpecificParametersItem("use_bitvc", false);
+    
     Exchange huobiExchange = ExchangeFactory.INSTANCE.createExchange(exSpec);
 
+    futures(exSpec);
     generic(huobiExchange);
     raw(huobiExchange);
+  }
+  
+  private static void futures(ExchangeSpecification exSpec) throws IOException {
+	 exSpec.setExchangeSpecificParametersItem("use_bitvc", true);
+	 exSpec.setExchangeSpecificParametersItem("use_bitvc_futures", true);
+	 exSpec.setExchangeSpecificParametersItem("Futures_Contract_String", "ThisWeek");
+	    
+	 Exchange exchange = ExchangeFactory.INSTANCE.createExchange(exSpec);
+	 
+	 PollingMarketDataService pollingMarketDataService = exchange.getPollingMarketDataService();
+
+	 Ticker ticker = pollingMarketDataService.getTicker(CurrencyPair.BTC_CNY);
+	 
+	 System.out.println(ticker);
+	 
+	 BitVcFuturesMarketDataServiceRaw raw = (BitVcFuturesMarketDataServiceRaw) pollingMarketDataService;
+	 BitVcExchangeRate bitVcExchangeRate = raw.getBitVcExchangeRate();
+	 
+	 System.out.println("Current exchange rate: " + bitVcExchangeRate.getRate());
   }
 
   private static void generic(Exchange exchange) throws IOException {

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/BitVcFutures.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/BitVcFutures.java
@@ -1,0 +1,42 @@
+package com.xeiam.xchange.huobi;
+
+import java.io.IOException;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcExchangeRate;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesDepth;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTicker;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTrade;
+
+@Path("/")
+@Produces(MediaType.APPLICATION_JSON)
+public interface BitVcFutures {
+
+  @GET
+  @Path("ticker_{symbol}_{contract}.js")
+  public BitVcFuturesTicker getTicker(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+
+  @GET
+  @Path("depths_{symbol}_{contract}.js")
+  public BitVcFuturesDepth getDepths(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+
+  @GET
+  @Path("trades_{symbol}_{contract}.js")
+  public BitVcFuturesTrade[] getTrades(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+  
+  /** Non-XChange compatible methods */
+  
+/*  @GET
+  @Path("index_price_{symbol}")
+  public BitVcIndex getIndex(@PathParam("symbol") String symbol) throws IOException;
+*/
+ 
+  @GET
+  @Path("exchange_rate.js")
+  public BitVcExchangeRate getExchangeRate() throws IOException;
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/BitVcFuturesAdapter.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/BitVcFuturesAdapter.java
@@ -1,0 +1,73 @@
+package com.xeiam.xchange.huobi;
+
+import static com.xeiam.xchange.dto.Order.OrderType.ASK;
+import static com.xeiam.xchange.dto.Order.OrderType.BID;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.Order.OrderType;
+import com.xeiam.xchange.dto.marketdata.OrderBook;
+import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.Trade;
+import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
+import com.xeiam.xchange.dto.trade.LimitOrder;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesDepth;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTicker;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTrade;
+
+
+public class BitVcFuturesAdapter {
+  
+  public static Ticker adaptTicker(BitVcFuturesTicker ticker, CurrencyPair currencyPair) {
+
+    return new Ticker.Builder().currencyPair(currencyPair).last(ticker.getLast()).bid(ticker.getBuy()).ask(ticker.getSell()).high(ticker.getHigh())
+        .low(ticker.getLow()).volume(ticker.getVol()).build();
+  }
+ 
+  public static OrderBook adaptOrderBook(BitVcFuturesDepth depth, CurrencyPair currencyPair) {
+
+    List<LimitOrder> asks = adaptOrderBook(depth.getAsks(), ASK, currencyPair);
+    List<LimitOrder> bids = adaptOrderBook(depth.getBids(), BID, currencyPair);
+
+    // ask side is flipped
+    Collections.sort(asks);
+    
+    return new OrderBook(null, asks, bids);
+  }
+
+  private static List<LimitOrder> adaptOrderBook(BigDecimal[][] orders, OrderType type, CurrencyPair currencyPair) {
+
+    List<LimitOrder> limitOrders = new ArrayList<LimitOrder>(orders.length);
+    
+    for (int i = 0; i < orders.length; i++) {
+      BigDecimal[] order = orders[i];
+      
+      LimitOrder limitOrder = new LimitOrder(type, order[1], currencyPair, null, null, order[0]);
+      limitOrders.add(limitOrder);
+    }
+    return limitOrders;
+  }
+
+  public static Trades adaptTrades(BitVcFuturesTrade[] trades, CurrencyPair currencyPair) {
+
+    List<Trade> tradeList = new ArrayList<Trade>(trades.length);
+    for (BitVcFuturesTrade trade : trades) {
+      tradeList.add(adaptTrade(trade, currencyPair));
+    }
+    
+    return new Trades(tradeList, TradeSortType.SortByID);
+  }
+  
+  private static Trade adaptTrade(BitVcFuturesTrade trade, CurrencyPair currencyPair) {
+
+    OrderType type = trade.getType().equals("buy") ? BID : ASK;
+    return new Trade(type, trade.getAmount(), currencyPair, trade.getPrice(), trade.getDate(), trade.getId());
+  }
+  
+
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/FuturesContract.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/FuturesContract.java
@@ -1,0 +1,21 @@
+package com.xeiam.xchange.huobi;
+
+/**
+ * Delivery dates for future date currencies
+ */
+public enum FuturesContract {
+  ThisWeek("week"), NextWeek("next_week"), Quarter("quarter");
+
+  private final String name;
+
+  /**
+   * Private constructor so it cannot be instantiated
+   */
+  private FuturesContract(String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/HuobiExchange.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/HuobiExchange.java
@@ -6,6 +6,7 @@ import com.xeiam.xchange.BaseExchange;
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.ExchangeSpecification;
 import com.xeiam.xchange.huobi.service.polling.BitVcAccountService;
+import com.xeiam.xchange.huobi.service.polling.BitVcFuturesMarketDataService;
 import com.xeiam.xchange.huobi.service.polling.BitVcTradeServiceRaw;
 import com.xeiam.xchange.huobi.service.polling.GenericTradeService;
 import com.xeiam.xchange.huobi.service.polling.HuobiAccountService;
@@ -24,10 +25,12 @@ import com.xeiam.xchange.service.streaming.StreamingExchangeService;
 public class HuobiExchange extends BaseExchange implements Exchange {
 
   public static final String TRADE_PASSWORD_PARAMETER = "trade_password";
-  
+
   /** Potentially different market data endpoints should be settable */
   public static final String HUOBI_MARKET_DATA = "huobi_uri_marketdata";  
   public static final String USE_BITVC = "use_bitvc";
+  public static final String USE_BITVC_FUTURES = "use_bitvc_futures";
+
 
   @Override
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
@@ -39,18 +42,41 @@ public class HuobiExchange extends BaseExchange implements Exchange {
       exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "NOT IMPLEMENTED");
     }
 
-    pollingMarketDataService = new HuobiMarketDataService(this);
+    if (exchangeSpecification.getExchangeSpecificParametersItem(USE_BITVC).equals(true) &&
+        exchangeSpecification.getExchangeSpecificParametersItem(USE_BITVC_FUTURES).equals(true)) {
+      FuturesContract contract = futuresContractOfConfig(exchangeSpecification);
+
+      pollingMarketDataService = new BitVcFuturesMarketDataService(this, contract);
+    } else {
+      pollingMarketDataService = new HuobiMarketDataService(this);
+    }
+
+
     if (exchangeSpecification.getApiKey() != null) {
       if ((Boolean) exchangeSpecification.getExchangeSpecificParametersItem(USE_BITVC)) {
         pollingAccountService = new BitVcAccountService(this);
         pollingTradeService = new GenericTradeService(this, new BitVcTradeServiceRaw(this));
-        
+
       } else {
         pollingAccountService = new HuobiAccountService(this);
         pollingTradeService = new GenericTradeService(this, new HuobiTradeServiceRaw(this));
-        
+
       }
     }
+  }
+
+  private static FuturesContract futuresContractOfConfig(ExchangeSpecification exchangeSpecification) {
+    FuturesContract contract;
+
+    if (exchangeSpecification.getExchangeSpecificParameters().containsKey("Futures_Contract")) {
+      contract = (FuturesContract)exchangeSpecification.getExchangeSpecificParameters().get("Futures_Contract");
+    } else if (exchangeSpecification.getExchangeSpecificParameters().containsKey("Futures_Contract_String")) {
+      contract = FuturesContract.valueOf((String)exchangeSpecification.getExchangeSpecificParameters().get("Futures_Contract_String"));
+    } else { 
+      throw new RuntimeException("`Futures_Contract` or `Futures_Contract_String` not defined in exchange specific parameters.");
+    }
+
+    return contract;
   }
 
   @Override
@@ -58,7 +84,7 @@ public class HuobiExchange extends BaseExchange implements Exchange {
 
     ExchangeSpecification spec = new ExchangeSpecification(getClass());
     spec.setExchangeName("Huobi");
-    spec.setExchangeDescription("Huobi-Family Exchange (Huobi, BitVC)");
+    spec.setExchangeDescription("Huobi-Family Exchange (Huobi, BitVC, BitVC Futures)");
 
     /* by default we request market data from huobi and execute on bitvc */
     spec.setPlainTextUri("http://market.huobi.com/staticmarket");
@@ -66,9 +92,10 @@ public class HuobiExchange extends BaseExchange implements Exchange {
 
     /* set to true if trade and account service should be from BitVc too */
     spec.setExchangeSpecificParametersItem(USE_BITVC, false);
+    spec.setExchangeSpecificParametersItem(USE_BITVC_FUTURES, false);
     spec.setExchangeSpecificParametersItem(HUOBI_MARKET_DATA, "http://market.huobi.com/staticmarket");
     spec.setExchangeSpecificParametersItem("Websocket_SslUri", "http://hq.huobi.com");
-    
+
     return spec;
   }
 
@@ -77,15 +104,14 @@ public class HuobiExchange extends BaseExchange implements Exchange {
     // BitVC doesn't require a nonce for it's authenticated API
     return null;
   }
-  
+
   @Override
   public StreamingExchangeService getStreamingExchangeService(ExchangeStreamingConfiguration configuration){
-      if (! (Boolean) exchangeSpecification.getExchangeSpecificParametersItem(USE_BITVC)){
-          return new HuobiStreamingExchangeService(getExchangeSpecification(),configuration);
-      }
-      else{
-          return super.getStreamingExchangeService(configuration);
-      }
+    if (! (Boolean) exchangeSpecification.getExchangeSpecificParametersItem(USE_BITVC)){
+      return new HuobiStreamingExchangeService(getExchangeSpecification(),configuration);
+    }
+    else{
+      return super.getStreamingExchangeService(configuration);
+    }
   }
 }
-                                                                                                                                                                                                                                                                                                                                                                                                                                                                           

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcExchangeRate.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcExchangeRate.java
@@ -1,0 +1,22 @@
+package com.xeiam.xchange.huobi.dto.marketdata.futures;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class BitVcExchangeRate {
+  private final BigDecimal rate;
+  
+  
+  public BitVcExchangeRate(@JsonProperty("rate") BigDecimal rate) {
+    this.rate = rate;
+  }
+  
+  
+  public BigDecimal getRate() {
+
+    return rate;
+  }
+
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesDepth.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesDepth.java
@@ -1,0 +1,28 @@
+package com.xeiam.xchange.huobi.dto.marketdata.futures;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitVcFuturesDepth {
+
+  private final BigDecimal[][] asks;
+  private final BigDecimal[][] bids;
+
+  public BitVcFuturesDepth(@JsonProperty("asks") final BigDecimal[][] asks, @JsonProperty("bids") final BigDecimal[][] bids) {
+
+    this.asks = asks;
+    this.bids = bids;
+  }
+
+  public BigDecimal[][] getAsks() {
+
+    return asks;
+  }
+
+  public BigDecimal[][] getBids() {
+
+    return bids;
+  }
+
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesTicker.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesTicker.java
@@ -1,0 +1,78 @@
+package com.xeiam.xchange.huobi.dto.marketdata.futures;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitVcFuturesTicker {
+
+  private final BigDecimal high;
+  private final BigDecimal low;
+  private final BigDecimal last;
+  private final BigDecimal vol;
+  private final BigDecimal buy;
+  private final BigDecimal sell;
+  private final String contractType;
+  private final int contractId;
+
+  public BitVcFuturesTicker(@JsonProperty("high") final BigDecimal high, @JsonProperty("low") final BigDecimal low,
+      @JsonProperty("last") final BigDecimal last, @JsonProperty("vol") final BigDecimal vol, @JsonProperty("buy") final BigDecimal buy,
+      @JsonProperty("sell") final BigDecimal sell, @JsonProperty("contract_type") String contractType, @JsonProperty("contract_id") int contractId ) { 
+    this.high = high;
+    this.low = low;
+    this.last = last;
+    this.vol = vol;
+    this.buy = buy;
+    this.sell = sell;
+    this.contractType = contractType;
+    this.contractId = contractId;
+  }
+
+  
+  public BigDecimal getHigh() {
+  
+    return high;
+  }
+
+  
+  public BigDecimal getLow() {
+  
+    return low;
+  }
+
+  
+  public BigDecimal getLast() {
+  
+    return last;
+  }
+
+  
+  public BigDecimal getVol() {
+  
+    return vol;
+  }
+
+  
+  public BigDecimal getBuy() {
+  
+    return buy;
+  }
+
+  
+  public BigDecimal getSell() {
+  
+    return sell;
+  }
+  
+  
+  public String getContractType() {
+
+    return contractType;
+  }
+  
+  
+  public int getContractId() {
+
+    return contractId;
+  }
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesTrade.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/dto/marketdata/futures/BitVcFuturesTrade.java
@@ -1,0 +1,59 @@
+package com.xeiam.xchange.huobi.dto.marketdata.futures;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitVcFuturesTrade {
+
+  private final String id;
+  private final String time;
+  private final BigDecimal price;
+  private final BigDecimal amount;
+  private final String type;
+  private final Date date;
+
+  public BitVcFuturesTrade(@JsonProperty("tid") String id, @JsonProperty("time") final String time, @JsonProperty("price") final BigDecimal price,
+      @JsonProperty("amount") final BigDecimal amount, @JsonProperty("type") final String type, @JsonProperty("date") Date date) {
+
+    this.time = time;
+    this.price = price;
+    this.amount = amount;
+    this.type = type;
+    this.id = id;
+    this.date = date;
+  }
+
+  public String getTime() {
+
+    return time;
+  }
+
+  public BigDecimal getPrice() {
+
+    return price;
+  }
+
+  public BigDecimal getAmount() {
+
+    return amount;
+  }
+
+  public String getType() {
+
+    return type;
+  }
+  
+  public Date getDate() {
+
+    return date;
+  }
+  
+  
+  public String getId() {
+
+    return id;
+  }
+
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataService.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataService.java
@@ -1,0 +1,45 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import java.io.IOException;
+
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.marketdata.OrderBook;
+import com.xeiam.xchange.dto.marketdata.Ticker;
+import com.xeiam.xchange.dto.marketdata.Trades;
+import com.xeiam.xchange.huobi.BitVcFuturesAdapter;
+import com.xeiam.xchange.huobi.FuturesContract;
+import com.xeiam.xchange.service.polling.marketdata.PollingMarketDataService;
+
+public class BitVcFuturesMarketDataService extends BitVcFuturesMarketDataServiceRaw implements PollingMarketDataService {
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   * @param contract 
+   */
+  public BitVcFuturesMarketDataService(Exchange exchange, FuturesContract contract) {
+
+    super(exchange, contract);
+  }
+
+  @Override
+  public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
+
+    return BitVcFuturesAdapter.adaptTicker(getBitVcTicker(currencyPair.baseSymbol.toLowerCase()), currencyPair);
+  }
+
+  @Override
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
+
+    return BitVcFuturesAdapter.adaptOrderBook(getBitVcDepth(currencyPair.baseSymbol.toLowerCase()), currencyPair);
+  }
+
+  @Override
+  public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
+
+    return BitVcFuturesAdapter.adaptTrades(getBitVcTrades(currencyPair.baseSymbol.toLowerCase()), currencyPair);
+  }
+
+}

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataServiceRaw.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataServiceRaw.java
@@ -46,7 +46,7 @@ public class BitVcFuturesMarketDataServiceRaw extends HuobiBasePollingService {
     return bitvc.getTrades(symbol, contract.getName());
   }
 
-  public BitVcExchangeRate getExchangeRate() throws IOException {
+  public BitVcExchangeRate getBitVcExchangeRate() throws IOException {
 
     return bitvc.getExchangeRate();
   }

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataServiceRaw.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/BitVcFuturesMarketDataServiceRaw.java
@@ -1,0 +1,53 @@
+package com.xeiam.xchange.huobi.service.polling;
+
+import java.io.IOException;
+
+import si.mazi.rescu.RestProxyFactory;
+
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.huobi.BitVcFutures;
+import com.xeiam.xchange.huobi.FuturesContract;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcExchangeRate;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesDepth;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTicker;
+import com.xeiam.xchange.huobi.dto.marketdata.futures.BitVcFuturesTrade;
+
+public class BitVcFuturesMarketDataServiceRaw extends HuobiBasePollingService {
+
+  private final BitVcFutures bitvc;
+  private final FuturesContract contract;
+
+  /**
+   * Constructor
+   *
+   * @param exchange
+   * @param contract 
+   */
+  public BitVcFuturesMarketDataServiceRaw(Exchange exchange, FuturesContract contract) {
+
+    super(exchange);
+
+    this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "http://market.bitvc.com/futures/");
+    this.contract = contract;
+  }
+
+  public BitVcFuturesTicker getBitVcTicker(String symbol) throws IOException {
+
+    return bitvc.getTicker(symbol, contract.getName());
+  }
+
+  public BitVcFuturesDepth getBitVcDepth(String symbol) throws IOException {
+
+    return bitvc.getDepths(symbol, contract.getName());
+  }
+
+  public BitVcFuturesTrade[] getBitVcTrades(String symbol) throws IOException {
+
+    return bitvc.getTrades(symbol, contract.getName());
+  }
+
+  public BitVcExchangeRate getExchangeRate() throws IOException {
+
+    return bitvc.getExchangeRate();
+  }
+}


### PR DESCRIPTION
*No functional changes for existing code in the Huobi adapter*

Support for BitVc futures market data (trading functionality coming soon). This futures data also acts as Huobi's futures market. To see how to use it, check the `HuobiDepthDemo`.
