### PR TITLE
Migrate PollingTradeService.getTradeHistory(Object...) to TradeHistoryParams

### DIFF
--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
@@ -9,9 +9,10 @@ import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrades;
-import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+
+import static com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsZero.PARAMS_ZERO;
 
 public class BittrexTradeService extends BittrexTradeServiceRaw implements PollingTradeService {
 
@@ -55,20 +56,17 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
 
   @Override
   public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    return new UserTrades(BittrexAdapters.adaptUserTrades(getBittrexTradeHistory()), TradeSortType.SortByTimestamp);
+    return getTradeHistory((TradeHistoryParams) null);
   }
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
+    return new UserTrades(BittrexAdapters.adaptUserTrades(getBittrexTradeHistory()), TradeSortType.SortByTimestamp);
   }
 
   @Override
-  public com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
-
-    throw new NotAvailableFromExchangeException();
+  public TradeHistoryParams createTradeHistoryParams() {
+    return PARAMS_ZERO;
   }
 
 }

--- a/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/service/polling/BTCTradeTradeService.java
+++ b/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/service/polling/BTCTradeTradeService.java
@@ -1,6 +1,7 @@
 package com.xeiam.xchange.btctrade.service.polling;
 
 import java.io.IOException;
+import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.btctrade.BTCTradeAdapters;
@@ -13,9 +14,11 @@ import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
-import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import com.xeiam.xchange.utils.DateUtils;
 
 public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements PollingTradeService {
 
@@ -64,7 +67,19 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
   public UserTrades getTradeHistory(Object... arguments) throws IOException {
 
     long since = arguments.length > 0 ? toLong(arguments[0]) : 0L;
+    return getTradeHistory(new DefaultTradeHistoryParamsTimeSpan(DateUtils.fromUnixTime(since)));
+  }
 
+  /**
+   * Optional parameters: start time (default 0 = all) of {@link TradeHistoryParamsTimeSpan}
+   * <p/>
+   * Required parameters: none
+   * <p/>
+   * Note this method makes 1+N remote calls, where N is the number of returned trades
+   */
+  @Override
+  public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    long since = DateUtils.toUnixTime(((TradeHistoryParamsTimeSpan) params).getStartTime());
     BTCTradeOrder[] orders = getBTCTradeOrders(since, "all");
     BTCTradeOrder[] orderDetails = new BTCTradeOrder[orders.length];
 
@@ -75,16 +90,12 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
     return BTCTradeAdapters.adaptTrades(orders, orderDetails);
   }
 
+  /**
+   * @return an instance of {@link TradeHistoryParamsTimeSpan}
+   */
   @Override
-  public UserTrades getTradeHistory(TradeHistoryParams params) throws NotYetImplementedForExchangeException {
-
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
-  public com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
-
-    throw new NotYetImplementedForExchangeException();
+  public TradeHistoryParams createTradeHistoryParams() {
+    return new DefaultTradeHistoryParamsTimeSpan(new Date(0));
   }
 
 }

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
@@ -76,11 +76,9 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
       throw new IOException("You must supply a CurrencyPair!");
     } else {
       if (args[0] instanceof CurrencyPair) {
-
-        List<BTERTrade> userTrades = super.getBTERTradeHistory((CurrencyPair) args[0]).getTrades();
-
-        return BTERAdapters.adaptUserTrades(userTrades);
-
+        TradeHistoryParamCurrencyPair params = createTradeHistoryParams();
+        params.setCurrencyPair((CurrencyPair) args[0]);
+        return getTradeHistory(params);
       } else {
 
         throw new IOException("You must supply a CurrencyPair!");
@@ -102,7 +100,7 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
   }
 
   @Override
-  public TradeHistoryParams createTradeHistoryParams() {
+  public TradeHistoryParamCurrencyPair createTradeHistoryParams() {
 
     return new DefaultTradeHistoryParamCurrencyPair();
   }

--- a/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/service/polling/CleverCoinTradeService.java
+++ b/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/service/polling/CleverCoinTradeService.java
@@ -21,9 +21,7 @@ import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.exceptions.ExchangeException;
 import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
-import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
-import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+import com.xeiam.xchange.service.polling.trade.params.*;
 
 /**
  * @author Karsten Nilsen
@@ -91,8 +89,10 @@ public class CleverCoinTradeService extends CleverCoinTradeServiceRaw implements
         numberOfTransactions = ((Number) args[0]).intValue();
       }
     }
-    
-    return CleverCoinAdapters.adaptTradeHistory(getCleverCoinUserTransactions(numberOfTransactions));
+
+    TradeHistoryParamPaging params=createTradeHistoryParams();
+    params.setPageLength(numberOfTransactions);
+    return getTradeHistory(params);
   }
 
   /**
@@ -100,14 +100,13 @@ public class CleverCoinTradeService extends CleverCoinTradeServiceRaw implements
    */
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-
-    return CleverCoinAdapters.adaptTradeHistory(getCleverCoinUserTransactions(100));
+    Integer count = ((TradeHistoryParamPaging) params).getPageLength();
+    return CleverCoinAdapters.adaptTradeHistory(getCleverCoinUserTransactions(count));
   }
 
   @Override
-  public TradeHistoryParams createTradeHistoryParams() {
-
-    return new DefaultTradeHistoryParamPaging(1000);
+  public TradeHistoryParamPaging createTradeHistoryParams() {
+    return new DefaultTradeHistoryParamPaging(100);
   }
 
 }

--- a/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/CoinmateAdapters.java
@@ -46,6 +46,8 @@ import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrade;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.dto.trade.Wallet;
+import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Date;
@@ -191,4 +193,14 @@ public class CoinmateAdapters {
     return new OpenOrders(ordersList);
   }
 
+  public static String adaptOrder(TradeHistoryParamsSorted.Order order) {
+    switch (order) {
+    case asc:
+      return "ASC";
+    case desc:
+      return "DESC";
+    default:
+      throw new IllegalArgumentException();
+    }
+  }
 }

--- a/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/service/polling/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/service/polling/CoinmateTradeService.java
@@ -31,7 +31,6 @@ import com.xeiam.xchange.coinmate.CoinmateUtils;
 import com.xeiam.xchange.coinmate.dto.trade.CoinmateTradeResponse;
 import com.xeiam.xchange.coinmate.dto.trade.CoinmateCancelOrderResponse;
 import com.xeiam.xchange.coinmate.dto.trade.CoinmateOpenOrders;
-import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
@@ -41,7 +40,10 @@ import com.xeiam.xchange.exceptions.ExchangeException;
 import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPagingSorted;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+
 import java.io.IOException;
 
 /**
@@ -102,18 +104,21 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
 
     @Override
     public UserTrades getTradeHistory(Object... arguments) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-        return getTradeHistory((TradeHistoryParams) null);
+        return getTradeHistory(createTradeHistoryParams());
     }
 
     @Override
     public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-        return CoinmateAdapters.adaptTradeHistory(getCoinmateTradeHistory(0, 100, "ASC"));
+        DefaultTradeHistoryParamPagingSorted myParams = (DefaultTradeHistoryParamPagingSorted) params;
+        return CoinmateAdapters.adaptTradeHistory(getCoinmateTradeHistory(myParams.getPageNumber(), myParams.getPageLength(), CoinmateAdapters.adaptOrder(myParams.getOrder())));
     }
 
     @Override
     public TradeHistoryParams createTradeHistoryParams() {
-        //TODO
-        return null;
+        DefaultTradeHistoryParamPagingSorted params = new DefaultTradeHistoryParamPagingSorted(100);
+        params.setPageNumber(0);
+        params.setOrder(TradeHistoryParamsSorted.Order.asc);
+        return params;
     }
 
 }

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/PollingTradeService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/PollingTradeService.java
@@ -92,7 +92,9 @@ public interface PollingTradeService extends BasePollingService {
    * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   * @deprecated in favour of {@link #getTradeHistory(TradeHistoryParams)}
    */
+  @Deprecated
   public UserTrades getTradeHistory(Object... arguments) throws ExchangeException, NotAvailableFromExchangeException,
   NotYetImplementedForExchangeException, IOException;
 

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/TradeHistoryParamsZero.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/TradeHistoryParamsZero.java
@@ -1,0 +1,8 @@
+package com.xeiam.xchange.service.polling.trade.params;
+
+/**
+ * {@link TradeHistoryParams} with no parameters
+ */
+public class TradeHistoryParamsZero implements TradeHistoryParams {
+  final public static TradeHistoryParams PARAMS_ZERO = new TradeHistoryParamsZero();
+}

--- a/xchange-core/src/main/java/com/xeiam/xchange/utils/DateUtils.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/utils/DateUtils.java
@@ -127,4 +127,11 @@ public class DateUtils {
     return time == null ? null : time.getTime();
   }
 
+  /**
+   * Convert unix time to Java Date
+   */
+  public static Date fromUnixTime(long unix) {
+    return new Date(unix * 1000);
+  }
+
 }

--- a/xchange-independentreserve/src/main/java/com/xeiam/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
+++ b/xchange-independentreserve/src/main/java/com/xeiam/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
@@ -11,14 +11,12 @@ import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.independentreserve.IndependentReserveAdapters;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
+import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
 
 import java.io.IOException;
 
-/**
- * Author: Kamil Zbikowski
- * Date: 4/13/15
- */
 public class IndependentReserveTradeService extends IndependentReserveTradeServiceRaw implements PollingTradeService{
 
     public IndependentReserveTradeService(Exchange exchange) {
@@ -56,17 +54,20 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
 
     @Override
     public UserTrades getTradeHistory(Object... arguments) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-        return IndependentReserveAdapters.adaptTradeHistory(getIndependentReserveTradeHistory(1));
+        return getTradeHistory(createTradeHistoryParams());
     }
 
-
+    /**
+     * Optional parameters: {@link TradeHistoryParamPaging#getPageNumber()} indexed from 0
+     */
     @Override
     public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-        return null;
+        int pageNumber = ((TradeHistoryParamPaging) params).getPageNumber() + 1;
+        return IndependentReserveAdapters.adaptTradeHistory(getIndependentReserveTradeHistory(pageNumber));
     }
 
     @Override
-    public TradeHistoryParams createTradeHistoryParams() {
-        return null;
+    public TradeHistoryParamPaging createTradeHistoryParams() {
+        return new DefaultTradeHistoryParamPaging(null, 0);
     }
 }


### PR DESCRIPTION
All exchanges with implemented PollingTradeService.getTradeHistory(Object...) now have TradeHistoryParams version as well.

PollingTradeService.getTradeHistory(Object...) is now market as @Deprecated and may be removed in a future release (see #933)