### PR TITLE
Order class flags variable and Trade additional data map (with Kraken implementation)

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/Order.java
@@ -2,6 +2,8 @@ package com.xeiam.xchange.dto;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
 
 import com.xeiam.xchange.currency.CurrencyPair;
 
@@ -21,6 +23,9 @@ public class Order {
      */
     ASK
   }
+
+  public interface IOrderFlags {
+  };
 
   /**
    * Order type i.e. bid or ask
@@ -46,6 +51,11 @@ public class Order {
    * The timestamp on the order
    */
   private final Date timestamp;
+
+  /**
+   * Any applicable order flags
+   */
+  private final Set<IOrderFlags> flags = new HashSet<IOrderFlags>();
 
   /**
    * @param type Either BID (buying) or ASK (selling)
@@ -95,6 +105,21 @@ public class Order {
   public Date getTimestamp() {
 
     return timestamp;
+  }
+
+  public Set<IOrderFlags> getOrderFlags() {
+    return flags;
+  }
+
+  public void addOrderFlag(IOrderFlags flag) {
+    flags.add(flag);
+  }
+
+  public void setOrderFlags(Set<IOrderFlags> flags) {
+    this.flags.clear();
+    if (flags != null) {
+      this.flags.addAll(flags);
+    }
   }
 
   @Override

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/marketdata/Trade.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/marketdata/Trade.java
@@ -2,6 +2,8 @@ package com.xeiam.xchange.dto.marketdata;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
@@ -40,6 +42,11 @@ public class Trade {
    * The trade id
    */
   protected final String id;
+
+  /**
+   * Additional exchange specific data that might be of interest
+   */
+  private final Map<String, Object> additionalData = new HashMap<String, Object>();
 
   /**
    * This constructor is called to create a public Trade object in
@@ -94,6 +101,26 @@ public class Trade {
     return id;
   }
 
+  public Object getAdditionalData(String key) {
+    return additionalData.get(key);
+  }
+
+  public void putAdditionalData(String key, Object value) {
+    additionalData.put(key, value);
+  }
+
+  public Map<String, Object> getAdditionalData() {
+    return additionalData;
+  }
+
+  public Trade setAdditionalData(Map<String, Object> value) {
+    additionalData.clear();
+    if (value != null) {
+      additionalData.putAll(value);
+    }
+    return this;
+  }
+
   @Override
   public boolean equals(Object o) {
 
@@ -127,14 +154,15 @@ public class Trade {
     private BigDecimal price;
     private Date timestamp;
     private String id;
+    private Map<String, Object> additionalData;
 
     public Builder() {
 
     }
 
     public static Builder from(Trade trade) {
-      return new Builder().type(trade.getType()).tradableAmount(trade.getTradableAmount()).currencyPair(trade.getCurrencyPair()).price(trade.getPrice()).timestamp(trade.getTimestamp())
-          .id(trade.getId());
+      return new Builder().type(trade.getType()).tradableAmount(trade.getTradableAmount()).currencyPair(trade.getCurrencyPair())
+          .price(trade.getPrice()).timestamp(trade.getTimestamp()).id(trade.getId()).additionalData(trade.getAdditionalData());
     }
 
     public Builder type(OrderType type) {
@@ -173,9 +201,15 @@ public class Trade {
       return this;
     }
 
+    public Builder additionalData(Map<String, Object> additionalData) {
+
+      this.additionalData = additionalData;
+      return this;
+    }
+
     public Trade build() {
 
-      return new Trade(type, tradableAmount, currencyPair, price, timestamp, id);
+      return new Trade(type, tradableAmount, currencyPair, price, timestamp, id).setAdditionalData(additionalData);
     }
   }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/UserTrade.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/UserTrade.java
@@ -2,6 +2,7 @@ package com.xeiam.xchange.dto.trade;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.Map;
 
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
@@ -89,14 +90,16 @@ public final class UserTrade extends Trade {
     private String orderId;
     private BigDecimal feeAmount;
     private String feeCurrency;
+    private Map<String, Object> additionalData;
 
     public Builder() {
 
     }
 
     public static Builder from(UserTrade trade) {
-      return new Builder().type(trade.getType()).tradableAmount(trade.getTradableAmount()).currencyPair(trade.getCurrencyPair()).price(trade.getPrice()).timestamp(trade.getTimestamp())
-          .id(trade.getId()).orderId(trade.getOrderId()).feeAmount(trade.getFeeAmount()).feeCurrency(trade.getFeeCurrency());
+      return new Builder().type(trade.getType()).tradableAmount(trade.getTradableAmount()).currencyPair(trade.getCurrencyPair())
+          .price(trade.getPrice()).timestamp(trade.getTimestamp()).id(trade.getId()).orderId(trade.getOrderId()).feeAmount(trade.getFeeAmount())
+          .feeCurrency(trade.getFeeCurrency()).additionalData(trade.getAdditionalData());
     }
 
     public Builder type(OrderType type) {
@@ -153,9 +156,17 @@ public final class UserTrade extends Trade {
       return this;
     }
 
+    public Builder additionalData(Map<String, Object> additionalData) {
+
+      this.additionalData = additionalData;
+      return this;
+    }
+
     public UserTrade build() {
 
-      return new UserTrade(type, tradableAmount, currencyPair, price, timestamp, id, orderId, feeAmount, feeCurrency);
+      UserTrade trade = new UserTrade(type, tradableAmount, currencyPair, price, timestamp, id, orderId, feeAmount, feeCurrency);
+      trade.setAdditionalData(additionalData);
+      return trade;
     }
   }
 }

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/account/CryptsyTransfers.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/dto/account/CryptsyTransfers.java
@@ -34,8 +34,8 @@ public class CryptsyTransfers {
    * @param funds The funds
    * @throws ParseException
    */
-  public CryptsyTransfers(@JsonProperty("currency") String currency, @JsonProperty("request_timeStamp") String req_timeStamp,
-      @JsonProperty("processed") int processed, @JsonProperty("processed_timeStamp") String proc_timeStamp, @JsonProperty("from") String from,
+  public CryptsyTransfers(@JsonProperty("currency") String currency, @JsonProperty("request_timestamp") String req_timeStamp,
+      @JsonProperty("processed") int processed, @JsonProperty("processed_timestamp") String proc_timeStamp, @JsonProperty("from") String from,
       @JsonProperty("to") String to, @JsonProperty("quantity") BigDecimal quantity, @JsonProperty("direction") CryptsyTrfDirection direction)
       throws ParseException {
 

--- a/xchange-cryptsy/src/test/java/com/xeiam/xchange/cryptsy/dto/account/CryptsyAccountJsonTest.java
+++ b/xchange-cryptsy/src/test/java/com/xeiam/xchange/cryptsy/dto/account/CryptsyAccountJsonTest.java
@@ -5,8 +5,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import org.junit.Test;
 
@@ -96,6 +99,11 @@ public class CryptsyAccountJsonTest {
     assertEquals(transfer.getQuantity(), new BigDecimal("0.00022557"));
     assertEquals(transfer.getRecipient(), "B00191301");
     assertEquals(transfer.getTransferDirection(), CryptsyTrfDirection.out);
+    
+    DateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    format.setTimeZone(TimeZone.getTimeZone("US/Eastern"));
+    assertEquals("2014-05-19 09:31:52", format.format(transfer.getRequestTimestamp()));
+    assertEquals("2014-05-19 09:31:53", format.format(transfer.getProcessedTimestamp()));
   }
 
   @Test

--- a/xchange-cryptsy/src/test/resources/account/Sample_MyTransfers_Data.json
+++ b/xchange-cryptsy/src/test/resources/account/Sample_MyTransfers_Data.json
@@ -1,1 +1,1 @@
-{"success":"1","return":[{"currency":"NET","request_timestamp":"2014-05-19 09:31:52","processed":0,"processed_timestamp":"0000-00-00 00:00:00","from":"A00010101","to":"B00191301","quantity":"0.00022557","direction":"out"}]}
+{"success":"1","return":[{"currency":"NET","request_timestamp":"2014-05-19 09:31:52","processed":0,"processed_timestamp":"2014-05-19 09:31:53","from":"A00010101","to":"B00191301","quantity":"0.00022557","direction":"out"}]}

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
@@ -215,8 +215,10 @@ public class KrakenAdapters {
     BigDecimal averagePrice = krakenTrade.getAverageClosePrice();
     BigDecimal price = (averagePrice == null) ? krakenTrade.getPrice() : averagePrice;
 
-    return new UserTrade(orderType, tradableAmount, new CurrencyPair(tradableIdentifier, transactionCurrency), price, timestamp, tradeId,
-        krakenTrade.getOrderTxId(), krakenTrade.getFee(), transactionCurrency);
+    UserTrade userTrade = new UserTrade(orderType, tradableAmount, new CurrencyPair(tradableIdentifier, transactionCurrency), price, timestamp,
+        tradeId, krakenTrade.getOrderTxId(), krakenTrade.getFee(), transactionCurrency);
+    userTrade.putAdditionalData("cost", krakenTrade.getCost());
+    return userTrade;
   }
 
   public static OrderType adaptOrderType(KrakenType krakenType) {

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenOrderFlags.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenOrderFlags.java
@@ -12,10 +12,14 @@ import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.xeiam.xchange.dto.Order.IOrderFlags;
 
-public enum KrakenOrderFlags {
+public enum KrakenOrderFlags implements IOrderFlags {
 
-  VIQC, FCIB, FCIQ, NOMPP;
+  VIQC, // volume in quote currency
+  FCIB, // prefer fee in base currency
+  FCIQ, // prefer fee in quote currency
+  NOMPP; // no market price protection
 
   @Override
   public String toString() {

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenStandardOrder.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/dto/trade/KrakenStandardOrder.java
@@ -1,12 +1,13 @@
 package com.xeiam.xchange.kraken.dto.trade;
 
 import java.math.BigDecimal;
-import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
 import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.Order.IOrderFlags;
 
 public class KrakenStandardOrder {
 
@@ -18,7 +19,7 @@ public class KrakenStandardOrder {
   private final BigDecimal volume;
   private final String leverage;
   private final String positionTxId;
-  private final Set<KrakenOrderFlags> orderFlags;
+  private final Set<IOrderFlags> orderFlags;
   private final String startTime;
   private final String expireTime;
   private final String userRefId;
@@ -26,8 +27,8 @@ public class KrakenStandardOrder {
   private final Map<String, String> closeOrder;
 
   private KrakenStandardOrder(CurrencyPair currencyPair, KrakenType type, KrakenOrderType orderType, String price, String secondaryPrice,
-      BigDecimal volume, String leverage, String positionTxId, Set<KrakenOrderFlags> orderFlags, String startTime, String expireTime,
-      String userRefId, boolean validateOnly, Map<String, String> closeOrder) {
+      BigDecimal volume, String leverage, String positionTxId, Set<IOrderFlags> orderFlags, String startTime, String expireTime, String userRefId,
+      boolean validateOnly, Map<String, String> closeOrder) {
 
     this.currencyPair = currencyPair;
     this.type = type;
@@ -85,7 +86,7 @@ public class KrakenStandardOrder {
     return positionTxId;
   }
 
-  public Set<KrakenOrderFlags> getOrderFlags() {
+  public Set<IOrderFlags> getOrderFlags() {
 
     return orderFlags;
   }
@@ -202,7 +203,7 @@ public class KrakenStandardOrder {
     private final BigDecimal volume;
     private String leverage;
     private String positionTxId;
-    private Set<KrakenOrderFlags> orderFlags;
+    private final Set<IOrderFlags> orderFlags;
     private String startTime;
     private String expireTime;
     private String userRefId;
@@ -215,7 +216,7 @@ public class KrakenStandardOrder {
       this.type = type;
       this.orderType = orderType;
       this.volume = volume;
-      this.orderFlags = EnumSet.noneOf(KrakenOrderFlags.class);
+      this.orderFlags = new HashSet<IOrderFlags>();
       this.startTime = "0";
       this.positionTxId = "0";
       this.validateOnly = false;
@@ -245,9 +246,13 @@ public class KrakenStandardOrder {
       return this;
     }
 
-    public KrakenOrderBuilder withOrderFlags(Set<KrakenOrderFlags> orderFlags) {
+    public KrakenOrderBuilder withOrderFlags(Set<IOrderFlags> flags) {
 
-      this.orderFlags.addAll(orderFlags);
+      if (flags == null) {
+        orderFlags.clear();
+      } else {
+        orderFlags.addAll(flags);
+      }
       return this;
     }
 
@@ -339,7 +344,7 @@ public class KrakenStandardOrder {
       return positionTxId;
     }
 
-    public Set<KrakenOrderFlags> getOrderFlags() {
+    public Set<IOrderFlags> getOrderFlags() {
 
       return orderFlags;
     }

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingService.java
@@ -13,6 +13,7 @@ import si.mazi.rescu.RestProxyFactory;
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.currency.Currencies;
 import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.Order.IOrderFlags;
 import com.xeiam.xchange.exceptions.ExchangeException;
 import com.xeiam.xchange.exceptions.FrequencyLimitExceededException;
 import com.xeiam.xchange.exceptions.NonceException;
@@ -25,6 +26,7 @@ import com.xeiam.xchange.kraken.dto.marketdata.KrakenServerTime;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenAssetPairsResult;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenAssetsResult;
 import com.xeiam.xchange.kraken.dto.marketdata.results.KrakenServerTimeResult;
+import com.xeiam.xchange.kraken.dto.trade.KrakenOrderFlags;
 import com.xeiam.xchange.kraken.service.KrakenDigest;
 import com.xeiam.xchange.service.BaseExchangeService;
 import com.xeiam.xchange.service.polling.BasePollingService;
@@ -207,17 +209,22 @@ public class KrakenBasePollingService extends BaseExchangeService implements Bas
     return assetPairsString;
   }
 
-  protected String delimitSet(Set<?> items) {
+  protected String delimitSet(Set<IOrderFlags> items) {
 
     String delimitedSetString = null;
     if (items != null && !items.isEmpty()) {
       StringBuilder delimitStringBuilder = null;
       for (Object item : items) {
-        if (delimitStringBuilder == null) {
-          delimitStringBuilder = new StringBuilder(item.toString());
-        } else {
-          delimitStringBuilder.append(",").append(item.toString());
+        if (item instanceof KrakenOrderFlags) {
+          if (delimitStringBuilder == null) {
+            delimitStringBuilder = new StringBuilder(item.toString());
+          } else {
+            delimitStringBuilder.append(",").append(item.toString());
+          }
         }
+      }
+      if (delimitStringBuilder != null) {
+        delimitedSetString = delimitStringBuilder.toString();
       }
     }
     return delimitedSetString;

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeServiceRaw.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeServiceRaw.java
@@ -129,7 +129,8 @@ public class KrakenTradeServiceRaw extends KrakenBasePollingService {
   public KrakenOrderResponse placeKrakenMarketOrder(MarketOrder marketOrder) throws IOException {
 
     KrakenType type = KrakenType.fromOrderType(marketOrder.getType());
-    KrakenOrderBuilder orderBuilder = KrakenStandardOrder.getMarketOrderBuilder(marketOrder.getCurrencyPair(), type, marketOrder.getTradableAmount());
+    KrakenOrderBuilder orderBuilder = KrakenStandardOrder.getMarketOrderBuilder(marketOrder.getCurrencyPair(), type, marketOrder.getTradableAmount())
+        .withOrderFlags(marketOrder.getOrderFlags());
 
     return placeKrakenOrder(orderBuilder.buildOrder());
   }
@@ -137,8 +138,8 @@ public class KrakenTradeServiceRaw extends KrakenBasePollingService {
   public KrakenOrderResponse placeKrakenLimitOrder(LimitOrder limitOrder) throws IOException {
 
     KrakenType type = KrakenType.fromOrderType(limitOrder.getType());
-    KrakenOrderBuilder krakenOrderBuilder = KrakenStandardOrder.getLimitOrderBuilder(limitOrder.getCurrencyPair(), type, limitOrder.getLimitPrice()
-        .toString(), limitOrder.getTradableAmount());
+    KrakenOrderBuilder krakenOrderBuilder = KrakenStandardOrder.getLimitOrderBuilder(limitOrder.getCurrencyPair(), type,
+        limitOrder.getLimitPrice().toString(), limitOrder.getTradableAmount()).withOrderFlags(limitOrder.getOrderFlags());
 
     return placeKrakenOrder(krakenOrderBuilder.buildOrder());
   }

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/KrakenAdaptersTest.java
@@ -136,8 +136,8 @@ public class KrakenAdaptersTest {
 
     AccountInfo info = KrakenAdapters.adaptBalance(krakenBalance.getResult(), null);
 
-    assertThat(info.getBalance(Currencies.EUR)).isEqualTo(new BigDecimal("1.0539"));
-    assertThat(info.getBalance(Currencies.BTC)).isEqualTo(new BigDecimal("0.4888583300"));
+    assertThat(info.getWallet(Currencies.EUR).getBalance()).isEqualTo(new BigDecimal("1.0539"));
+    assertThat(info.getWallet(Currencies.BTC).getBalance()).isEqualTo(new BigDecimal("0.4888583300"));
 
   }
 
@@ -210,5 +210,6 @@ public class KrakenAdaptersTest {
     assertThat(trade.getType()).isEqualTo(OrderType.ASK);
     assertThat(trade.getFeeAmount()).isEqualTo(new BigDecimal("0.03208"));
     assertThat(trade.getFeeCurrency()).isEqualTo(Currencies.LTC);
+    assertThat(trade.getAdditionalData("cost")).isEqualTo(new BigDecimal("16.03781"));
   }
 }

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingServiceTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/service/polling/KrakenBasePollingServiceTest.java
@@ -1,0 +1,54 @@
+package com.xeiam.xchange.kraken.service.polling;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.ExchangeFactory;
+import com.xeiam.xchange.ExchangeSpecification;
+import com.xeiam.xchange.dto.Order.IOrderFlags;
+import com.xeiam.xchange.kraken.KrakenExchange;
+import com.xeiam.xchange.kraken.dto.trade.KrakenOrderFlags;
+
+public class KrakenBasePollingServiceTest {
+
+  private enum OtherExchangeFlags implements IOrderFlags {
+    OTHER;
+  };
+
+  @Test
+  public void testDelimitSetOrderFlags() {
+    ExchangeSpecification specification = new ExchangeSpecification(KrakenExchange.class);
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(specification);
+    KrakenBasePollingService service = new KrakenBasePollingService(exchange);
+
+    assertThat(service.delimitSet(null)).isNull();
+
+    Set<IOrderFlags> flags = new HashSet<IOrderFlags>();
+    assertThat(service.delimitSet(flags)).isNull();
+
+    flags.add(KrakenOrderFlags.NOMPP);
+    assertThat(service.delimitSet(flags)).isEqualTo(KrakenOrderFlags.NOMPP.toString());
+
+    flags.add(OtherExchangeFlags.OTHER); // this flag should not be added to the string
+    assertThat(service.delimitSet(flags)).isEqualTo(KrakenOrderFlags.NOMPP.toString());
+    flags.remove(OtherExchangeFlags.OTHER);
+
+    flags.add(KrakenOrderFlags.VIQC);
+    flags.add(KrakenOrderFlags.FCIQ);
+    // flags should now contain NOMPP, VIQC and FCIQ
+    Collection<String> flagsAsStrings = Arrays.asList(service.delimitSet(flags).split(","));
+    assertThat(flagsAsStrings.size()).isEqualTo(3);
+    assertThat(flagsAsStrings.size()).isEqualTo(flags.size());
+    for(IOrderFlags flag : flags) {
+      assertThat(flagsAsStrings).contains(flag.toString());
+    }
+  }
+
+}


### PR DESCRIPTION
Added an extra field to the Order and Trade classes to hold additional data, the rationale behind this is:

* on order entry some exchanges will support flags to tag the order with additional information, this does not currently seem possible to do in a generic manner using the existing implementation. 

* on trade message from the exchange additional information is sometimes provided above and beyond the standard trade facts. If this information is of interest it can be stored in the additional data map. In the example below the calculated quantity (1.130102248) does not match the cost returned in the message (1.13010). 

```
Order Entry
pair=XXBTXLTC&type=sell&ordertype=limit&price=162.60003&volume=0.010147599&position=0&oflags=fcib

Trade
"TTTTT-TTTTT-TTTTT":{"ordertxid":"OOOOO-OOOOO-OOOOO","pair":"XXBTXLTC",
"time":1431587791.0000,"type":"sell","ordertype":"limit","price":"162.80000",
"cost":"1.13010","fee":"0.00102","vol":"0.00694166","margin":"0.00000","misc":""}

Price * Quantity = 1.130102248 LTC
Actual balance movement = cost = 1.13010 LTC
```