### PR TITLE
 BTER order API returns 'true' instead of order id.

### DIFF
--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeServiceRaw.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeServiceRaw.java
@@ -17,84 +17,81 @@ import com.xeiam.xchange.dto.trade.LimitOrder;
 
 public class BTERPollingTradeServiceRaw extends BTERBasePollingService {
 
-  /**
-   * Constructor
-   *
-   * @param exchange
-   */
-  public BTERPollingTradeServiceRaw(Exchange exchange) {
+	/**
+	 * Constructor
+	 *
+	 * @param exchange
+	 */
+	public BTERPollingTradeServiceRaw(Exchange exchange) {
 
-    super(exchange);
-  }
+		super(exchange);
+	}
 
-  /**
-   * Submits a Limit Order to be executed on the BTER Exchange for the desired market defined by {@code CurrencyPair}. WARNING - BTER will return true
-   * regardless of whether or not an order actually gets created. The reason for this is that orders are simply submitted to a queue in their
-   * back-end. One example for why an order might not get created is because there are insufficient funds. The best attempt you can make to confirm
-   * that the order was created is to poll {@link #getBTEROpenOrders}. However if the order is created and executed before it is caught in its open
-   * state from calling {@link #getBTEROpenOrders} then the only way to confirm would be confirm the expected difference in funds available for your
-   * account.
-   *
-   * @param limitOrder
-   * @return boolean Used to determine if the order request was submitted successfully.
-   * @throws IOException
-   */
-  public boolean placeBTERLimitOrder(LimitOrder limitOrder) throws IOException {
+	/**
+	 * Submits a Limit Order to be executed on the BTER Exchange for the desired market defined by {@code CurrencyPair}. WARNING - BTER will return true regardless of whether or
+	 * not an order actually gets created. The reason for this is that orders are simply submitted to a queue in their back-end. One example for why an order might not get created
+	 * is because there are insufficient funds. The best attempt you can make to confirm that the order was created is to poll {@link #getBTEROpenOrders}. However if the order is
+	 * created and executed before it is caught in its open state from calling {@link #getBTEROpenOrders} then the only way to confirm would be confirm the expected difference in
+	 * funds available for your account.
+	 *
+	 * @param limitOrder
+	 * @return String order id of submitted request.
+	 * @throws IOException
+	 */
+	public String placeBTERLimitOrder(LimitOrder limitOrder) throws IOException {
 
-    BTEROrderType type = (limitOrder.getType() == Order.OrderType.BID) ? BTEROrderType.BUY : BTEROrderType.SELL;
+		BTEROrderType type = (limitOrder.getType() == Order.OrderType.BID) ? BTEROrderType.BUY : BTEROrderType.SELL;
 
-    return placeBTERLimitOrder(limitOrder.getCurrencyPair(), type, limitOrder.getLimitPrice(), limitOrder.getTradableAmount());
-  }
+		return placeBTERLimitOrder(limitOrder.getCurrencyPair(), type, limitOrder.getLimitPrice(), limitOrder.getTradableAmount());
+	}
 
-  /**
-   * Submits a Limit Order to be executed on the BTER Exchange for the desired market defined by {@code currencyPair}. WARNING - BTER will return true
-   * regardless of whether or not an order actually gets created. The reason for this is that orders are simply submitted to a queue in their
-   * back-end. One example for why an order might not get created is because there are insufficient funds. The best attempt you can make to confirm
-   * that the order was created is to poll {@link #getBTEROpenOrders}. However if the order is created and executed before it is caught in its open
-   * state from calling {@link #getBTEROpenOrders} then the only way to confirm would be confirm the expected difference in funds available for your
-   * account.
-   *
-   * @param currencyPair
-   * @param orderType
-   * @param rate
-   * @param amount
-   * @return boolean Used to determine if the order request was submitted successfully.
-   * @throws IOException
-   */
-  public boolean placeBTERLimitOrder(CurrencyPair currencyPair, BTEROrderType orderType, BigDecimal rate, BigDecimal amount) throws IOException {
+	/**
+	 * Submits a Limit Order to be executed on the BTER Exchange for the desired market defined by {@code currencyPair}. WARNING - BTER will return true regardless of whether or
+	 * not an order actually gets created. The reason for this is that orders are simply submitted to a queue in their back-end. One example for why an order might not get created
+	 * is because there are insufficient funds. The best attempt you can make to confirm that the order was created is to poll {@link #getBTEROpenOrders}. However if the order is
+	 * created and executed before it is caught in its open state from calling {@link #getBTEROpenOrders} then the only way to confirm would be confirm the expected difference in
+	 * funds available for your account.
+	 *
+	 * @param currencyPair
+	 * @param orderType
+	 * @param rate
+	 * @param amount
+	 * @return String order id of submitted request.  
+	 * @throws IOException
+	 */
+	public String placeBTERLimitOrder(CurrencyPair currencyPair, BTEROrderType orderType, BigDecimal rate, BigDecimal amount) throws IOException {
 
-    String pair = String.format("%s_%s", currencyPair.baseSymbol, currencyPair.counterSymbol).toLowerCase();
-    BTERPlaceOrderReturn orderId = bter.placeOrder(pair, orderType, rate, amount, apiKey, signatureCreator, exchange.getNonceFactory());
+		String pair = String.format("%s_%s", currencyPair.baseSymbol, currencyPair.counterSymbol).toLowerCase();
+		BTERPlaceOrderReturn orderId = bter.placeOrder(pair, orderType, rate, amount, apiKey, signatureCreator, exchange.getNonceFactory());
 
-    return handleResponse(orderId).isResult();
-  }
+		return handleResponse(orderId).getOrderId();
+	}
 
-  public boolean cancelOrder(String orderId) throws IOException {
+	public boolean cancelOrder(String orderId) throws IOException {
 
-    BTERBaseResponse cancelOrderResult = bter.cancelOrder(orderId, apiKey, signatureCreator, exchange.getNonceFactory());
+		BTERBaseResponse cancelOrderResult = bter.cancelOrder(orderId, apiKey, signatureCreator, exchange.getNonceFactory());
 
-    return handleResponse(cancelOrderResult).isResult();
-  }
+		return handleResponse(cancelOrderResult).isResult();
+	}
 
-  public BTEROpenOrders getBTEROpenOrders() throws IOException {
+	public BTEROpenOrders getBTEROpenOrders() throws IOException {
 
-    BTEROpenOrders bterOpenOrdersReturn = bter.getOpenOrders(apiKey, signatureCreator, exchange.getNonceFactory());
+		BTEROpenOrders bterOpenOrdersReturn = bter.getOpenOrders(apiKey, signatureCreator, exchange.getNonceFactory());
 
-    return handleResponse(bterOpenOrdersReturn);
-  }
+		return handleResponse(bterOpenOrdersReturn);
+	}
 
-  public BTEROrderStatus getBTEROrderStatus(String orderId) throws IOException {
+	public BTEROrderStatus getBTEROrderStatus(String orderId) throws IOException {
 
-    BTEROrderStatus orderStatus = bter.getOrderStatus(orderId, apiKey, signatureCreator, exchange.getNonceFactory());
+		BTEROrderStatus orderStatus = bter.getOrderStatus(orderId, apiKey, signatureCreator, exchange.getNonceFactory());
 
-    return handleResponse(orderStatus);
-  }
+		return handleResponse(orderStatus);
+	}
 
-  public BTERTradeHistoryReturn getBTERTradeHistory(CurrencyPair currencyPair) throws IOException {
+	public BTERTradeHistoryReturn getBTERTradeHistory(CurrencyPair currencyPair) throws IOException {
 
-    BTERTradeHistoryReturn bterTradeHistoryReturn = bter.getUserTradeHistory(apiKey, signatureCreator, exchange.getNonceFactory(),
-        BTERUtils.toPairString(currencyPair));
+		BTERTradeHistoryReturn bterTradeHistoryReturn = bter.getUserTradeHistory(apiKey, signatureCreator, exchange.getNonceFactory(), BTERUtils.toPairString(currencyPair));
 
-    return handleResponse(bterTradeHistoryReturn);
-  }
+		return handleResponse(bterTradeHistoryReturn);
+	}
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bter/trade/BTERTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bter/trade/BTERTradeDemo.java
@@ -62,9 +62,9 @@ public class BTERTradeDemo {
 
   private static void raw(BTERPollingTradeServiceRaw tradeService) throws IOException, InterruptedException {
 
-    boolean placedOrderResult = tradeService.placeBTERLimitOrder(CurrencyPair.LTC_BTC, BTEROrderType.SELL, new BigDecimal("0.0265"), new BigDecimal(
+    String placedOrderId = tradeService.placeBTERLimitOrder(CurrencyPair.LTC_BTC, BTEROrderType.SELL, new BigDecimal("0.0265"), new BigDecimal(
         "0.384"));
-    System.out.println(placedOrderResult); // Returned order id is currently broken for BTER, rely on open orders instead for demo :(
+    System.out.println(placedOrderId);
 
     Thread.sleep(2000); // wait for BTER's back-end to propagate the order
 


### PR DESCRIPTION
Please see issue: https://github.com/timmolter/XChange/issues/1001

This updates placeBTERLimitOrder method to return exchange reference (provided by exchange) instead of boolean.  This is in line with other feeds.  Tested and verified working.