### PR TITLE
Remove PollingTradeService.getTradeHistory(Object...)

### DIFF
--- a/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeService.java
+++ b/xchange-anx/src/main/java/com/xeiam/xchange/anx/v2/service/polling/ANXTradeService.java
@@ -79,25 +79,6 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
     return cancelANXOrder(orderId, "BTC", "EUR").getResult().equals("success");
   }
 
-  /**
-   * @param args Accept zero or 2 parameters, both are unix time: Long from, Long to
-   */
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    Long from = null;
-    Long to = null;
-
-    if (args.length > 0) {
-      from = (Long) args[0];
-    }
-    if (args.length > 1) {
-      to = (Long) args[1];
-    }
-
-    return getTradeHistory(from, to);
-  }
-
   private UserTrades getTradeHistory(Long from, Long to) throws IOException {
     ANXTradeResultWrapper rawTrades = getExecutedANXTrades(from, to);
     String error = rawTrades.getError();

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
@@ -66,33 +66,6 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Pol
     return cancelBitfinexOrder(orderId);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    String symbol = "btcusd";
-    long timestamp = 0;
-    int limit = 50;
-
-    if (arguments.length >= 1) {
-      if (arguments[0] instanceof CurrencyPair) {
-        final CurrencyPair pair = (CurrencyPair) arguments[0];
-        symbol = pair.baseSymbol + pair.counterSymbol;
-      } else {
-        symbol = (String) arguments[0];
-      }
-    }
-    if (arguments.length >= 2) {
-      timestamp = (Long) arguments[1];
-    }
-    if (arguments.length >= 3) {
-      limit = (Integer) arguments[2];
-    }
-
-    final BitfinexTradeResponse[] trades = getBitfinexTradeHistory(symbol, timestamp, limit);
-
-    return BitfinexAdapters.adaptTradeHistory(trades, symbol);
-  }
-
   /**
    * @param params Implementation of {@link TradeHistoryParamCurrencyPair} is mandatory. Can optionally implement {@link TradeHistoryParamPaging} and
    *        {@link TradeHistoryParamsTimeSpan#getStartTime()}. All other TradeHistoryParams types will be ignored.

--- a/xchange-bitmarket/src/main/java/com/xeiam/xchange/bitmarket/service/polling/BitMarketTradeService.java
+++ b/xchange-bitmarket/src/main/java/com/xeiam/xchange/bitmarket/service/polling/BitMarketTradeService.java
@@ -9,7 +9,6 @@ import com.xeiam.xchange.bitmarket.dto.trade.BitMarketHistoryTradesResponse;
 import com.xeiam.xchange.bitmarket.dto.trade.BitMarketOrdersResponse;
 import com.xeiam.xchange.bitmarket.dto.trade.BitMarketTradeResponse;
 import com.xeiam.xchange.bitmarket.service.polling.params.BitMarketHistoryParams;
-import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
@@ -61,22 +60,6 @@ public class BitMarketTradeService extends BitMarketTradeServiceRaw implements P
 
     cancelBitMarketOrder(id);
     return true;
-  }
-
-  @Override
-  public UserTrades getTradeHistory(Object... objects)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
-    BitMarketHistoryParams params = new BitMarketHistoryParams();
-
-    try {
-      params.setCurrencyPair((CurrencyPair) objects[0]);
-      params.setCount((Integer) objects[1]);
-      params.setOffset((Long) objects[2]);
-    } catch (Exception e) {
-    } //ignore, wrong or missed params just will be default
-
-    return getTradeHistory(params);
   }
 
   @Override

--- a/xchange-bitso/src/main/java/com/xeiam/xchange/bitso/service/polling/BitsoTradeService.java
+++ b/xchange-bitso/src/main/java/com/xeiam/xchange/bitso/service/polling/BitsoTradeService.java
@@ -84,25 +84,16 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements PollingTr
     return cancelBitsoOrder(orderId);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, BitsoException {
-
-    Long numberOfTransactions = 1000L;
-    if (args.length > 0) {
-      Object arg0 = args[0];
-      if (!(arg0 instanceof Number)) {
-        throw new ExchangeException("Argument must be a Number!");
-      } else {
-        numberOfTransactions = ((Number) args[0]).longValue();
-      }
-    }
-
-    return BitsoAdapters.adaptTradeHistory(getBitsoUserTransactions(numberOfTransactions));
-  }
-
   /**
    * Required parameter types: {@link com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamPaging#getPageLength()}
+   * <p/>
+   * Warning: using a limit here can be misleading. The underlying call
+   * retrieves trades, withdrawals, and deposits. So the example here will
+   * limit the result to 17 of those types and from those 17 only trades are
+   * returned. It is recommended to use the raw service demonstrated below
+   * if you want to use this feature.
    */
+
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampTradeService.java
@@ -86,22 +86,6 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Pol
     return cancelBitstampOrder(Integer.parseInt(orderId));
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, BitstampException {
-
-    Long numberOfTransactions = 1000L;
-    if (args.length > 0) {
-      Object arg0 = args[0];
-      if (!(arg0 instanceof Number)) {
-        throw new ExchangeException("Argument must be a Number!");
-      } else {
-        numberOfTransactions = ((Number) args[0]).longValue();
-      }
-    }
-
-    return BitstampAdapters.adaptTradeHistory(getBitstampUserTransactions(numberOfTransactions));
-  }
-
   /**
    * Required parameter types: {@link TradeHistoryParamPaging#getPageLength()}
    */

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexTradeService.java
@@ -55,11 +55,6 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-    return getTradeHistory((TradeHistoryParams) null);
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     return new UserTrades(BittrexAdapters.adaptUserTrades(getBittrexTradeHistory()), TradeSortType.SortByTimestamp);
   }

--- a/xchange-bleutrade/src/main/java/com/xeiam/xchange/bleutrade/service/polling/BleutradeTradeService.java
+++ b/xchange-bleutrade/src/main/java/com/xeiam/xchange/bleutrade/service/polling/BleutradeTradeService.java
@@ -54,12 +54,6 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements P
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
     throw new NotAvailableFromExchangeException();

--- a/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/com/xeiam/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -125,29 +125,6 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
     return ret;
   }
 
-  /**
-   * Gets trade history for user's account.
-   *
-   * @param args 2 optional arguments:
-   *        <ol>
-   *        <li>limit: limit the number of transactions, default value is 10 if null.</li>
-   *        <li>offset: start index used for pagination, default value is 0 if null.</li>
-   *        <li>since: to fetch the transactions from this point, which can either be an order id or a unix timestamp, default value is 0.</li>
-   *        <li>sincetype: specify the type of 'since' parameter, can either be 'id' or 'time'. default value is 'time'.</li>
-   *        </ol>
-   */
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    final String type = BTCChinaTransactionsRequest.TYPE_ALL;
-    final Integer limit = args.length > 0 ? ((Number) args[0]).intValue() : null;
-    final Integer offset = args.length > 1 ? ((Number) args[1]).intValue() : null;
-    final Integer since = args.length > 2 ? ((Number) args[2]).intValue() : null;
-    final String sincetype = args.length > 3 ? ((String) args[3]) : null;
-
-    return getUserTrades(type, limit, offset, since, sincetype);
-  }
-
   private UserTrades getUserTrades(String type, Integer limit, Integer offset, Integer since, String sincetype) throws IOException {
     log.debug("type: {}, limit: {}, offset: {}, since: {}, sincetype: {}", type, limit, offset, since, sincetype);
 

--- a/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeService.java
+++ b/xchange-btce/src/main/java/com/xeiam/xchange/btce/v3/service/polling/BTCETradeService.java
@@ -85,36 +85,6 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
   }
 
   /**
-   * @param arguments Vararg list of optional (nullable) arguments: (Long) arguments[0] Number of transactions to return (String) arguments[1]
-   *        TradableIdentifier (String) arguments[2] TransactionCurrency (Long) arguments[3] Starting ID
-   * @return Trades object
-   * @throws IOException
-   */
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    Long numberOfTransactions = Long.MAX_VALUE;
-    String tradableIdentifier = "";
-    String transactionCurrency = "";
-    Long id = null;
-    try {
-      numberOfTransactions = (Long) arguments[0];
-      tradableIdentifier = (String) arguments[1];
-      transactionCurrency = (String) arguments[2];
-      id = (Long) arguments[3];
-    } catch (ArrayIndexOutOfBoundsException e) {
-      // ignore, can happen if no arg given.
-    }
-    String pair = null;
-    if (!tradableIdentifier.equals("") && !transactionCurrency.equals("")) {
-      pair = String.format("%s_%s", tradableIdentifier, transactionCurrency).toLowerCase();
-    }
-    Map<Long, BTCETradeHistoryResult> resultMap = getBTCETradeHistory(null, numberOfTransactions, id, id, BTCEAuthenticated.SortOrder.DESC, null,
-        null, pair);
-    return BTCEAdapters.adaptTradeHistory(resultMap);
-  }
-
-  /**
    * Supported parameters: {@link TradeHistoryParamPaging} {@link TradeHistoryParamsIdSpan} {@link TradeHistoryParamsTimeSpan}
    * {@link TradeHistoryParamCurrencyPair} You can also override sorting order (default is descending) by using {@link BTCETradeHistoryParams}
    */

--- a/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/service/polling/BTCTradeTradeService.java
+++ b/xchange-btctrade/src/main/java/com/xeiam/xchange/btctrade/service/polling/BTCTradeTradeService.java
@@ -63,13 +63,6 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
     return BTCTradeAdapters.adaptResult(result);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    long since = arguments.length > 0 ? toLong(arguments[0]) : 0L;
-    return getTradeHistory(new DefaultTradeHistoryParamsTimeSpan(DateUtils.fromUnixTime(since)));
-  }
-
   /**
    * Optional parameters: start time (default 0 = all) of {@link TradeHistoryParamsTimeSpan}
    * <p/>

--- a/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
+++ b/xchange-bter/src/main/java/com/xeiam/xchange/bter/service/polling/BTERPollingTradeService.java
@@ -68,25 +68,6 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
     return super.cancelOrder(orderId);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    if (args.length == 0) {
-
-      throw new IOException("You must supply a CurrencyPair!");
-    } else {
-      if (args[0] instanceof CurrencyPair) {
-        TradeHistoryParamCurrencyPair params = createTradeHistoryParams();
-        params.setCurrencyPair((CurrencyPair) args[0]);
-        return getTradeHistory(params);
-      } else {
-
-        throw new IOException("You must supply a CurrencyPair!");
-      }
-    }
-
-  }
-
   /**
    * Required parameter: {@link TradeHistoryParamCurrencyPair}
    */

--- a/xchange-campbx/src/main/java/com/xeiam/xchange/campbx/service/polling/CampBXTradeService.java
+++ b/xchange-campbx/src/main/java/com/xeiam/xchange/campbx/service/polling/CampBXTradeService.java
@@ -6,9 +6,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.campbx.CampBX;
 import com.xeiam.xchange.campbx.dto.CampBXOrder;
@@ -21,9 +18,11 @@ import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.exceptions.ExchangeException;
-import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
+import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Matija Mazi
@@ -130,21 +129,15 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements Polling
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) {
-
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
 }

--- a/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/service/polling/CexIOTradeService.java
+++ b/xchange-cexio/src/main/java/com/xeiam/xchange/cexio/service/polling/CexIOTradeService.java
@@ -60,12 +60,6 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements PollingTr
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
     throw new NotAvailableFromExchangeException();
@@ -73,8 +67,7 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements PollingTr
 
   @Override
   public com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
-
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
 }

--- a/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/service/polling/CleverCoinTradeService.java
+++ b/xchange-clevercoin/src/main/java/com/xeiam/xchange/clevercoin/service/polling/CleverCoinTradeService.java
@@ -79,24 +79,6 @@ public class CleverCoinTradeService extends CleverCoinTradeServiceRaw implements
     return cancelCleverCoinOrder(Integer.parseInt(orderId)).getResult().equals("success");
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, CleverCoinException {
-
-    int numberOfTransactions = 100;
-    if (args.length > 0) {
-      Object arg0 = args[0];
-      if (!(arg0 instanceof Number)) {
-        throw new ExchangeException("Argument must be a Number!");
-      } else {
-        numberOfTransactions = ((Number) args[0]).intValue();
-      }
-    }
-
-    TradeHistoryParamPaging params = createTradeHistoryParams();
-    params.setPageLength(numberOfTransactions);
-    return getTradeHistory(params);
-  }
-
   /**
    * Required parameter types: {@link TradeHistoryParamPaging#getPageLength()}
    */

--- a/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseTradeService.java
+++ b/xchange-coinbase/src/main/java/com/xeiam/xchange/coinbase/service/polling/CoinbaseTradeService.java
@@ -63,32 +63,7 @@ public final class CoinbaseTradeService extends CoinbaseTradeServiceRaw implemen
    * Authenticated resource which returns the user’s Bitcoin purchases and sells. Sorted in descending order by creation date.
    *
    * @see <a href="https://coinbase.com/api/doc/1.0/transfers/index.html">coinbase.com/api/doc/1.0/transfers/index.html</a>
-   * @param arguments Optional Integer arguments page (arg[0]) and limit (arg[1]). If no arguments are given then page 1 will be returned and the
-   *        results are limited to 25 per page by coinbase by default.
    */
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws ExchangeException, IOException {
-
-    Integer page = null;
-    Integer limit = null;
-    if (arguments != null && arguments.length > 0) {
-      if (!(arguments[0] instanceof Integer)) {
-        throw new ExchangeException("args[0] must be of type Integer.");
-      }
-      page = (Integer) arguments[0];
-
-      if (arguments.length > 1) {
-        if (!(arguments[1] instanceof Integer)) {
-          throw new ExchangeException("args[1] must be of type Integer.");
-        }
-        limit = (Integer) arguments[1];
-      }
-    }
-
-    final CoinbaseTransfers transfers = super.getCoinbaseTransfers(page, limit);
-    return CoinbaseAdapters.adaptTrades(transfers);
-  }
-
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 

--- a/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExTradeService.java
+++ b/xchange-coinbaseex/src/main/java/com/xeiam/xchange/coinbaseex/service/polling/CoinbaseExTradeService.java
@@ -54,12 +54,6 @@ public class CoinbaseExTradeService extends CoinbaseExTradeServiceRaw implements
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     throw new NotYetImplementedForExchangeException();
   }

--- a/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/service/polling/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/com/xeiam/xchange/coinmate/service/polling/CoinmateTradeService.java
@@ -105,12 +105,6 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getTradeHistory(createTradeHistoryParams());
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     DefaultTradeHistoryParamPagingSorted myParams = (DefaultTradeHistoryParamPagingSorted) params;
     return CoinmateAdapters.adaptTradeHistory(

--- a/xchange-coinmate/src/test/java/com/xeiam/xchange/coinmate/service/polling/TradeServiceIntegration.java
+++ b/xchange-coinmate/src/test/java/com/xeiam/xchange/coinmate/service/polling/TradeServiceIntegration.java
@@ -32,7 +32,7 @@ public class TradeServiceIntegration {
     assertNotNull(exchange);
     PollingTradeService service = exchange.getPollingTradeService();
     assertNotNull(service);
-    UserTrades trades = service.getTradeHistory();
+    UserTrades trades = service.getTradeHistory(service.createTradeHistoryParams());
     assertNotNull(trades);
     System.out.println("Got " + trades.getUserTrades().size() + " trades.");
     for (Trade trade : trades.getTrades()) {

--- a/xchange-coinsetter/src/main/java/com/xeiam/xchange/coinsetter/service/polling/CoinsetterTradeService.java
+++ b/xchange-coinsetter/src/main/java/com/xeiam/xchange/coinsetter/service/polling/CoinsetterTradeService.java
@@ -100,15 +100,6 @@ public class CoinsetterTradeService extends CoinsetterOrderServiceRaw implements
     return "SUCCESS".equals(response.getRequestStatus());
   }
 
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 

--- a/xchange-cointrader/src/main/java/com/xeiam/xchange/cointrader/service/polling/CointraderTradeService.java
+++ b/xchange-cointrader/src/main/java/com/xeiam/xchange/cointrader/service/polling/CointraderTradeService.java
@@ -78,11 +78,6 @@ public class CointraderTradeService extends CointraderTradeServiceRaw implements
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, CointraderException {
-    return CointraderAdapters.adaptTradeHistory(getCointraderUserTransactions((CurrencyPair) args[0], 0, 1000, 0L));
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     Integer offset = null;
     Integer limit = null;

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/PollingTradeService.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/PollingTradeService.java
@@ -83,22 +83,6 @@ public interface PollingTradeService extends BasePollingService {
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
-   * gets trade history for user's account
-   *
-   * @param arguments
-   * @return
-   * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
-   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the requested function or data
-   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been
-   *         implemented
-   * @throws IOException - Indication that a networking error occurred while fetching JSON data
-   * @deprecated in favour of {@link #getTradeHistory(TradeHistoryParams)}
-   */
-  @Deprecated
-  public UserTrades getTradeHistory(Object... arguments)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
-
-  /**
    * Fetch the history of user trades.
    * <p/>
    * If you are calling this method for single exchange, known at the development time, you may pass an object of specific *TradeHistoryParam class
@@ -124,7 +108,6 @@ public interface PollingTradeService extends BasePollingService {
    * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
-   * @see #getTradeHistory(Object...)
    * @see #createTradeHistoryParams()
    * @see com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamsAll
    */

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/DefaultTradeHistoryParamCurrencyPair.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/DefaultTradeHistoryParamCurrencyPair.java
@@ -6,6 +6,13 @@ public class DefaultTradeHistoryParamCurrencyPair implements TradeHistoryParamCu
 
   private CurrencyPair pair;
 
+  public DefaultTradeHistoryParamCurrencyPair() {
+  }
+
+  public DefaultTradeHistoryParamCurrencyPair(CurrencyPair pair) {
+    this.pair = pair;
+  }
+
   @Override
   public void setCurrencyPair(CurrencyPair pair) {
 

--- a/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/TradeHistoryParamTransactionId.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/service/polling/trade/params/TradeHistoryParamTransactionId.java
@@ -1,0 +1,7 @@
+package com.xeiam.xchange.service.polling.trade.params;
+
+public interface TradeHistoryParamTransactionId extends TradeHistoryParams {
+  void setTransactionId(String txId);
+
+  String getTransactionId();
+}

--- a/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/service/polling/CryptsyTradeService.java
+++ b/xchange-cryptsy/src/main/java/com/xeiam/xchange/cryptsy/service/polling/CryptsyTradeService.java
@@ -1,7 +1,6 @@
 package com.xeiam.xchange.cryptsy.service.polling;
 
 import java.io.IOException;
-import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.cryptsy.CryptsyAdapters;
@@ -55,8 +54,7 @@ public class CryptsyTradeService extends CryptsyTradeServiceRaw implements Polli
   public String placeLimitOrder(LimitOrder limitOrder) throws IOException, ExchangeException {
 
     CryptsyPlaceOrderReturn result = super.placeCryptsyLimitOrder(CryptsyCurrencyUtils.convertToMarketId(limitOrder.getCurrencyPair()),
-        limitOrder.getType() == OrderType.ASK ? CryptsyOrderType.Sell : CryptsyOrderType.Buy, limitOrder.getTradableAmount(),
-        limitOrder.getLimitPrice());
+        limitOrder.getType() == OrderType.ASK ? CryptsyOrderType.Sell : CryptsyOrderType.Buy, limitOrder.getTradableAmount(), limitOrder.getLimitPrice());
 
     return Integer.toString(result.getReturnValue());
   }
@@ -69,30 +67,8 @@ public class CryptsyTradeService extends CryptsyTradeServiceRaw implements Polli
   }
 
   /**
-   * @param arguments Vararg list of optional (nullable) arguments: (Long) arguments[0] Number of transactions to return (String) arguments[1]
-   *        TradableIdentifier (String) arguments[2] TransactionCurrency (Long) arguments[3] Starting ID
-   * @return Trades object
-   * @throws IOException
-   */
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException, ExchangeException {
-
-    Date startDate = new Date(0); // default value
-    Date endDate = new Date(); // default value
-    if (arguments.length == 2) {
-      startDate = (Date) arguments[0];
-      endDate = (Date) arguments[1];
-    }
-
-    CryptsyTradeHistoryReturn tradeHistoryReturnData = super.getCryptsyTradeHistory(startDate, endDate);
-
-    return CryptsyAdapters.adaptTradeHistory(tradeHistoryReturnData);
-  }
-
-  /**
    * @param params Can optionally implement {@link TradeHistoryParamsTimeSpan}. All other TradeHistoryParams types will be ignored.
    */
-
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 

--- a/xchange-empoex/src/main/java/com/xeiam/xchange/empoex/service/polling/EmpoExTradeService.java
+++ b/xchange-empoex/src/main/java/com/xeiam/xchange/empoex/service/polling/EmpoExTradeService.java
@@ -55,12 +55,6 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements Polling
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
     throw new NotAvailableFromExchangeException();
@@ -69,7 +63,7 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements Polling
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
 
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/anx/v2/trade/TradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/anx/v2/trade/TradesDemo.java
@@ -20,7 +20,7 @@ public class TradesDemo {
     // Interested in the private trading functionality (authentication)
     PollingTradeService tradeService = anx.getPollingTradeService();
 
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     for (Trade trade : trades.getTrades()) {
       System.out.println(trade);
     }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitso/trade/BitsoUserTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitso/trade/BitsoUserTradeHistoryDemo.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.bitso.service.polling.BitsoTradeServiceRaw;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.examples.bitso.BitsoDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 
 /**
  * <p>
@@ -31,7 +32,7 @@ public class BitsoUserTradeHistoryDemo {
 
   private static void generic(PollingTradeService tradeService) throws IOException {
 
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println(trades);
 
     // Warning: using a limit here can be misleading. The underlying call
@@ -39,7 +40,7 @@ public class BitsoUserTradeHistoryDemo {
     // limit the result to 17 of those types and from those 17 only trades are
     // returned. It is recommended to use the raw service demonstrated below
     // if you want to use this feature.
-    Trades tradesLimitedTo17 = tradeService.getTradeHistory(17L);
+    Trades tradesLimitedTo17 = tradeService.getTradeHistory(new DefaultTradeHistoryParamPaging(17));
     System.out.println(tradesLimitedTo17);
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/trade/BitstampUserTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/trade/BitstampUserTradeHistoryDemo.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.bitstamp.service.polling.BitstampTradeServiceRaw;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.examples.bitstamp.BitstampDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 
 /**
  * <p>
@@ -31,7 +32,7 @@ public class BitstampUserTradeHistoryDemo {
 
   private static void generic(PollingTradeService tradeService) throws IOException {
 
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println(trades);
 
     // Warning: using a limit here can be misleading. The underlying call
@@ -39,7 +40,7 @@ public class BitstampUserTradeHistoryDemo {
     // limit the result to 17 of those types and from those 17 only trades are
     // returned. It is recommended to use the raw service demonstrated below
     // if you want to use this feature.
-    Trades tradesLimitedTo17 = tradeService.getTradeHistory(17L);
+    Trades tradesLimitedTo17 = tradeService.getTradeHistory(new DefaultTradeHistoryParamPaging(17));
     System.out.println(tradesLimitedTo17);
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaGetTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btcchina/trade/BTCChinaGetTradeHistoryDemo.java
@@ -15,7 +15,7 @@ import com.xeiam.xchange.examples.btcchina.BTCChinaExamplesUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 
 /**
- * Demo for {@link BTCChinaTradeService#getTradeHistory(Object...)}.
+ * Demo for {@link BTCChinaTradeService#getTradeHistory(com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams)}.
  */
 public class BTCChinaGetTradeHistoryDemo {
 
@@ -31,7 +31,9 @@ public class BTCChinaGetTradeHistoryDemo {
 
   private static void generic() throws IOException {
 
-    Trades trades = tradeService.getTradeHistory(10);
+    BTCChinaTradeService.BTCChinaTradeHistoryParams params = new BTCChinaTradeService.BTCChinaTradeHistoryParams();
+    params.setPageLength(10);
+    Trades trades = tradeService.getTradeHistory(params);
     System.out.println("Trade count: " + trades.getTrades().size());
     for (Trade trade : trades.getTrades()) {
       System.out.println(trade);

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/btctrade/trade/TradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/btctrade/trade/TradeHistoryDemo.java
@@ -36,7 +36,7 @@ public class TradeHistoryDemo {
     OpenOrders openOrders = tradeService.getOpenOrders();
     System.out.println("Open orders: " + openOrders);
 
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println("Trades: " + trades);
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bter/trade/BTERTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bter/trade/BTERTradeDemo.java
@@ -18,6 +18,7 @@ import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.examples.bter.BTERDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamCurrencyPair;
 
 public class BTERTradeDemo {
 
@@ -56,7 +57,7 @@ public class BTERTradeDemo {
 
     Thread.sleep(2000);
 
-    Trades tradeHistory = tradeService.getTradeHistory(CurrencyPair.LTC_BTC);
+    Trades tradeHistory = tradeService.getTradeHistory(new DefaultTradeHistoryParamCurrencyPair(CurrencyPair.LTC_BTC));
     System.out.println(tradeHistory);
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/clevercoin/trade/CleverCoinUserTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/clevercoin/trade/CleverCoinUserTradeHistoryDemo.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.clevercoin.service.polling.CleverCoinTradeServiceRaw;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.examples.clevercoin.CleverCoinDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 
 /**
  * <p>
@@ -31,7 +32,7 @@ public class CleverCoinUserTradeHistoryDemo {
 
   private static void generic(PollingTradeService tradeService) throws IOException {
 
-    Trades trades = tradeService.getTradeHistory(150);
+    Trades trades = tradeService.getTradeHistory(new DefaultTradeHistoryParamPaging(150));
     System.out.println(trades);
 
     // Warning: using a limit here can be misleading. The underlying call

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/coinbase/trade/CoinbaseTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/coinbase/trade/CoinbaseTradeDemo.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.coinbase.service.polling.CoinbaseTradeService;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.examples.coinbase.CoinbaseDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
+import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 
 /**
  * @author jamespedwards42
@@ -31,7 +32,7 @@ public class CoinbaseTradeDemo {
 
     int page = 1; // optional
     int limit = 3; // optional
-    Trades trades = tradeService.getTradeHistory(page, limit);
+    Trades trades = tradeService.getTradeHistory(new DefaultTradeHistoryParamPaging(page, limit));
     System.out.println(trades);
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/cryptsy/CryptsyDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/cryptsy/CryptsyDemo.java
@@ -90,7 +90,7 @@ public class CryptsyDemo {
     System.out.println("\nOpenOrders:\n" + tradeService.getOpenOrders());
     Thread.sleep(500);
 
-    System.out.println("\nTradeHistory:\n" + tradeService.getTradeHistory());
+    System.out.println("\nTradeHistory:\n" + tradeService.getTradeHistory(tradeService.createTradeHistoryParams()));
     Thread.sleep(500);
 
   }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/independentreserve/trade/IndependentReserveTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/independentreserve/trade/IndependentReserveTradeDemo.java
@@ -40,7 +40,7 @@ public class IndependentReserveTradeDemo {
 
     printOpenOrders(tradeService);
 
-    UserTrades tradeHistory = tradeService.getTradeHistory();
+    UserTrades tradeHistory = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println("Trade history: " + tradeHistory.toString());
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/itbit/trade/ItBitTradesDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/itbit/trade/ItBitTradesDemo.java
@@ -82,7 +82,7 @@ public class ItBitTradesDemo {
     System.out.println("Cancelling " + placeLimitOrder1);
     trades.cancelOrder(placeLimitOrder1);
 
-    Trades tradeHistory = trades.getTradeHistory();
+    Trades tradeHistory = trades.getTradeHistory(trades.createTradeHistoryParams());
     System.out.println("Trade history: " + tradeHistory);
   }
 }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/kraken/trade/KrakenTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/kraken/trade/KrakenTradeHistoryDemo.java
@@ -26,7 +26,7 @@ public class KrakenTradeHistoryDemo {
     PollingTradeService tradeService = krakenExchange.getPollingTradeService();
 
     // Get the trade history
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println(trades.toString());
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/lakebtc/trade/LakeBTCTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/lakebtc/trade/LakeBTCTradeHistoryDemo.java
@@ -9,9 +9,6 @@ import com.xeiam.xchange.lakebtc.dto.trade.LakeBTCTradeResponse;
 import com.xeiam.xchange.lakebtc.service.polling.LakeBTCTradeServiceRaw;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 
-/**
- * Created by Cristi on 12/22/2014.
- */
 public class LakeBTCTradeHistoryDemo {
 
   public static void main(String[] args) throws IOException {
@@ -25,10 +22,7 @@ public class LakeBTCTradeHistoryDemo {
     PollingTradeService tradeService = lakebtcExchange.getPollingTradeService();
 
     // Get the trade history
-    Trades trades = tradeService.getTradeHistory();
-    System.out.println(trades);
-
-    trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println(trades);
 
   }

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.examples.poloniex.trade;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
@@ -12,6 +13,7 @@ import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.examples.poloniex.PoloniexExamplesUtils;
 import com.xeiam.xchange.poloniex.PoloniexAdapters;
+import com.xeiam.xchange.poloniex.service.polling.PoloniexTradeService;
 import com.xeiam.xchange.poloniex.service.polling.PoloniexTradeServiceRaw;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
 import com.xeiam.xchange.utils.CertHelper;
@@ -46,11 +48,17 @@ public class PoloniexTradeDemo {
 
     System.out.println("----------GENERIC----------");
 
-    System.out.println(tradeService.getTradeHistory(currencyPair));
-    long startTime = (new Date().getTime() / 1000) - 8 * 60 * 60;
-    System.out.println(tradeService.getTradeHistory(currencyPair, startTime));
-    long endTime = startTime + 4 * 60 * 60;
-    System.out.println(tradeService.getTradeHistory(currencyPair, startTime, endTime));
+    PoloniexTradeService.PoloniexTradeHistoryParams params = new PoloniexTradeService.PoloniexTradeHistoryParams();
+    params.setCurrencyPair(currencyPair);
+    System.out.println(tradeService.getTradeHistory(params));
+
+    params.setStartTime(new Date());
+    System.out.println(tradeService.getTradeHistory(params));
+
+    Calendar endTime = Calendar.getInstance();
+    endTime.add(Calendar.HOUR, 4);
+    params.setEndTime(endTime.getTime());
+    System.out.println(tradeService.getTradeHistory(params));
 
     LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).tradableAmount(new BigDecimal(".01")).limitPrice(xmrBuyRate).build();
     String orderId = tradeService.placeLimitOrder(order);

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/taurus/trade/TaurusUserTradeHistoryDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/taurus/trade/TaurusUserTradeHistoryDemo.java
@@ -34,7 +34,7 @@ public class TaurusUserTradeHistoryDemo {
 
   private static void generic(PollingTradeService tradeService) throws IOException {
 
-    Trades trades = tradeService.getTradeHistory();
+    Trades trades = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println(trades);
 
     // Warning: using a limit here can be misleading. The underlying call

--- a/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/GatecoinAuthenticated.java
+++ b/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/GatecoinAuthenticated.java
@@ -74,8 +74,8 @@ public interface GatecoinAuthenticated extends Gatecoin {
   public GatecoinTradeHistoryResult getUserTrades(@HeaderParam("API_PUBLIC_KEY") String publicKey,
           @HeaderParam("API_REQUEST_SIGNATURE") ParamsDigest signature,
           @HeaderParam("API_REQUEST_DATE") String date,
-          @QueryParam("Count") int Count,
-          @QueryParam("TransactionID") long TransactionID) throws  IOException;
+          @QueryParam("Count") Integer Count,
+          @QueryParam("TransactionID") Long TransactionID) throws  IOException;
 
   @GET
   @Path("Balance/Balances")

--- a/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/service/polling/GatecoinTradeServiceRaw.java
+++ b/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/service/polling/GatecoinTradeServiceRaw.java
@@ -56,7 +56,7 @@ public class GatecoinTradeServiceRaw extends GatecoinBasePollingService {
     return gatecoinAuthenticated.cancelAllOrders(exchange.getExchangeSpecification().getApiKey(), signatureCreator, String.valueOf(now));
   }
 
-  public GatecoinTradeHistoryResult getGatecoinUserTrades(int count, long transactionId) throws IOException {
+  public GatecoinTradeHistoryResult getGatecoinUserTrades(Integer count, Long transactionId) throws IOException {
     return gatecoinAuthenticated.getUserTrades(exchange.getExchangeSpecification().getApiKey(), signatureCreator, String.valueOf(now),
         count,transactionId);
   }

--- a/xchange-gatecoin/src/test/java/com/xeiam/xchange/gatecoin/testclient/trade/GatecoinTradeHistoryDemo.java
+++ b/xchange-gatecoin/src/test/java/com/xeiam/xchange/gatecoin/testclient/trade/GatecoinTradeHistoryDemo.java
@@ -4,6 +4,7 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.gatecoin.dto.trade.GatecoinTradeHistory;
 import com.xeiam.xchange.gatecoin.dto.trade.Results.GatecoinTradeHistoryResult;
+import com.xeiam.xchange.gatecoin.service.polling.GatecoinTradeService;
 import com.xeiam.xchange.gatecoin.service.polling.GatecoinTradeServiceRaw;
 import com.xeiam.xchange.gatecoin.testclient.GatecoinDemoUtils;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
@@ -26,15 +27,15 @@ public class GatecoinTradeHistoryDemo {
 
   private static void generic(PollingTradeService tradeService) throws IOException {
 
-    UserTrades result = tradeService.getTradeHistory();
+    UserTrades result = tradeService.getTradeHistory(tradeService.createTradeHistoryParams());
     System.out.println("Trade history returned " + result);
     
     //with count parameter
-    result = tradeService.getTradeHistory(10);
+    result = tradeService.getTradeHistory(new GatecoinTradeService.GatecoinTradeHistoryParams(10));
     System.out.println("Trade history returned " + result);
     
     //with count and tradeId parameter
-    result = tradeService.getTradeHistory(10, 24561);
+    result = tradeService.getTradeHistory(new GatecoinTradeService.GatecoinTradeHistoryParams(10, "24561"));
     System.out.println("Trade history returned " + result);
     
   }

--- a/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/com/xeiam/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -62,23 +62,6 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
     return cancelOrderRaw.getCancelReject() == null && cancelOrderRaw.getExecutionReport() != null;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    int startIndex = 0;
-    int maxResults = 1000;
-    String symbols = "BTCUSD";
-
-    if (arguments.length == 3) {
-      startIndex = (Integer) arguments[0];
-      maxResults = (Integer) arguments[1];
-      symbols = (String) arguments[2]; // comma separated
-    }
-
-    HitbtcOwnTrade[] tradeHistoryRaw = getTradeHistoryRaw(startIndex, maxResults, symbols);
-    return HitbtcAdapters.adaptTradeHistory(tradeHistoryRaw, (ExchangeMetaData) exchange.getMetaData());
-  }
-
   /**
    * Required parameters: {@link TradeHistoryParamPaging} {@link TradeHistoryParamCurrencyPair}
    */

--- a/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/GenericTradeService.java
+++ b/xchange-huobi/src/main/java/com/xeiam/xchange/huobi/service/polling/GenericTradeService.java
@@ -67,8 +67,7 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
   @Override
   public String placeMarketOrder(MarketOrder marketOrder) throws IOException {
 
-    HuobiPlaceOrderResult result = tradeServiceRaw.placeMarketOrder(marketOrder.getType(), coinTypes.get(marketOrder.getCurrencyPair()),
-        marketOrder.getTradableAmount());
+    HuobiPlaceOrderResult result = tradeServiceRaw.placeMarketOrder(marketOrder.getType(), coinTypes.get(marketOrder.getCurrencyPair()), marketOrder.getTradableAmount());
     return HuobiAdapters.adaptPlaceOrderResult(result);
   }
 
@@ -101,18 +100,12 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 }

--- a/xchange-independentreserve/src/main/java/com/xeiam/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
+++ b/xchange-independentreserve/src/main/java/com/xeiam/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
@@ -49,12 +49,6 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
     return independentReserveCancelOrder(orderId);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getTradeHistory(createTradeHistoryParams());
-  }
-
   /**
    * Optional parameters: {@link TradeHistoryParamPaging#getPageNumber()} indexed from 0
    */

--- a/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/com/xeiam/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -61,20 +61,6 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
     return true;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    String currency;
-    if (arguments.length == 1) {
-      CurrencyPair currencyPair = ((CurrencyPair) arguments[0]);
-      currency = currencyPair.baseSymbol + currencyPair.counterSymbol;
-    } else {
-      currency = "XBTUSD";
-    }
-
-    return ItBitAdapters.adaptTradeHistory(getItBitTradeHistory(currency, "1", "1000"));
-  }
-
   /**
    * Required parameters: {@link TradeHistoryParamPaging} {@link TradeHistoryParamCurrencyPair}
    */

--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeService.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/service/polling/KrakenTradeService.java
@@ -52,12 +52,6 @@ public class KrakenTradeService extends KrakenTradeServiceRaw implements Polling
     return super.cancelKrakenOrder(orderId).getCount() > 0;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    return KrakenAdapters.adaptTradesHistory(getKrakenTradeHistory());
-  }
-
   /**
    * @param params Can optionally implement {@link TradeHistoryParamOffset} and {@link TradeHistoryParamsTimeSpan}. All other TradeHistoryParams types
    *        will be ignored.

--- a/xchange-lakebtc/src/main/java/com/xeiam/xchange/lakebtc/service/polling/LakeBTCTradeService.java
+++ b/xchange-lakebtc/src/main/java/com/xeiam/xchange/lakebtc/service/polling/LakeBTCTradeService.java
@@ -11,12 +11,8 @@ import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.lakebtc.dto.trade.LakeBTCCancelResponse;
 import com.xeiam.xchange.lakebtc.dto.trade.LakeBTCOrderResponse;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
-import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
 import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
 
-/**
- * Created by cristian.lucaci on 12/19/2014.
- */
 public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements PollingTradeService {
 
   /**
@@ -53,18 +49,13 @@ public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements Polli
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     throw new NotYetImplementedForExchangeException();
   }
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
-    return new DefaultTradeHistoryParamsTimeSpan();
+    throw new NotYetImplementedForExchangeException();
   }
 
 }

--- a/xchange-loyalbit/src/main/java/com/xeiam/xchange/loyalbit/service/polling/LoyalbitTradeService.java
+++ b/xchange-loyalbit/src/main/java/com/xeiam/xchange/loyalbit/service/polling/LoyalbitTradeService.java
@@ -62,11 +62,6 @@ public class LoyalbitTradeService extends LoyalbitTradeServiceRaw implements Pol
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, LoyalbitException {
-    return LoyalbitAdapters.adaptTradeHistory(getLoyalbitUserTransactions(0, 1000, LoyalbitAuthenticated.Sort.asc));
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     Integer offset = 0;
     Integer limit = 100;

--- a/xchange-mercadobitcoin/src/main/java/com/xeiam/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
+++ b/xchange-mercadobitcoin/src/main/java/com/xeiam/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
@@ -105,13 +105,6 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
     return true;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    // TODO: see #getTradeHistory(TradeHistoryParams params)
-    throw new NotYetImplementedForExchangeException();
-  }
-
   /**
    * Required parameter types: {@link com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamPaging#getPageLength()}
    */

--- a/xchange-mercadobitcoin/src/main/java/com/xeiam/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
+++ b/xchange-mercadobitcoin/src/main/java/com/xeiam/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
@@ -2,6 +2,7 @@ package com.xeiam.xchange.mercadobitcoin.service.polling;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import com.xeiam.xchange.Exchange;
@@ -13,15 +14,15 @@ import com.xeiam.xchange.dto.trade.MarketOrder;
 import com.xeiam.xchange.dto.trade.OpenOrders;
 import com.xeiam.xchange.dto.trade.UserTrades;
 import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
-import com.xeiam.xchange.exceptions.NotYetImplementedForExchangeException;
 import com.xeiam.xchange.mercadobitcoin.MercadoBitcoinAdapters;
 import com.xeiam.xchange.mercadobitcoin.MercadoBitcoinUtils;
 import com.xeiam.xchange.mercadobitcoin.dto.MercadoBitcoinBaseTradeApiResult;
 import com.xeiam.xchange.mercadobitcoin.dto.trade.MercadoBitcoinPlaceLimitOrderResult;
 import com.xeiam.xchange.mercadobitcoin.dto.trade.MercadoBitcoinUserOrders;
 import com.xeiam.xchange.service.polling.trade.PollingTradeService;
-import com.xeiam.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
-import com.xeiam.xchange.service.polling.trade.params.TradeHistoryParams;
+import com.xeiam.xchange.service.polling.trade.params.*;
+
+import static com.xeiam.xchange.utils.DateUtils.toUnixTimeNullSafe;
 
 /**
  * @author Felipe Micaroni Lalli
@@ -85,8 +86,7 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
       type = "sell";
     }
 
-    MercadoBitcoinBaseTradeApiResult<MercadoBitcoinPlaceLimitOrderResult> newOrderResult = mercadoBitcoinPlaceLimitOrder(pair, type,
-        limitOrder.getTradableAmount(), limitOrder.getLimitPrice());
+    MercadoBitcoinBaseTradeApiResult<MercadoBitcoinPlaceLimitOrderResult> newOrderResult = mercadoBitcoinPlaceLimitOrder(pair, type, limitOrder.getTradableAmount(), limitOrder.getLimitPrice());
 
     return MercadoBitcoinUtils.makeMercadoBitcoinOrderId(limitOrder.getCurrencyPair(), newOrderResult.getTheReturn().keySet().iterator().next());
   }
@@ -106,22 +106,91 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
   }
 
   /**
-   * Required parameter types: {@link com.xeiam.xchange.service.polling.trade.params.TradeHistoryParamPaging#getPageLength()}
+   * @param params Required parameter types: {@link TradeHistoryParamCurrencyPair}. Supported types: {@link TradeHistoryParamsIdSpan},
+   * {@link TradeHistoryParamsTimeSpan}.
+   *
    */
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    CurrencyPair pair = ((TradeHistoryParamCurrencyPair)params).getCurrencyPair();
 
-    // TODO: use getMercadoBitcoinUserOrders of MercadoBitcoinTradeServiceRaw
-    // and get order of all status (active, completed and canceled) and look for
-    // getOperations()
-    throw new NotYetImplementedForExchangeException();
+    String fromId = null;
+    String toId = null;
+    if(params instanceof TradeHistoryParamsIdSpan){
+      TradeHistoryParamsIdSpan paramsIdSpan = (TradeHistoryParamsIdSpan) params;
+      fromId= paramsIdSpan.getStartId();
+      toId = paramsIdSpan.getEndId();
+    }
+
+    Long fromDate = null;
+    Long toDate = null;
+    if(params instanceof TradeHistoryParamsTimeSpan){
+      TradeHistoryParamsTimeSpan paramsTimeSpan = (TradeHistoryParamsTimeSpan) params;
+      fromDate = toUnixTimeNullSafe(paramsTimeSpan.getStartTime());
+      toDate = toUnixTimeNullSafe(paramsTimeSpan.getEndTime());
+    }
+
+
+    MercadoBitcoinBaseTradeApiResult<MercadoBitcoinUserOrders> orders = getMercadoBitcoinUserOrders(MercadoBitcoinAdapters.adaptCurrencyPair(pair), null, /*all*/null, fromId, toId,
+        fromDate, toDate);
+
+    return MercadoBitcoinAdapters.toUserTrades(pair, orders);
   }
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
+    return new MercadoTradeHistoryParams(CurrencyPair.BTC_BRL);
+  }
 
-    return new DefaultTradeHistoryParamPaging(1000); // the API limit of Mercado
-    // Bitcoin is 1000
+  public static class MercadoTradeHistoryParams extends DefaultTradeHistoryParamCurrencyPair implements TradeHistoryParamsIdSpan, TradeHistoryParamsTimeSpan{
+    private String startId;
+    private String endId;
+    private Date startTime;
+    private Date endTime;
+
+    public MercadoTradeHistoryParams(CurrencyPair pair) {
+      super(pair);
+    }
+
+    @Override
+    public void setStartId(String startId) {
+      this.startId = startId;
+    }
+
+    @Override
+    public String getStartId() {
+      return startId;
+    }
+
+    @Override
+    public void setEndId(String endId) {
+      this.endId = endId;
+    }
+
+    @Override
+    public String getEndId() {
+      return endId;
+    }
+
+    @Override
+    public void setStartTime(Date startTime) {
+      this.startTime = startTime;
+    }
+
+    @Override
+    public Date getStartTime() {
+      return startTime;
+    }
+
+    @Override
+    public void setEndTime(Date endTime) {
+      this.endTime = endTime;
+    }
+
+    @Override
+    public Date getEndTime() {
+      return endTime;
+    }
   }
 
 }

--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
@@ -134,22 +134,6 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
     return ret;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-    OkCoinFuturesTradeHistoryParams params = createTradeHistoryParams();
-
-    if (arguments.length >= 0)
-      params.setCurrencyPair((CurrencyPair) arguments[0]);
-
-    if (arguments.length > 0)
-      params.setFuturesContract((FuturesContract) arguments[1]);
-
-    if (arguments.length > 1)
-      params.setPageNumber((Integer) arguments[2]);
-
-    return getTradeHistory(params);
-  }
-
   /**
    * Parameters: see {@link OkCoinFuturesTradeService.OkCoinFuturesTradeHistoryParams}
    */

--- a/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinTradeService.java
+++ b/xchange-okcoin/src/main/java/com/xeiam/xchange/okcoin/service/polling/OkCoinTradeService.java
@@ -120,16 +120,6 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements Polling
     return ret;
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    CurrencyPair currencyPair = arguments.length > 0 ? (CurrencyPair) arguments[0] : (useIntl ? CurrencyPair.BTC_USD : CurrencyPair.BTC_CNY);
-    Integer page = arguments.length > 1 ? (Integer) arguments[1] : 0;
-
-    OkCoinOrderResult orderHistory = getOrderHistory(OkCoinAdapters.adaptSymbol(currencyPair), "1", page.toString(), "1000");
-    return OkCoinAdapters.adaptTrades(orderHistory);
-  }
-
   /**
    * Required parameters {@link TradeHistoryParamPaging} Supported parameters {@link TradeHistoryParamCurrencyPair}
    */

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/service/polling/PoloniexTradeService.java
@@ -73,37 +73,10 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Pol
     return cancel(orderId);
   }
 
-  @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    CurrencyPair currencyPair = null;
-    Long startTime = null;
-    Long endTime = null;
-
-    if (arguments != null) {
-      switch (arguments.length) {
-      case 3:
-        if (arguments[2] != null && arguments[2] instanceof Long) {
-          endTime = (Long) arguments[2];
-        }
-      case 2:
-        if (arguments[1] != null && arguments[1] instanceof Long) {
-          startTime = (Long) arguments[1];
-        }
-      case 1:
-        if (arguments[0] != null && arguments[0] instanceof CurrencyPair) {
-          currencyPair = (CurrencyPair) arguments[0];
-        }
-      }
-    }
-    return getTradeHistory(currencyPair, startTime, endTime);
-  }
-
   /**
    * @param params Can optionally implement {@link TradeHistoryParamCurrencyPair} and {@link TradeHistoryParamsTimeSpan}. All other TradeHistoryParams
    *        types will be ignored.
    */
-
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineTradeService.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineTradeService.java
@@ -62,12 +62,6 @@ public class QuoineTradeService extends QuoineTradeServiceRaw implements Polling
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
     throw new NotAvailableFromExchangeException();

--- a/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/service/polling/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/com/xeiam/xchange/ripple/service/polling/RippleTradeService.java
@@ -72,21 +72,6 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
   }
 
   /**
-   * Search through the last {@link RippleTradeHistoryParams#DEFAULT_PAGE_LENGTH} notifications looking for a maximum of
-   * {@link RippleTradeHistoryCount#DEFAULT_TRADE_COUNT_LIMIT} trades. If an account enters many orders and receives few executions then it is likely
-   * that this query will return no trades. See {@link #getTradeHistory(TradeHistoryParams)} for details of how to structure the query to fit your use
-   * case.
-   *
-   * @param arguments these are ignored.
-   */
-
-  @Override
-  public UserTrades getTradeHistory(final Object... arguments)
-      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getTradeHistory(defaultTradeHistoryParams);
-  }
-
-  /**
    * Ripple trade history is a request intensive process. The REST API does not provide a simple single trade history query. Trades are retrieved by
    * querying account notifications and for those of type order details of the hash are then queried. These order detail queries could be order entry,
    * cancel or execution, it is not possible to tell from the notification. Therefore if an account is entering many orders but executing few of them,

--- a/xchange-taurus/src/main/java/com/xeiam/xchange/taurus/service/polling/TaurusTradeService.java
+++ b/xchange-taurus/src/main/java/com/xeiam/xchange/taurus/service/polling/TaurusTradeService.java
@@ -68,14 +68,6 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements Polling
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, TaurusException {
-    if (args.length == 0) {
-      return getTradeHistory(createTradeHistoryParams());
-    }
-    throw new IllegalArgumentException("Please use getTradeHistory(TradeHistoryParams).");
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     Integer offset = null;
     Integer limit = null;

--- a/xchange-therock/src/main/java/com/xeiam/xchange/therock/service/polling/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/com/xeiam/xchange/therock/service/polling/TheRockTradeService.java
@@ -48,11 +48,6 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Polli
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... args) throws IOException, TheRockException {
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
     throw new NotYetImplementedForExchangeException();
   }

--- a/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/service/polling/VircurexTradeService.java
+++ b/xchange-vircurex/src/main/java/com/xeiam/xchange/vircurex/service/polling/VircurexTradeService.java
@@ -48,12 +48,6 @@ public class VircurexTradeService extends VircurexTradeServiceRaw implements Pol
   }
 
   @Override
-  public UserTrades getTradeHistory(Object... arguments) throws IOException {
-
-    throw new NotYetImplementedForExchangeException();
-  }
-
-  @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
     throw new NotYetImplementedForExchangeException();


### PR DESCRIPTION
implement #1064

Trade history not implemented for:
- LakeBTC
- CoinbaseEx
- TheRock
- Vircurex

Mercado isn't implemented, but should be trivial - WiP

exchanges accept long page length, but our api allows only int:
- Bitso
- Bitstamp