### PR TITLE
BTCMarkets: fix market orders

### DIFF
--- a/xchange-btcmarkets/src/main/java/com/xeiam/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
+++ b/xchange-btcmarkets/src/main/java/com/xeiam/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
@@ -46,7 +46,7 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
 
   @Override
   public String placeMarketOrder(MarketOrder order) throws IOException, BTCMarketsException {
-    return placeOrder(order.getCurrencyPair(), order.getType(), order.getTradableAmount(), null, BTCMarketsOrder.Type.Market);
+    return placeOrder(order.getCurrencyPair(), order.getType(), order.getTradableAmount(), BigDecimal.ZERO, BTCMarketsOrder.Type.Market);
   }
 
   @Override


### PR DESCRIPTION
The guys at BTCMarkets fixed the server to not require a price that is close to the current market price to be submitted with a market order, so we can just always submit 0 now.