### PR TITLE
Update cancel limited order endpoint

### DIFF
--- a/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/CleverCoinAuthenticated.java
+++ b/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/CleverCoinAuthenticated.java
@@ -49,8 +49,8 @@ public interface CleverCoinAuthenticated extends CleverCoin {
 		  @FormParam("price") BigDecimal price)
       throws CleverCoinException, IOException;
   
-  @GET
-  @Path("orders/limited/cancel")
+  @DELETE
+  @Path("orders/limited")
   public CleverCoinCancelOrder cancelOrder(@HeaderParam("X-CleverAPI-Key") String apiKey, @HeaderParam("X-CleverAPI-Signature") ParamsDigest signer,
 		  @HeaderParam("X-CleverAPI-Nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("orderID") int orderId)
       throws CleverCoinException, IOException;


### PR DESCRIPTION
Change the request method and the url of the cancel limited order
endpoint. The old one will be deprecated soon.