### PR TITLE
[core] made Order abstract and improved LimitOrder.Builder

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/Order.java
@@ -10,7 +10,7 @@ import com.xeiam.xchange.currency.CurrencyPair;
 /**
  * Data object representing an order
  */
-public class Order {
+public abstract class Order {
 
   public enum OrderType {
 
@@ -169,7 +169,7 @@ public class Order {
     return true;
   }
 
-  public static class Builder {
+  public abstract static class Builder {
 
     protected OrderType orderType;
     protected BigDecimal tradableAmount;
@@ -179,14 +179,9 @@ public class Order {
 
     protected final Set<IOrderFlags> flags = new HashSet<IOrderFlags>();
 
-    public Builder(OrderType orderType, CurrencyPair currencyPair) {
+    protected Builder(OrderType orderType, CurrencyPair currencyPair) {
       this.orderType = orderType;
       this.currencyPair = currencyPair;
-    }
-
-    public static Builder from(Order order) {
-      return new Builder(order.getType(), order.getCurrencyPair()).tradableAmount(order.getTradableAmount()).timestamp(order.getTimestamp())
-          .id(order.getId()).flags(order.getOrderFlags());
     }
 
     public Builder orderType(OrderType orderType) {
@@ -222,12 +217,6 @@ public class Order {
     public Builder flag(IOrderFlags flag) {
       this.flags.add(flag);
       return this;
-    }
-
-    public Order build() {
-      Order order = new Order(orderType, tradableAmount, currencyPair, id, timestamp);
-      order.setOrderFlags(flags);
-      return order;
     }
   }
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/trade/LimitOrder.java
@@ -89,9 +89,14 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
       super(orderType, currencyPair);
     }
 
-    public static Builder from(LimitOrder order) {
-      return (Builder) new Builder(order.getType(), order.getCurrencyPair()).tradableAmount(order.getTradableAmount()).timestamp(order.getTimestamp())
-          .id(order.getId()).limitPrice(order.getLimitPrice()).flags(order.getOrderFlags());
+    public static Builder from(Order order) {
+      Builder builder = (Builder) new Builder(order.getType(), order.getCurrencyPair()).tradableAmount(order.getTradableAmount())
+          .timestamp(order.getTimestamp()).id(order.getId()).flags(order.getOrderFlags());
+      if (order instanceof LimitOrder) {
+        LimitOrder limitOrder = (LimitOrder) order;
+        builder.limitPrice(limitOrder.getLimitPrice());
+      }
+      return builder;
     }
 
     public Builder orderType(OrderType orderType) {


### PR DESCRIPTION
As discussed with @rafalkrupinski [here](https://github.com/timmolter/XChange/commit/3f29273f80a64a2447934b25a3eaf45829c6e7f8#commitcomment-12137423) the LimitOrder.Builder from(...) method needs improvement. Also as agreed by @timmolter the parent Order class should be abstract, orders should be a MarketOrder or LimitOrder. 