### PR TITLE
[ripple] added trade history error handling and fixed trade history count limits bug

### DIFF
--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/RippleException.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/RippleException.java
@@ -13,6 +13,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
  {"success": false, "error_type": "invalid_request", 
  "message": "Invalid parameter: counter. Must be a currency string in the form currency+counterparty", "error": "restINVALID_PARAMETER"}
+ 
+ {"success": false, "error": "Cannot read property 'currency' of undefined", "error_type": "transaction"}
+ 
  */
 
 @SuppressWarnings("serial")
@@ -38,5 +41,10 @@ public class RippleException extends HttpStatusExceptionSupport {
 
   public String getErrorType() {
     return errorType;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s errorType[%s] error[%s] message[%s]", super.toString(), errorType, error, message);
   }
 }


### PR DESCRIPTION
For Ripple added trade history error handling to protect against any future occurrences similar to https://github.com/ripple/ripple-rest/issues/384 when failure or Ripple REST to parse (what turned out to be) a non-trade transaction was causing total failure of the trade history query. 

Fixed bug so that when trade history count limits are set to zero the check is disabled.