### PR TITLE
ItBit: Use all exchange currencies for PollingTradeService.getOpenOrders()

### DIFF
--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -1,6 +1,9 @@
 package com.xeiam.xchange.itbit.v1.service.polling;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.currency.CurrencyPair;
@@ -10,6 +13,7 @@ import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.itbit.v1.ItBitAdapters;
+import com.xeiam.xchange.itbit.v1.dto.trade.ItBitOrder;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
@@ -30,8 +34,12 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return ItBitAdapters.adaptPrivateOrders(getItBitOpenOrders());
+	List<ItBitOrder> orders = new ArrayList<>();
+	for (CurrencyPair currencyPair : getExchangeSymbols()) {
+		orders.addAll(Arrays.asList(getItBitOpenOrders(currencyPair)));
+	}
+	ItBitOrder[] empty = {};
+    return ItBitAdapters.adaptPrivateOrders(orders.isEmpty()? empty : (ItBitOrder[]) orders.toArray());
   }
 
   @Override

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeServiceRaw.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.itbit.v1.dto.trade.ItBitOrder;
@@ -27,9 +28,9 @@ public class ItBitTradeServiceRaw extends ItBitBasePollingService {
     walletId = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get("walletId");
   }
 
-  public ItBitOrder[] getItBitOpenOrders() throws IOException {
+  public ItBitOrder[] getItBitOpenOrders(CurrencyPair currencyPair) throws IOException {
 
-    ItBitOrder[] orders = itBitAuthenticated.getOrders(signatureCreator, new Date().getTime(), exchange.getNonceFactory(), "XBTUSD", "1", "1000",
+    ItBitOrder[] orders = itBitAuthenticated.getOrders(signatureCreator, new Date().getTime(), exchange.getNonceFactory(), currencyPair.baseSymbol+currencyPair.counterSymbol, "1", "1000",
         "open", walletId);
 
     return orders;


### PR DESCRIPTION
Rather than hardcoding the XBTUSD currency, available currencies are fetched from the exchange and then open orders are requested for each of the valid CurrencyPairs.

Fixes #1018