### PR TITLE
Remove @Consumes from GET requests

### DIFF
--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAuthenticated.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/ItBitAuthenticated.java
@@ -36,13 +36,11 @@ public interface ItBitAuthenticated extends ItBit {
 
   @GET
   @Path("wallets/{walletId}")
-  @Consumes(MediaType.APPLICATION_JSON)
   ItBitAccountInfoReturn getWallet(@HeaderParam("Authorization") ParamsDigest signer, @HeaderParam("X-Auth-Timestamp") long timestamp,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<Long> valueFactory, @PathParam("walletId") String walletId) throws IOException;
 
   @GET
   @Path("wallets/{walletId}/orders")
-  @Consumes(MediaType.APPLICATION_JSON)
   ItBitOrder[] getOrders(@HeaderParam("Authorization") ParamsDigest signer, @HeaderParam("X-Auth-Timestamp") long timestamp,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<Long> valueFactory, @QueryParam("instrument") String instrument,
       @QueryParam("page") String page, @QueryParam("perPage") String perPage, @QueryParam("status") String status,
@@ -50,7 +48,6 @@ public interface ItBitAuthenticated extends ItBit {
 
   @GET
   @Path("wallets/{walletId}/orders/{orderId}")
-  @Consumes(MediaType.APPLICATION_JSON)
   ItBitOrder getOrder(@HeaderParam("Authorization") ParamsDigest signer, @HeaderParam("X-Auth-Timestamp") long timestamp,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<Long> valueFactory, @PathParam("walletId") String walletId,
       @PathParam("orderId") String orderId) throws IOException;
@@ -65,7 +62,6 @@ public interface ItBitAuthenticated extends ItBit {
   /** Returns empty body, return object is always null */
   @DELETE
   @Path("wallets/{walletId}/orders/{orderId}")
-  @Consumes(MediaType.APPLICATION_JSON)
   Object cancelOrder(@HeaderParam("Authorization") ParamsDigest signer, @HeaderParam("X-Auth-Timestamp") long timestamp,
       @HeaderParam("X-Auth-Nonce") SynchronizedValueFactory<Long> valueFactory, @PathParam("walletId") String walletId,
       @PathParam("orderId") String orderId) throws IOException;


### PR DESCRIPTION
Remove @Consumes from ItBit GET requests as they are not expected to have body content. Corrects warnings from rescu.