### PR TITLE
okcoin streaming not reconnecting

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/ReconnectService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/ReconnectService.java
@@ -34,7 +34,7 @@ public class ReconnectService {
     this.exchangeStreamingConfiguration = exchangeStreamingConfiguration;
   }
 
-  public void intercept(ExchangeEvent exchangeEvent) {
+  public void intercept(ExchangeEvent exchangeEvent) throws Exception {
 
     reconnectTask.cancel();
     reconnectTask = new ReconnectTask();
@@ -47,17 +47,17 @@ public class ReconnectService {
         e.printStackTrace();
       }
       reconnect();
-    } else if (exchangeEvent.getEventType() == ExchangeEventType.CONNECT) {
+    }
+    else if (exchangeEvent.getEventType() == ExchangeEventType.CONNECT) {
       numConnectionAttempts = 0;
     }
 
   }
 
-  private void reconnect() {
+  private void reconnect() throws Exception {
 
     if (!streamingExchangeService.getWebSocketStatus().equals(READYSTATE.OPEN)) {
-      log.debug("ExchangeType Error. Attempting reconnect " + numConnectionAttempts + " of "
-          + exchangeStreamingConfiguration.getMaxReconnectAttempts());
+      log.debug("ExchangeType Error. Attempting reconnect " + numConnectionAttempts + " of " + exchangeStreamingConfiguration.getMaxReconnectAttempts());
 
       if (numConnectionAttempts >= exchangeStreamingConfiguration.getMaxReconnectAttempts()) {
         log.debug("Terminating reconnection attempts.");
@@ -80,7 +80,12 @@ public class ReconnectService {
       if (!streamingExchangeService.getWebSocketStatus().equals(READYSTATE.OPEN)) {
         log.debug("Time out!");
         timer.purge();
-        reconnect();
+        try {
+          reconnect();
+        } catch (Exception e) {
+          // TODO Auto-generated catch block
+          e.printStackTrace();
+        }
       }
       timer.purge();
       timer.schedule(new ReconnectTask(), exchangeStreamingConfiguration.getTimeoutInMs());

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/StreamingExchangeService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/StreamingExchangeService.java
@@ -16,8 +16,10 @@ public interface StreamingExchangeService {
    * <p>
    * Opens the connection to the upstream server for this instance.
    * </p>
+   * 
+   * @throws Exception
    */
-  void connect();
+  void connect() throws Exception;
 
   /**
    * <p>
@@ -39,11 +41,10 @@ public interface StreamingExchangeService {
    * <p>
    * Returns number of events in consumer event queue.
    * </p>
-   *
+   * 
    * @return An int
    */
   int countEventsAvailable();
-
 
   /**
    * <p>

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/streaming/WebSocketEventProducer.java
@@ -38,8 +38,7 @@ public class WebSocketEventProducer extends WebSocketClient {
    * @param headers
    * @throws URISyntaxException
    */
-  public WebSocketEventProducer(String url, ExchangeEventListener exchangeEventListener, Map<String, String> headers,
-      ReconnectService reconnectService) throws URISyntaxException {
+  public WebSocketEventProducer(String url, ExchangeEventListener exchangeEventListener, Map<String, String> headers, ReconnectService reconnectService) throws URISyntaxException {
 
     super(new URI(url), new Draft_17(), headers, 0);
     this.exchangeEventListener = exchangeEventListener;
@@ -56,7 +55,12 @@ public class WebSocketEventProducer extends WebSocketClient {
     ExchangeEvent exchangeEvent = new JsonWrappedExchangeEvent(ExchangeEventType.CONNECT, "connected");
 
     if (reconnectService != null) { // logic here to intercept errors and reconnect..
-      reconnectService.intercept(exchangeEvent);
+      try {
+        reconnectService.intercept(exchangeEvent);
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
     }
 
     exchangeEventListener.handleEvent(exchangeEvent);
@@ -73,7 +77,12 @@ public class WebSocketEventProducer extends WebSocketClient {
     ExchangeEvent exchangeEvent = new DefaultExchangeEvent(ExchangeEventType.MESSAGE, message);
 
     if (reconnectService != null) { // logic here to intercept errors and reconnect..
-      reconnectService.intercept(exchangeEvent);
+      try {
+        reconnectService.intercept(exchangeEvent);
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
     }
 
     exchangeEventListener.handleEvent(exchangeEvent);
@@ -116,7 +125,12 @@ public class WebSocketEventProducer extends WebSocketClient {
     ExchangeEvent exchangeEvent = new JsonWrappedExchangeEvent(ExchangeEventType.DISCONNECT, "disconnected");
 
     if (reconnectService != null) { // logic here to intercept errors and reconnect..
-      reconnectService.intercept(exchangeEvent);
+      try {
+        reconnectService.intercept(exchangeEvent);
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
     }
 
     exchangeEventListener.handleEvent(exchangeEvent);
@@ -132,7 +146,12 @@ public class WebSocketEventProducer extends WebSocketClient {
     ExchangeEvent exchangeEvent = new JsonWrappedExchangeEvent(ExchangeEventType.ERROR, ex.getMessage());
 
     if (reconnectService != null) { // logic here to intercept errors and reconnect..
-      reconnectService.intercept(exchangeEvent);
+      try {
+        reconnectService.intercept(exchangeEvent);
+      } catch (Exception e) {
+        // TODO Auto-generated catch block
+        e.printStackTrace();
+      }
     }
 
     exchangeEventListener.handleEvent(exchangeEvent);

--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/streaming/MonitorTask.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/streaming/MonitorTask.java
@@ -1,27 +1,34 @@
 package com.xeiam.xchange.okcoin.service.streaming;
 
 import java.util.TimerTask;
+import java.util.concurrent.RejectedExecutionException;
 
-class MonitorTask extends TimerTask {  
-  private long  startTime = System.currentTimeMillis();
-  private int checkTime = 5000;
+class MonitorTask extends TimerTask {
+  private long startTime = System.currentTimeMillis();
+  private final int checkTime = 5000;
   private WebSocketBase client = null;
-  
-  public void updateTime(){
+
+  public void updateTime() {
     startTime = System.currentTimeMillis();
   }
-  
-  public MonitorTask(WebSocketBase client){
+
+  public MonitorTask(WebSocketBase client) {
     this.client = client;
   }
-  
-  public void run() {  
-    if(System.currentTimeMillis() - startTime > checkTime){
+
+  @Override
+  public void run() {
+    if (System.currentTimeMillis() - startTime > checkTime) {
       client.setStatus(false);
 
       client.reConnect();
-    } 
-    
-    client.sendPing();
-  }  
+    }
+    try {
+      client.sendPing();
+    } catch (RejectedExecutionException reject) {
+      client.setStatus(false);
+
+      client.reConnect();
+    }
+  }
 }


### PR DESCRIPTION
Hi,

it would seem that com.xeiam.xchange.okcoin.service.streaming.WebSocketBase should automatically handle reconnects of the websockets.

How is it suggested to  handel certain exceptions such as hostnotfound in the event the connectivity is lost, or if the channel is not alive, nor do those exceptions seem to be bubbled up as call backs to the calling thread, so the main application cannot handel them by resubmitting another thread until connectivity is restored.

Quick simulation is to add a static route to okcoin.com once the streaming service has processed a set of events.
 route -n add 58.96.162.1/24 192.168.0.20
 route -n delete 58.96.162.0

