### PR TITLE
Coinbase digest utf-8 fix

### DIFF
--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
@@ -2,11 +2,9 @@ package com.xeiam.xchange.coinbaseex.service;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.math.BigInteger;
 
 import javax.crypto.Mac;
 import javax.ws.rs.HeaderParam;
-import javax.xml.bind.DatatypeConverter;
 
 import si.mazi.rescu.RestInvocation;
 import si.mazi.rescu.utils.Base64;

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
@@ -40,6 +40,7 @@ public class CoinbaseExDigest extends BaseParamsDigest {
 				"/" + restInvocation.getMethodPath() + (restInvocation.getRequestBody() != null ? restInvocation.getRequestBody() : "");
 
 		Mac mac256 = getMac();
+		
 		try {
 			mac256.update(message.getBytes("UTF-8"));
 		} catch (IllegalStateException | UnsupportedEncodingException e) {

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/CoinbaseExDigest.java
@@ -43,7 +43,7 @@ public class CoinbaseExDigest extends BaseParamsDigest {
 		
 		try {
 			mac256.update(message.getBytes("UTF-8"));
-		} catch (IllegalStateException | UnsupportedEncodingException e) {
+		} catch (Exception e) {
 			throw new ExchangeException("Digest encoding exception", e);
 		}
 


### PR DESCRIPTION
There's still quite frequent "invalid signature" 400 HTTP errors, not quite sure why. This reduces the failures a bit but does not fully solve it.