### PR TITLE
Update ItBitAuthenticated.java

### DIFF
--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAuthenticated.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAuthenticated.java
@@ -22,7 +22,6 @@ import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 @Path("v1")
-@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
 @Produces(MediaType.APPLICATION_JSON)
 public interface ItBitAuthenticated extends ItBit {
 
@@ -32,7 +31,6 @@ public interface ItBitAuthenticated extends ItBit {
 
   @GET
   @Path("wallets?userId={userId}")
-  @Consumes(MediaType.APPLICATION_JSON)
   ItBitAccountInfoReturn[] getInfo(@HeaderParam("Authorization") ParamsDigest signer, @HeaderParam("X-Auth-Timestamp") long timestamp,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<Long> valueFactory, @PathParam("userId") String userId) throws IOException;
 


### PR DESCRIPTION
Removed `@Consumes(MediaType.APPLICATION_FORM_URLENCODED)` from the Interface and `@Consumes(MediaType.APPLICATION_JSON)` from `@Path("wallets?userId={userId}")` as they were producing WARNINGS on GET requests.

Likely that other methods in this service need to be updated as well as a GET request should not spend any body contents.

Sample WARNINGS:

```
[main] WARN si.mazi.rescu.RestMethodMetadata - GET request declared as consuming method body as application/json. While body is allowed, it should be ignored by the server. Is this intended? Method: public abstract com.xeiam.xchange.itbit.v1.dto.account.ItBitAccountInfoReturn[] com.xeiam.xchange.itbit.v1.ItBitAuthenticated.getInfo(si.mazi.rescu.ParamsDigest,long,si.mazi.rescu.SynchronizedValueFactory,java.lang.String) throws java.io.IOException
Wallet [currency=XBT, balance=0E-8, available=0E-8, frozen=0, description=Wallet]

[main] WARN si.mazi.rescu.RestMethodMetadata - GET request declared as consuming method body as application/x-www-form-urlencoded. While body is allowed, it should be ignored by the server. Is this intended? Method: public abstract com.xeiam.xchange.itbit.v1.dto.marketdata.ItBitTicker com.xeiam.xchange.itbit.v1.ItBitAuthenticated.getTicker(java.lang.String,java.lang.String) throws java.io.IOException
Ticker [currencyPair=XBT/USD, last=263.94000000, bid=263.93, ask=264.25, high=267.13000000, low=262.67000000,avg=null, volume=3698.63340000, timestamp=1439226585467]
```
