### PR TITLE
CoinbaseEx: polling of trades

### DIFF
--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/CoinbaseEx.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/CoinbaseEx.java
@@ -20,6 +20,7 @@ import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProduct;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductBook;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductStats;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductTicker;
+import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExTrade;
 import com.xeiam.xchange.coinbaseex.dto.trade.CoinbaseExIdResponse;
 import com.xeiam.xchange.coinbaseex.dto.trade.CoinbaseExOrder;
 import com.xeiam.xchange.coinbaseex.dto.trade.CoinbaseExPlaceOrder;
@@ -45,6 +46,11 @@ public interface CoinbaseEx {
   @Path("products/{baseCurrency}-{targetCurrency}/book?level={level}")
   CoinbaseExProductBook getProductOrderBook(@PathParam("baseCurrency")String baseCurrency, @PathParam("targetCurrency") String targetCurrency, @PathParam("level") String level) throws IOException;
   
+  @GET
+  @Path("products/{baseCurrency}-{targetCurrency}/trades?limit={limit}")
+  CoinbaseExTrade[] getTrades(@PathParam("baseCurrency")String baseCurrency, @PathParam("targetCurrency") String targetCurrency, @PathParam("limit") String limit) throws IOException;
+
+  
   /** Authenticated calls */
   
   @GET
@@ -69,5 +75,6 @@ public interface CoinbaseEx {
   @Consumes(MediaType.TEXT_PLAIN)
   void cancelOrder(@PathParam("id") String id, @HeaderParam("CB-ACCESS-KEY") String apiKey, @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer, 
 		  @HeaderParam("CB-ACCESS-TIMESTAMP") String timestamp, @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase);
+  
   
 }

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/dto/marketdata/CoinbaseExTrade.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/dto/marketdata/CoinbaseExTrade.java
@@ -1,0 +1,54 @@
+package com.xeiam.xchange.coinbaseex.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CoinbaseExTrade {
+	private final String timestamp;
+	private final long tradeId;
+	private final BigDecimal price;
+	private final BigDecimal size;
+	private final String side;
+	public CoinbaseExTrade(@JsonProperty("time") String timestamp,@JsonProperty("trade_id") long tradeId, @JsonProperty("price") BigDecimal price,
+			@JsonProperty("size") BigDecimal size, @JsonProperty("side") String side) {
+		this.timestamp = timestamp;
+		this.tradeId = tradeId;
+		this.price = price;
+		this.size = size;
+		this.side = side;
+	}
+
+	public String getTimestamp() {
+		return timestamp;
+	}
+	public long getTradeId() {
+		return tradeId;
+	}
+	public BigDecimal getPrice() {
+		return price;
+	}
+	public BigDecimal getSize() {
+		return size;
+	}
+	public String getSide() {
+		return side;
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder();
+		builder.append("CoinbaseExTrade [timestamp=");
+		builder.append(timestamp);
+		builder.append(", tradeId=");
+		builder.append(tradeId);
+		builder.append(", price=");
+		builder.append(price);
+		builder.append(", size=");
+		builder.append(size);
+		builder.append(", side=");
+		builder.append(side);
+		builder.append("]");
+		return builder.toString();
+	}
+}

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExMarketDataService.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExMarketDataService.java
@@ -47,7 +47,9 @@ public class CoinbaseExMarketDataService extends CoinbaseExMarketDataServiceRaw 
 
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
-    throw new NotYetImplementedForExchangeException();
+	  
+	  return CoinbaseExAdapters.adaptTrades(getCoinbaseExTrades(currencyPair, 100), currencyPair);
   }
+
+
 }

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExMarketDataServiceRaw.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExMarketDataServiceRaw.java
@@ -7,6 +7,7 @@ import com.xeiam.xchange.coinbaseex.CoinbaseEx;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductBook;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductStats;
 import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExProductTicker;
+import com.xeiam.xchange.coinbaseex.dto.marketdata.CoinbaseExTrade;
 import com.xeiam.xchange.currency.CurrencyPair;
 
 /**
@@ -53,6 +54,12 @@ public class CoinbaseExMarketDataServiceRaw extends CoinbaseExBasePollingService
 	    CoinbaseExProductBook book = this.coinbaseEx.getProductOrderBook(currencyPair.baseSymbol, currencyPair.counterSymbol, String.valueOf(level));
 	    return book;  
   }
+  
+  public CoinbaseExTrade[] getCoinbaseExTrades(CurrencyPair currencyPair, int limit) throws IOException {
+	  
+	  return this.coinbaseEx.getTrades(currencyPair.baseSymbol, currencyPair.counterSymbol, String.valueOf(limit));
+		
+	}
 
   private boolean checkProductExists(CurrencyPair currencyPair) throws IOException {
 


### PR DESCRIPTION
Implement missing trades extraction. Currently by default just polls the last 100 trades. Coinbase supports elaborate pagination, can be implemented another time.