### PR TITLE
[ripple] trade history improvements and fixes

### DIFF
--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/RippleExchange.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/RippleExchange.java
@@ -25,7 +25,9 @@ public class RippleExchange extends BaseExchange implements Exchange {
 
   public static final String PARAMETER_TRUST_API_RIPPLE_COM = "trust.api.ripple.com";
 
-  public static final String PARAMETER_STORE_ORDER_DETAILS = "store.order.details";
+  public static final String PARAMETER_STORE_TRADE_TRANSACTION_DETAILS = "store.trade.transaction.details";
+
+  public static final String PARAMETER_VALIDATE_ORDER_REQUESTS = "validate.order.requests";
 
   public static final String PARAMETER_ROUNDING_SCALE = "rounding.scale";
 
@@ -59,7 +61,10 @@ public class RippleExchange extends BaseExchange implements Exchange {
     specification.setExchangeSpecificParametersItem(PARAMETER_TRUST_API_RIPPLE_COM, false);
 
     // Do not cache order detail queries by default to avoid running out of memory
-    specification.setExchangeSpecificParametersItem(PARAMETER_STORE_ORDER_DETAILS, false);
+    specification.setExchangeSpecificParametersItem(PARAMETER_STORE_TRADE_TRANSACTION_DETAILS, false);
+
+    // Wait for ledger consensus before confirming successful order entry or cancel
+    specification.setExchangeSpecificParametersItem(PARAMETER_VALIDATE_ORDER_REQUESTS, true);
 
     // Round to this decimal places on BigDecimal division
     specification.setExchangeSpecificParametersItem(PARAMETER_ROUNDING_SCALE, DEFAULT_ROUNDING_SCALE);
@@ -82,8 +87,12 @@ public class RippleExchange extends BaseExchange implements Exchange {
     return (Integer) specification.getExchangeSpecificParametersItem(RippleExchange.PARAMETER_ROUNDING_SCALE);
   }
 
-  public boolean isStoreOrderDetails() {
-    return (Boolean) getExchangeSpecification().getExchangeSpecificParametersItem(PARAMETER_STORE_ORDER_DETAILS);
+  public boolean validateOrderRequests() {
+    return (Boolean) getExchangeSpecification().getExchangeSpecificParametersItem(PARAMETER_VALIDATE_ORDER_REQUESTS);
+  }
+
+  public boolean isStoreTradeTransactionDetails() {
+    return (Boolean) getExchangeSpecification().getExchangeSpecificParametersItem(PARAMETER_STORE_TRADE_TRANSACTION_DETAILS);
   }
 
   public void clearOrderDetailsCache() {

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/RipplePublic.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/RipplePublic.java
@@ -15,7 +15,8 @@ import com.xeiam.xchange.ripple.dto.account.RippleAccountSettings;
 import com.xeiam.xchange.ripple.dto.marketdata.RippleOrderBook;
 import com.xeiam.xchange.ripple.dto.trade.RippleAccountOrders;
 import com.xeiam.xchange.ripple.dto.trade.RippleNotifications;
-import com.xeiam.xchange.ripple.dto.trade.RippleOrderDetails;
+import com.xeiam.xchange.ripple.dto.trade.RippleOrderTransaction;
+import com.xeiam.xchange.ripple.dto.trade.RipplePaymentTransaction;
 import com.xeiam.xchange.ripple.dto.trade.RippleTransactionFee;
 
 /**
@@ -57,11 +58,19 @@ public interface RipplePublic {
   public RippleAccountOrders openAccountOrders(@PathParam("address") final String address) throws IOException, RippleException;
 
   /**
-   * Returns the account information for this address.
+   * Returns detailed information about this order transaction.
    */
   @GET
   @Path("accounts/{address}/orders/{hash}")
-  public RippleOrderDetails orderDetails(@PathParam("address") final String address, @PathParam("hash") final String hash)
+  public RippleOrderTransaction orderTransaction(@PathParam("address") final String address, @PathParam("hash") final String hash)
+      throws IOException, RippleException;
+
+  /**
+   * Returns detailed information about this payment transaction.
+   */
+  @GET
+  @Path("accounts/{address}/payments/{hash}")
+  public RipplePaymentTransaction paymentTransaction(@PathParam("address") final String address, @PathParam("hash") final String hash)
       throws IOException, RippleException;
 
   /**

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/RippleAmount.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/RippleAmount.java
@@ -12,8 +12,10 @@ public final class RippleAmount {
 
   @JsonProperty("currency")
   private String currency;
+
   @JsonProperty("counterparty")
   private String counterparty;
+
   @JsonProperty("value")
   private BigDecimal value;
 
@@ -21,16 +23,23 @@ public final class RippleAmount {
     return currency;
   }
 
-  public void setCurrency(final String currency) {
-    this.currency = currency;
+  public void setCurrency(final String value) {
+    currency = value;
   }
 
   public String getCounterparty() {
     return counterparty;
   }
 
-  public void setCounterparty(final String counterparty) {
-    this.counterparty = counterparty;
+  public void setCounterparty(final String value) {
+    counterparty = value;
+  }
+
+  // issuer is the old term for counterparty
+  // still used in the payment json as of v1.8.1
+  @JsonProperty("issuer")
+  public void setIssuer(final String value) {
+    counterparty = value;
   }
 
   @JsonSerialize(using = ToStringSerializer.class)

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/IRippleTradeTransaction.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/IRippleTradeTransaction.java
@@ -1,0 +1,19 @@
+package com.xeiam.xchange.ripple.dto.trade;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import com.xeiam.xchange.ripple.dto.RippleAmount;
+
+public interface IRippleTradeTransaction {
+  public List<RippleAmount> getBalanceChanges();
+
+  public BigDecimal getFee();
+
+  public long getOrderId();
+
+  public String getHash();
+
+  public Date getTimestamp();
+}

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/RippleOrderTransaction.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/RippleOrderTransaction.java
@@ -8,7 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.xeiam.xchange.ripple.dto.RippleAmount;
 import com.xeiam.xchange.ripple.dto.RippleCommon;
 
-public class RippleOrderDetails extends RippleCommon {
+public class RippleOrderTransaction extends RippleCommon implements IRippleTradeTransaction {
 
   @JsonProperty("timestamp")
   public Date timestamp;
@@ -85,6 +85,15 @@ public class RippleOrderDetails extends RippleCommon {
 
   public void setOrderChanges(final List<RippleOrderResponseBody> value) {
     orderChanges = value;
+  }
+
+  @Override
+  public long getOrderId() {
+    if (orderChanges.size() == 1) {
+      return orderChanges.get(0).getSequence();
+    } else {
+      return 0; // cannot identify a single order
+    }
   }
 
   @Override

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/RipplePaymentTransaction.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/dto/trade/RipplePaymentTransaction.java
@@ -1,0 +1,404 @@
+package com.xeiam.xchange.ripple.dto.trade;
+
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.ripple.dto.RippleAmount;
+
+public class RipplePaymentTransaction implements IRippleTradeTransaction {
+
+  private Payment payment;
+
+  @JsonProperty("client_resource_id")
+  private String clientResourceId;
+
+  private String hash;
+
+  private String ledger;
+
+  private String state;
+
+  private boolean success;
+
+  public Payment getPayment() {
+    return payment;
+  }
+
+  public void setPayment(final Payment value) {
+    payment = value;
+  }
+
+  public String getClientResourceId() {
+    return clientResourceId;
+  }
+
+  public void setClientResourceId(final String value) {
+    clientResourceId = value;
+  }
+
+  public String getHash() {
+    return hash;
+  }
+
+  public void setHash(final String value) {
+    hash = value;
+  }
+
+  public String getLedger() {
+    return ledger;
+  }
+
+  public void setLedger(final String value) {
+    ledger = value;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public void setState(final String value) {
+    state = value;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public void setSuccess(final boolean value) {
+    success = value;
+  }
+
+  public static class OrderChange {
+    @JsonProperty("taker_pays")
+    private RippleAmount takerPays;
+
+    @JsonProperty("taker_gets")
+    private RippleAmount takerGets;
+
+    private long sequence;
+
+    private String status;
+
+    public RippleAmount getTakerPays() {
+      return takerPays;
+    }
+
+    public void setTakerPays(final RippleAmount value) {
+      takerPays = value;
+    }
+
+    public RippleAmount getTakerGets() {
+      return takerGets;
+    }
+
+    public void setTakerGets(final RippleAmount value) {
+      takerGets = value;
+    }
+
+    public long getSequence() {
+      return sequence;
+    }
+
+    public void setSequence(final long value) {
+      sequence = value;
+    }
+
+    public String getStatus() {
+      return status;
+    }
+
+    public void setStatus(final String value) {
+      status = value;
+    }
+  }
+
+  public static class Memo {
+    @JsonProperty("MemoType")
+    private String memoType;
+
+    @JsonProperty("MemoData")
+    private String memoData;
+
+    @JsonProperty("MemoFormat")
+    private String memoFormat;
+
+    @JsonProperty("parsed_memo_type")
+    private String parsedMemoType;
+
+    @JsonProperty("parsed_memo_format")
+    private String parsedMemoFormat;
+
+    public String getMemoType() {
+      return memoType;
+    }
+
+    public void setMemoType(final String value) {
+      memoType = value;
+    }
+
+    public String getMemoData() {
+      return memoData;
+    }
+
+    public void setMemoData(final String value) {
+      memoData = value;
+    }
+
+    public String getMemoFormat() {
+      return memoFormat;
+    }
+
+    public void setMemoFormat(final String value) {
+      memoFormat = value;
+    }
+
+    public String getParsedMemoType() {
+      return parsedMemoType;
+    }
+
+    public void setParsedMemoType(final String value) {
+      parsedMemoType = value;
+    }
+
+    public String getParsedMemoFormat() {
+      return parsedMemoFormat;
+    }
+
+    public void setParsedMemoFormat(final String value) {
+      parsedMemoFormat = value;
+    }
+  }
+
+  public static class Payment {
+    @JsonProperty("source_account")
+    private String sourceAccount;
+
+    @JsonProperty("source_tag")
+    private String sourceTag;
+
+    @JsonProperty("source_amount")
+    private RippleAmount sourceAmount;
+
+    @JsonProperty("source_slippage")
+    private String sourceSlippage;
+
+    @JsonProperty("destination_account")
+    private String destinationAccount;
+
+    @JsonProperty("destination_tag")
+    private String destinationTag;
+
+    @JsonProperty("destination_amount")
+    private RippleAmount destinationAmount;
+
+    @JsonProperty("invoice_id")
+    private String invoiceID;
+
+    private String paths;
+
+    @JsonProperty("no_direct_ripple")
+    private boolean noDirectRipple;
+
+    @JsonProperty("partial_payment")
+    private boolean partialPayment;
+
+    private String direction;
+
+    @JsonProperty("timestamp")
+    private Date timestamp;
+
+    private BigDecimal fee;
+
+    private String result;
+
+    @JsonProperty("balance_changes")
+    private List<RippleAmount> balanceChanges;
+
+    @JsonProperty("source_balance_changes")
+    private List<RippleAmount> sourceBalanceChanges;
+
+    @JsonProperty("destination_balance_changes")
+    private List<RippleAmount> destinationBalanceChanges;
+
+    @JsonProperty("order_changes")
+    private List<OrderChange> orderChanges;
+
+    public String getSourceAccount() {
+      return sourceAccount;
+    }
+
+    public void setSourceAccount(final String value) {
+      sourceAccount = value;
+    }
+
+    public String getSourceTag() {
+      return sourceTag;
+    }
+
+    public void setSourceTag(final String value) {
+      sourceTag = value;
+    }
+
+    public RippleAmount getSourceAmount() {
+      return sourceAmount;
+    }
+
+    public void setSourceAmount(final RippleAmount value) {
+      sourceAmount = value;
+    }
+
+    public String getSourceSlippage() {
+      return sourceSlippage;
+    }
+
+    public void setSourceSlippage(final String value) {
+      sourceSlippage = value;
+    }
+
+    public String getDestinationAccount() {
+      return destinationAccount;
+    }
+
+    public void setDestinationAccount(final String value) {
+      destinationAccount = value;
+    }
+
+    public String getDestinationTag() {
+      return destinationTag;
+    }
+
+    public void setDestinationTag(final String value) {
+      destinationTag = value;
+    }
+
+    public RippleAmount getDestinationAmount() {
+      return destinationAmount;
+    }
+
+    public void setDestinationAmount(final RippleAmount value) {
+      destinationAmount = value;
+    }
+
+    public String getInvoiceID() {
+      return invoiceID;
+    }
+
+    public void setInvoiceID(final String value) {
+      invoiceID = value;
+    }
+
+    public String getPaths() {
+      return paths;
+    }
+
+    public void setPaths(final String value) {
+      paths = value;
+    }
+
+    public boolean isNoDirectRipple() {
+      return noDirectRipple;
+    }
+
+    public void setNoDirectRipple(final boolean value) {
+      noDirectRipple = value;
+    }
+
+    public boolean isPartialPayment() {
+      return partialPayment;
+    }
+
+    public void setPartialPayment(final boolean value) {
+      partialPayment = value;
+    }
+
+    public String getDirection() {
+      return direction;
+    }
+
+    public void setDirection(final String value) {
+      direction = value;
+    }
+
+    public Date getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(final Date value) {
+      timestamp = value;
+    }
+
+    public BigDecimal getFee() {
+      return fee;
+    }
+
+    public void setFee(final BigDecimal value) {
+      fee = value;
+    }
+
+    public String getResult() {
+      return result;
+    }
+
+    public void setResult(final String value) {
+      result = value;
+    }
+
+    public List<RippleAmount> getBalanceChanges() {
+      return balanceChanges;
+    }
+
+    public void setBalanceChanges(final List<RippleAmount> value) {
+      balanceChanges = value;
+    }
+
+    public List<RippleAmount> getSourceBalanceChanges() {
+      return sourceBalanceChanges;
+    }
+
+    public void setSourceBalanceChanges(final List<RippleAmount> value) {
+      sourceBalanceChanges = value;
+    }
+
+    public List<RippleAmount> getDestinationBalanceChanges() {
+      return destinationBalanceChanges;
+    }
+
+    public void setDestinationBalanceChanges(final List<RippleAmount> value) {
+      destinationBalanceChanges = value;
+    }
+
+    public List<OrderChange> getOrderChanges() {
+      return orderChanges;
+    }
+
+    public void setOrderChanges(final List<OrderChange> value) {
+      orderChanges = value;
+    }
+  }
+
+  @Override
+  public List<RippleAmount> getBalanceChanges() {
+    return payment.getBalanceChanges();
+  }
+
+  @Override
+  public BigDecimal getFee() {
+    return payment.getFee();
+  }
+
+  @Override
+  public long getOrderId() {
+    if (payment.orderChanges.size() == 1) {
+      return payment.orderChanges.get(0).getSequence();
+    } else {
+      return 0; // cannot identify a single order
+    }
+  }
+
+  @Override
+  public Date getTimestamp() {
+    return getPayment().getTimestamp();
+  }
+}

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/service/polling/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/service/polling/RippleTradeService.java
@@ -12,8 +12,8 @@ import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.ripple.RippleAdapters;
 import com.xeiam.xchange.ripple.RippleExchange;
+import com.xeiam.xchange.ripple.dto.trade.IRippleTradeTransaction;
 import com.xeiam.xchange.ripple.dto.trade.RippleLimitOrder;
-import com.xeiam.xchange.ripple.dto.trade.RippleOrderDetails;
 import com.xeiam.xchange.ripple.service.polling.params.RippleTradeHistoryAccount;
 import com.xeiam.xchange.ripple.service.polling.params.RippleTradeHistoryCount;
 import com.xeiam.xchange.ripple.service.polling.params.RippleTradeHistoryHashLimit;
@@ -24,8 +24,6 @@ import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
 
 public class RippleTradeService extends RippleTradeServiceRaw implements PollingTradeService {
-
-  private static final boolean VALIDATE_ALL_REQUESTS = true;
 
   private final RippleExchange ripple;
 
@@ -61,7 +59,7 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
   public String placeLimitOrder(final LimitOrder order)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (order instanceof RippleLimitOrder) {
-      return placeOrder((RippleLimitOrder) order, VALIDATE_ALL_REQUESTS);
+      return placeOrder((RippleLimitOrder) order, ripple.validateOrderRequests());
     } else {
       throw new IllegalArgumentException("order must be of type: " + RippleLimitOrder.class.getName());
     }
@@ -70,7 +68,7 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
   @Override
   public boolean cancelOrder(final String orderId)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return cancelOrder(orderId, VALIDATE_ALL_REQUESTS);
+    return cancelOrder(orderId, ripple.validateOrderRequests());
   }
 
   /**
@@ -129,7 +127,7 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
       account = defaultTradeHistoryParams.getAccount();
     }
 
-    final List<RippleOrderDetails> trades = getTradesForAccount(params, account);
+    final List<IRippleTradeTransaction> trades = getTradesForAccount(params, account);
     return RippleAdapters.adaptTrades(trades, params, (RippleAccountService) exchange.getPollingAccountService(), ripple.getRoundingScale());
   }
 

--- a/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RippleNotificationTest.java
+++ b/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RippleNotificationTest.java
@@ -16,7 +16,7 @@ import com.xeiam.xchange.ripple.dto.trade.RippleNotifications.RippleNotification
 public class RippleNotificationTest {
 
   @Test
-  public void orderEntryResponseUnmarshalTest() throws IOException, ParseException {
+  public void notificationUnmarshalTest() throws IOException, ParseException {
     // Read in the JSON from the example resources
     final InputStream is = getClass().getResourceAsStream("/trade/example-notifications.json");
     final ObjectMapper mapper = new ObjectMapper();
@@ -24,23 +24,24 @@ public class RippleNotificationTest {
 
     // Verify that the example data was unmarshalled correctly
     assertThat(response.isSuccess()).isEqualTo(true);
-    assertThat(response.getNotifications()).hasSize(10);
+    assertThat(response.getNotifications()).hasSize(11);
 
-    final RippleNotification lastNotification = response.getNotifications().get(9);
-    assertThat(lastNotification.getAccount()).isEqualTo("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B");
-    assertThat(lastNotification.getType()).isEqualTo("order");
-    assertThat(lastNotification.getDirection()).isEqualTo("incoming");
-    assertThat(lastNotification.getState()).isEqualTo("validated");
-    assertThat(lastNotification.getResult()).isEqualTo("tesSUCCESS");
-    assertThat(lastNotification.getLedger()).isEqualTo(14024693);
-    assertThat(lastNotification.getHash()).isEqualTo("BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5");
-    assertThat(lastNotification.getTimestamp()).isEqualTo(RippleExchange.ToDate("2015-06-13T11:45:20.102Z"));
-    assertThat(lastNotification.getTransactionUrl()).isEqualTo(
+    final RippleNotification orderType = response.getNotifications().get(9);
+    assertThat(orderType.getAccount()).isEqualTo("rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B");
+    assertThat(orderType.getType()).isEqualTo("order");
+    assertThat(orderType.getDirection()).isEqualTo("incoming");
+    assertThat(orderType.getState()).isEqualTo("validated");
+    assertThat(orderType.getResult()).isEqualTo("tesSUCCESS");
+    assertThat(orderType.getLedger()).isEqualTo(14024693);
+    assertThat(orderType.getHash()).isEqualTo("BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5");
+    assertThat(orderType.getTimestamp()).isEqualTo(RippleExchange.ToDate("2015-06-13T11:45:20.102Z"));
+    assertThat(orderType.getTransactionUrl()).isEqualTo(
         "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/orders/BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5");
-    assertThat(lastNotification.getPreviousHash()).isEqualTo("F2DCD35FB1D2E9951B56BD773D67345C4955CB41D8A43DB3D2BF5AE9E2F831C6");
-    assertThat(lastNotification.getPreviousNotificationUrl()).isEqualTo(
+    assertThat(orderType.getPreviousHash()).isEqualTo("F2DCD35FB1D2E9951B56BD773D67345C4955CB41D8A43DB3D2BF5AE9E2F831C6");
+    assertThat(orderType.getPreviousNotificationUrl()).isEqualTo(
         "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/notifications/F2DCD35FB1D2E9951B56BD773D67345C4955CB41D8A43DB3D2BF5AE9E2F831C6");
-    assertThat(lastNotification.getNextHash()).isEqualTo("");
-    assertThat(lastNotification.getNextNotificationUrl()).isEqualTo("");
+    assertThat(orderType.getNextHash()).isEqualTo("GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107");
+    assertThat(orderType.getNextNotificationUrl()).isEqualTo(
+        "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/notifications/GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107");
   }
 }

--- a/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RippleOrderTest.java
+++ b/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RippleOrderTest.java
@@ -14,7 +14,7 @@ import com.xeiam.xchange.ripple.dto.RippleAmount;
 import com.xeiam.xchange.ripple.dto.trade.RippleAccountOrders;
 import com.xeiam.xchange.ripple.dto.trade.RippleAccountOrdersBody;
 import com.xeiam.xchange.ripple.dto.trade.RippleOrderCancelResponse;
-import com.xeiam.xchange.ripple.dto.trade.RippleOrderDetails;
+import com.xeiam.xchange.ripple.dto.trade.RippleOrderTransaction;
 import com.xeiam.xchange.ripple.dto.trade.RippleOrderEntryResponse;
 import com.xeiam.xchange.ripple.dto.trade.RippleOrderResponseBody;
 
@@ -107,11 +107,11 @@ public class RippleOrderTest {
   }
 
   @Test
-  public void orderDetailsUnmarshalTest() throws IOException, ParseException {
+  public void orderTransactionUnmarshalTest() throws IOException, ParseException {
     // Read in the JSON from the example resources
     final InputStream is = getClass().getResourceAsStream("/trade/example-order-details.json");
     final ObjectMapper mapper = new ObjectMapper();
-    final RippleOrderDetails response = mapper.readValue(is, RippleOrderDetails.class);
+    final RippleOrderTransaction response = mapper.readValue(is, RippleOrderTransaction.class);
 
     // Verify that the example data was unmarshalled correctly
     assertThat(response.isSuccess()).isEqualTo(true);

--- a/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RipplePaymentTest.java
+++ b/xchange-ripple/src/test/java/com/xeiam/xchange/ripple/dto/account/trade/RipplePaymentTest.java
@@ -1,0 +1,69 @@
+package com.xeiam.xchange.ripple.dto.account.trade;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.xeiam.xchange.ripple.RippleExchange;
+import com.xeiam.xchange.ripple.dto.RippleAmount;
+import com.xeiam.xchange.ripple.dto.trade.RipplePaymentTransaction;
+
+public class RipplePaymentTest {
+  
+  @Test
+  public void passthroughUnmarshalTest() throws IOException, ParseException {
+    // Read in the JSON from the example resources
+    final InputStream is = getClass().getResourceAsStream("/trade/example-payment-passthrough.json");
+    final ObjectMapper mapper = new ObjectMapper();
+    final RipplePaymentTransaction response = mapper.readValue(is, RipplePaymentTransaction.class);
+
+    final RipplePaymentTransaction.Payment payment = response.getPayment();
+
+    assertThat(payment.getSourceAccount()).isEqualTo("r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv");
+    assertThat(payment.getSourceTag()).isEqualTo("");
+    assertThat(payment.getSourceAmount().getCurrency()).isEqualTo("BTC");
+    assertThat(payment.getSourceAmount().getValue()).isEqualTo("0.010000000003347");
+    assertThat(payment.getSourceAmount().getCounterparty()).isEqualTo("r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv");
+    assertThat(payment.getSourceSlippage()).isEqualTo("0");
+
+    assertThat(payment.getDestinationAccount()).isEqualTo("r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv");
+    assertThat(payment.getDestinationTag()).isEqualTo("");
+    assertThat(payment.getDestinationAmount().getCurrency()).isEqualTo("CNY");
+    assertThat(payment.getDestinationAmount().getValue()).isEqualTo("17.2701672");
+    assertThat(payment.getDestinationAmount().getCounterparty()).isEqualTo("r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv");
+
+    assertThat(payment.getInvoiceID()).isEqualTo("");
+    assertThat(payment.isNoDirectRipple()).isEqualTo(false);
+    assertThat(payment.isPartialPayment()).isEqualTo(false);
+    assertThat(payment.getDirection()).isEqualTo("passthrough");
+    assertThat(payment.getTimestamp()).isEqualTo(RippleExchange.ToDate("2015-08-07T03:58:10.000Z"));
+    assertThat(payment.getFee()).isEqualTo("0.012");
+    assertThat(payment.getResult()).isEqualTo("tesSUCCESS");
+    
+    assertThat(payment.getBalanceChanges()).hasSize(2);
+    final RippleAmount balance1 = payment.getBalanceChanges().get(0);
+    assertThat(balance1.getCurrency()).isEqualTo("XRP");
+    assertThat(balance1.getValue()).isEqualTo("-349.559725");
+    assertThat(balance1.getCounterparty()).isEqualTo("");
+    
+    final RippleAmount balance2 = payment.getBalanceChanges().get(1);
+    assertThat(balance2.getCurrency()).isEqualTo("BTC");
+    assertThat(balance2.getValue()).isEqualTo("0.009941478580724");
+    assertThat(balance2.getCounterparty()).isEqualTo("rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q");
+
+    assertThat(payment.getSourceBalanceChanges()).hasSize(3);
+    assertThat(payment.getDestinationBalanceChanges()).hasSize(3);
+
+    assertThat(response.getClientResourceId()).isEqualTo("");
+    assertThat(response.getHash()).isEqualTo("GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107");
+    assertThat(response.getLedger()).isEqualTo("15103564");
+    assertThat(response.getState()).isEqualTo("validated");
+    assertThat(response.isSuccess()).isEqualTo(true);
+  }
+
+}

--- a/xchange-ripple/src/test/resources/trade/example-notifications.json
+++ b/xchange-ripple/src/test/resources/trade/example-notifications.json
@@ -147,6 +147,21 @@
          "transaction_url":"api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/orders/BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5",
          "previous_hash":"F2DCD35FB1D2E9951B56BD773D67345C4955CB41D8A43DB3D2BF5AE9E2F831C6",
          "previous_notification_url":"api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/notifications/F2DCD35FB1D2E9951B56BD773D67345C4955CB41D8A43DB3D2BF5AE9E2F831C6",
+         "next_hash": "GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107",
+         "next_notification_url": "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/notifications/GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107"
+      },
+      {
+         "account": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+         "type": "payment",
+         "direction": "passthrough",
+         "state": "validated",
+         "result": "tesSUCCESS",
+         "ledger": "15103564",
+         "hash": "GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107",
+         "timestamp": "2015-06-13T11:46:20.102Z",
+         "transaction_url": "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/payments/GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107",
+         "previous_hash": "BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5",
+         "previous_notification_url": "api.ripple.com/v1/accounts/rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B/notifications/BFFD04119882BF26B68E27090EE44C0074EAAFA92E0248C979511808193522D5",
          "next_hash":"",
          "next_notification_url":""
       }

--- a/xchange-ripple/src/test/resources/trade/example-payment-passthrough.json
+++ b/xchange-ripple/src/test/resources/trade/example-payment-passthrough.json
@@ -1,0 +1,94 @@
+{
+  "payment": {
+    "source_account": "r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv",
+    "source_tag": "",
+    "source_amount": {
+      "currency": "BTC",
+      "value": "0.010000000003347",
+      "issuer": "r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv"
+    },
+    "source_slippage": "0",
+    "destination_account": "r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv",
+    "destination_tag": "",
+    "destination_amount": {
+      "currency": "CNY",
+      "value": "17.2701672",
+      "issuer": "r9qdKsVyeSTc9P5mDP4s7qucQaLrhTfPcv"
+    },
+    "invoice_id": "",
+    "paths": "[[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"XRP\",\"type\":16,\"type_hex\":\"0000000000000010\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"BTC\",\"issuer\":\"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":1,\"type_hex\":\"0000000000000001\"}],[{\"account\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":1,\"type_hex\":\"0000000000000001\"},{\"currency\":\"USD\",\"issuer\":\"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"currency\":\"CNY\",\"issuer\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":48,\"type_hex\":\"0000000000000030\"},{\"account\":\"rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y\",\"type\":1,\"type_hex\":\"0000000000000001\"}]]",
+    "no_direct_ripple": false,
+    "partial_payment": false,
+    "direction": "passthrough",
+    "timestamp": "2015-08-07T03:58:10.000Z",
+    "fee": "0.012",
+    "result": "tesSUCCESS",
+    "balance_changes": [
+      {
+        "currency": "XRP",
+        "value": "-349.559725",
+        "issuer": ""
+      },
+      {
+        "currency": "BTC",
+        "value": "0.009941478580724",
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      }
+    ],
+    "source_balance_changes": [
+      {
+        "currency": "XRP",
+        "value": "-0.012",
+        "issuer": ""
+      },
+      {
+        "currency": "BTC",
+        "value": "-0.009961361537885",
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      {
+        "currency": "CNY",
+        "value": "17.2701672",
+        "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y"
+      }
+    ],
+    "destination_balance_changes": [
+      {
+        "currency": "XRP",
+        "value": "-0.012",
+        "issuer": ""
+      },
+      {
+        "currency": "BTC",
+        "value": "-0.009961361537885",
+        "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      {
+        "currency": "CNY",
+        "value": "17.2701672",
+        "issuer": "rKiCet8SdvWxPXnAgYarFUXMh1zCPz432Y"
+      }
+    ],
+    "order_changes": [
+      {
+        "taker_pays": {
+          "currency": "BTC",
+          "value": "-0.00994147858072444",
+          "issuer": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+        },
+        "taker_gets": {
+          "currency": "XRP",
+          "value": "-349.559725",
+          "issuer": ""
+        },
+        "sequence": 9338,
+        "status": "open"
+      }
+    ]
+  },
+  "client_resource_id": "",
+  "hash": "GHRE072948B95345396B2D9A364363GDE521HRT67QQRGGRTHYTRUP0RRB631107",
+  "ledger": "15103564",
+  "state": "validated",
+  "success": true
+}

--- a/xchange-ripple/src/test/resources/trade/example-trade-buyBTC-sellBTC.json
+++ b/xchange-ripple/src/test/resources/trade/example-trade-buyBTC-sellBTC.json
@@ -1,46 +1,63 @@
 {
-  "hash": "2222222222222222222222222222222222222222222222222222222222222222",
-  "ledger": 22222222,
-  "validated": true,
-  "timestamp": "2022-22-22T22:22:22.222Z",
-  "fee": "0.012",
-  "action": "order_create",
-  "direction": "outgoing",
-  "order": {
-    "account": "r222222222222222222222222222222222",
-    "taker_pays": {
-      "currency": "BTC",
-      "value": "0.501508355451214",
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+  "hash":"2222222222222222222222222222222222222222222222222222222222222222",
+  "ledger":22222222,
+  "validated":true,
+  "timestamp":"2022-22-22T22:22:22.222Z",
+  "fee":"0.012",
+  "action":"order_create",
+  "direction":"outgoing",
+  "order":{
+    "account":"r222222222222222222222222222222222",
+    "taker_pays":{
+      "currency":"BTC",
+      "value":"0.501508355451214",
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
     },
-    "taker_gets": {
-      "currency": "BTC",
-      "value": "0.5",
-      "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+    "taker_gets":{
+      "currency":"BTC",
+      "value":"0.5",
+      "counterparty":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
     },
-    "passive": false,
-    "immediate_or_cancel": false,
-    "fill_or_kill": false,
-    "type": "buy",
-    "sequence": 2222
+    "passive":false,
+    "immediate_or_cancel":false,
+    "fill_or_kill":false,
+    "type":"buy",
+    "sequence":0
   },
-  "balance_changes": [
+  "balance_changes":[
     {
-      "counterparty": "",
-      "currency": "XRP",
-      "value": "-0.012"
+      "counterparty":"",
+      "currency":"XRP",
+      "value":"-0.012"
     },
     {
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-      "currency": "BTC",
-      "value": "0.50150835545121407952"
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "currency":"BTC",
+      "value":"0.50150835545121407952"
     },
     {
-      "counterparty": "rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
-      "currency": "BTC",
-      "value": "-0.501"
+      "counterparty":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B",
+      "currency":"BTC",
+      "value":"-0.501"
     }
+    
   ],
-  "order_changes": [],
-  "success": true
+  "order_changes":[
+    {
+      "taker_pays":{
+        "currency":"BTC",
+        "value":"0.501508355451214",
+        "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      "taker_gets":{
+        "currency":"BTC",
+        "value":"0.5",
+        "counterparty":"rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B"
+      },
+      "sequence":2222,
+      "status":"closed"
+    }
+    
+  ],
+  "success":true
 }

--- a/xchange-ripple/src/test/resources/trade/example-trade-buyXRP-sellBTC.json
+++ b/xchange-ripple/src/test/resources/trade/example-trade-buyXRP-sellBTC.json
@@ -1,41 +1,56 @@
 {
-  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
-  "ledger": 0,
-  "validated": true,
-  "timestamp": "2000-00-00T00:00:00.000Z",
-  "fee": "0.012",
-  "action": "order_create",
-  "direction": "outgoing",
-  "order": {
-    "account": "r000000000000000000000000000000000",
-    "taker_pays": {
-      "currency": "XRP",
-      "value": "1",
-      "counterparty": ""
+  "hash":"0000000000000000000000000000000000000000000000000000000000000000",
+  "ledger":0,
+  "validated":true,
+  "timestamp":"2000-00-00T00:00:00.000Z",
+  "fee":"0.012",
+  "action":"order_create",
+  "direction":"outgoing",
+  "order":{
+    "account":"r000000000000000000000000000000000",
+    "taker_pays":{
+      "currency":"XRP",
+      "value":"1",
+      "counterparty":""
     },
-    "taker_gets": {
-      "currency": "BTC",
-      "value": "0.00002926",
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+    "taker_gets":{
+      "currency":"BTC",
+      "value":"0.00002926",
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
     },
-    "passive": false,
-    "immediate_or_cancel": false,
-    "fill_or_kill": false,
-    "type": "buy",
-    "sequence": 0
+    "passive":false,
+    "immediate_or_cancel":false,
+    "fill_or_kill":false,
+    "type":"buy",
+    "sequence":0
   },
-  "balance_changes": [
+  "balance_changes":[
     {
-      "counterparty": "",
-      "currency": "XRP",
-      "value": "0.988"
+      "counterparty":"",
+      "currency":"XRP",
+      "value":"0.988"
     },
     {
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-      "currency": "BTC",
-      "value": "-0.000029309526038"
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "currency":"BTC",
+      "value":"-0.000029309526038"
     }
   ],
-  "order_changes": [],
-  "success": true
+  "order_changes":[
+    {
+      "taker_pays":{
+        "currency":"XRP",
+        "value":"1",
+        "counterparty":""
+      },
+      "taker_gets":{
+        "currency":"BTC",
+        "value":"0.00002926",
+        "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      "sequence":1010,
+      "status":"closed"
+    }
+  ],
+  "success":true
 }

--- a/xchange-ripple/src/test/resources/trade/example-trade-sellXRP-buyBTC.json
+++ b/xchange-ripple/src/test/resources/trade/example-trade-sellXRP-buyBTC.json
@@ -1,41 +1,56 @@
 {
-  "hash": "1111111111111111111111111111111111111111111111111111111111111111",
-  "ledger": 11111111,
-  "validated": true,
-  "timestamp": "2011-11-11T11:11:11.111Z",
-  "fee": "0.012",
-  "action": "order_create",
-  "direction": "outgoing",
-  "order": {
-    "account": "r111111111111111111111111111111111",
-    "taker_pays": {
-      "currency": "BTC",
-      "value": "0.00002857",
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+  "hash":"1111111111111111111111111111111111111111111111111111111111111111",
+  "ledger":11111111,
+  "validated":true,
+  "timestamp":"2011-11-11T11:11:11.111Z",
+  "fee":"0.012",
+  "action":"order_create",
+  "direction":"outgoing",
+  "order":{
+    "account":"r111111111111111111111111111111111",
+    "taker_pays":{
+      "currency":"BTC",
+      "value":"0.00002857",
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
     },
-    "taker_gets": {
-      "currency": "XRP",
-      "value": "1",
-      "counterparty": ""
+    "taker_gets":{
+      "currency":"XRP",
+      "value":"1",
+      "counterparty":""
     },
-    "passive": false,
-    "immediate_or_cancel": false,
-    "fill_or_kill": false,
-    "type": "buy",
-    "sequence": 1111
+    "passive":false,
+    "immediate_or_cancel":false,
+    "fill_or_kill":false,
+    "type":"buy",
+    "sequence":1111
   },
-  "balance_changes": [
+  "balance_changes":[
     {
-      "counterparty": "",
-      "currency": "XRP",
-      "value": "-1.012"
+      "counterparty":"",
+      "currency":"XRP",
+      "value":"-1.012"
     },
     {
-      "counterparty": "rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
-      "currency": "BTC",
-      "value": "0.000028572057152"
+      "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q",
+      "currency":"BTC",
+      "value":"0.000028572057152"
     }
   ],
-  "order_changes": [],
-  "success": true
+  "order_changes":[
+    {
+      "taker_pays":{
+        "currency":"BTC",
+        "value":"0.00002857",
+        "counterparty":"rMwjYedjc7qqtKYVLiAccJSmCwih4LnE2q"
+      },
+      "taker_gets":{
+        "currency":"XRP",
+        "value":"1",
+        "counterparty":""
+      },
+      "sequence":1111,
+      "status":"closed"
+    }
+  ],
+  "success":true
 }


### PR DESCRIPTION
* added support for trades presented as passthrough payments
* fixed bug causing incorrect buy/sell direction to be reported if a DTO was adapted more than once
* order ID on trades now matches that on original order
* request wait for validation of successful order entry/cancel moved to an option