### PR TITLE
[Cryptsy] Public market data service fix

### DIFF
--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyExchange.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/CryptsyExchange.java
@@ -82,6 +82,15 @@ public class CryptsyExchange extends BaseExchange implements Exchange {
   public PollingMarketDataService getPollingPublicMarketDataService() {
     return pollingPublicMarketDataService;
   }
+  
+  @Override
+  public PollingMarketDataService getPollingMarketDataService() {
+    if (exchangeSpecification != null && exchangeSpecification.getApiKey() != null) {
+      return pollingMarketDataService;
+    } else {
+      return pollingPublicMarketDataService;
+    }
+  }
 
   @Override
   public SynchronizedValueFactory<Long> getNonceFactory() {


### PR DESCRIPTION
Override getPollingMarketDataService so that it returns the public
service if apiKey is null.