### PR TITLE
Change mode of authentication for Quoine

### DIFF
--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/quoine/QuoineExamplesUtils.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/quoine/QuoineExamplesUtils.java
@@ -16,10 +16,7 @@ public class QuoineExamplesUtils {
 
     // enter your specific API access info here
     exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_USER_ID, "");
-    exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_DEVICE_NAME, "");
-    exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_USER_TOKEN, "");
-
-    exSpec.setSecretKey("");
+    exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_USER_SECRET, "");
 
     return ExchangeFactory.INSTANCE.createExchange(exSpec);
   }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/QuoineAuthenticated.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/QuoineAuthenticated.java
@@ -19,6 +19,7 @@ import com.xeiam.xchange.quoine.dto.trade.QuoineNewOrderRequest;
 import com.xeiam.xchange.quoine.dto.trade.QuoineOrderDetailsResponse;
 import com.xeiam.xchange.quoine.dto.trade.QuoineOrderResponse;
 import com.xeiam.xchange.quoine.dto.trade.QuoineOrdersList;
+import si.mazi.rescu.ParamsDigest;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
@@ -26,33 +27,33 @@ public interface QuoineAuthenticated extends Quoine {
 
   @GET
   @Path("accounts")
-  public QuoineAccountInfo getAccountInfo(@HeaderParam("X-Quoine-Device") String device, @HeaderParam("X-Quoine-User-Id") String userID,
-      @HeaderParam("X-Quoine-User-Token") String userToken) throws IOException;
+  public QuoineAccountInfo getAccountInfo(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer) throws IOException;
 
   @GET
   @Path("trading_accounts")
-  public QuoineTradingAccountInfo[] getTradingAccountInfo(@HeaderParam("X-Quoine-Device") String device,
-      @HeaderParam("X-Quoine-User-Id") String userID, @HeaderParam("X-Quoine-User-Token") String userToken) throws IOException;
+  public QuoineTradingAccountInfo[] getTradingAccountInfo(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer) throws IOException;
 
   @POST
   @Path("orders")
   @Consumes(MediaType.APPLICATION_JSON)
-  public QuoineOrderResponse placeOrder(@HeaderParam("X-Quoine-Device") String device, @HeaderParam("X-Quoine-User-Id") String userID,
-      @HeaderParam("X-Quoine-User-Token") String userToken, QuoineNewOrderRequest quoineNewOrderRequest) throws IOException;
+  public QuoineOrderResponse placeOrder(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer, QuoineNewOrderRequest quoineNewOrderRequest) throws IOException;
 
   @PUT
   @Path("orders/{order_id}/cancel")
-  public QuoineOrderResponse cancelOrder(@HeaderParam("X-Quoine-Device") String device, @HeaderParam("X-Quoine-User-Id") String userID,
-      @HeaderParam("X-Quoine-User-Token") String userToken, @PathParam("order_id") String orderID) throws IOException;
+  public QuoineOrderResponse cancelOrder(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer, @PathParam("order_id") String orderID) throws IOException;
 
   @GET
   @Path("orders/{order_id}")
-  public QuoineOrderDetailsResponse orderDetails(@HeaderParam("X-Quoine-Device") String device, @HeaderParam("X-Quoine-User-Id") String userID,
-      @HeaderParam("X-Quoine-User-Token") String userToken, @PathParam("order_id") String orderID) throws IOException;
+  public QuoineOrderDetailsResponse orderDetails(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer, @PathParam("order_id") String orderID) throws IOException;
 
   @GET
   @Path("orders")
-  public QuoineOrdersList listOrders(@HeaderParam("X-Quoine-Device") String device, @HeaderParam("X-Quoine-User-Id") String userID,
-      @HeaderParam("X-Quoine-User-Token") String userToken, @QueryParam("currency_pair_code") String currencyPair) throws IOException;
+  public QuoineOrdersList listOrders(@HeaderParam("Content-Type") String contentType, @HeaderParam("Content-MD5") ParamsDigest contentMD5, @HeaderParam("Date") String date,
+      @HeaderParam("NONCE") String nonce, @HeaderParam("Authorization") ParamsDigest signer, @QueryParam("currency_pair_code") String currencyPair) throws IOException;
 
 }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/QuoineExchange.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/QuoineExchange.java
@@ -7,16 +7,19 @@ import com.xeiam.xchange.quoine.service.polling.QuoineAccountService;
 import com.xeiam.xchange.quoine.service.polling.QuoineMarketDataService;
 import com.xeiam.xchange.quoine.service.polling.QuoineTradeService;
 
+import com.xeiam.xchange.utils.nonce.CurrentTimeNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 public class QuoineExchange extends BaseExchange implements Exchange {
 
   public static final String KEY_USER_ID = "KEY_USER_ID";
-  public static final String KEY_DEVICE_NAME = "KEY_DEVICE_NAME";
-  public static final String KEY_USER_TOKEN = "KEY_USER_TOKEN";
+  public static final String KEY_USER_SECRET = "KEY_USER_SECRET";
+
+  private SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
   @Override
   protected void initServices() {
+
     boolean useMargin = (Boolean) exchangeSpecification.getExchangeSpecificParametersItem("Use_Margin");
 
     this.pollingMarketDataService = new QuoineMarketDataService(this);
@@ -37,7 +40,6 @@ public class QuoineExchange extends BaseExchange implements Exchange {
   @Override
   public SynchronizedValueFactory<Long> getNonceFactory() {
 
-    // not used by this exchange
-    return null;
+    return nonceFactory;
   }
 }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/QuoineSignatureDigest.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/QuoineSignatureDigest.java
@@ -1,0 +1,63 @@
+package com.xeiam.xchange.quoine.service;
+
+import com.xeiam.xchange.service.BaseParamsDigest;
+import net.iharder.Base64;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.RestInvocation;
+
+import javax.crypto.Mac;
+import javax.ws.rs.HeaderParam;
+import java.io.UnsupportedEncodingException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+public class QuoineSignatureDigest extends BaseParamsDigest {
+
+  private final String userID;
+
+  public QuoineSignatureDigest(String userID, String secretKeyBase64) {
+    super(secretKeyBase64, HMAC_SHA_1);
+    this.userID = userID;
+  }
+
+  public ParamsDigest getContentMD5Digester() {
+
+    return new QuoineContentMD5Digest();
+  }
+
+  @Override
+  public String digestParams(RestInvocation restInvocation) {
+
+    String contentMD5 = getContentMD5(restInvocation.getRequestBody());
+    String date = restInvocation.getParamValue(HeaderParam.class, "Date").toString();
+    String nonce = restInvocation.getParamValue(HeaderParam.class, "NONCE").toString();
+    String data = "application/json," + contentMD5 + "," + restInvocation.getPath() + "," + date + "," + nonce;
+
+    Mac mac = getMac();
+    byte[] hash = mac.doFinal(data.getBytes());
+
+    return "APIAuth " + userID + ":" + Base64.encodeBytes(hash);
+  }
+
+  private String getContentMD5(String content) {
+
+    String digest = null;
+    try {
+      byte[] bytesOfMessage = content.getBytes("UTF-8");
+      MessageDigest md = MessageDigest.getInstance("MD5");
+      digest = Base64.encodeBytes(md.digest(bytesOfMessage));
+    } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+      e.printStackTrace();
+    }
+    return digest;
+  }
+
+  private class QuoineContentMD5Digest implements ParamsDigest {
+
+    @Override
+    public String digestParams(RestInvocation restInvocation) {
+
+      return getContentMD5(restInvocation.getRequestBody());
+    }
+  }
+}

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineAccountServiceRaw.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineAccountServiceRaw.java
@@ -6,6 +6,7 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.exceptions.ExchangeException;
 import com.xeiam.xchange.quoine.dto.account.QuoineAccountInfo;
 import com.xeiam.xchange.quoine.dto.account.QuoineTradingAccountInfo;
+import com.xeiam.xchange.quoine.service.QuoineSignatureDigest;
 import com.xeiam.xchange.utils.Assert;
 
 import si.mazi.rescu.HttpStatusIOException;
@@ -25,7 +26,7 @@ public class QuoineAccountServiceRaw extends QuoineBasePollingService {
   public QuoineAccountInfo getQuoineAccountInfo() throws IOException {
 
     try {
-      return quoine.getAccountInfo(device, userID, userToken);
+      return quoine.getAccountInfo(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator);
     } catch (HttpStatusIOException e) {
       throw new ExchangeException(e.getHttpBody());
     }
@@ -34,7 +35,7 @@ public class QuoineAccountServiceRaw extends QuoineBasePollingService {
   public QuoineTradingAccountInfo[] getQuoineTradingAccountInfo() throws IOException {
 
     try {
-      return quoine.getTradingAccountInfo(device, userID, userToken);
+      return quoine.getTradingAccountInfo(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator);
     } catch (HttpStatusIOException e) {
       throw new ExchangeException(e.getHttpBody());
     }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineBasePollingService.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineBasePollingService.java
@@ -3,6 +3,7 @@ package com.xeiam.xchange.quoine.service.polling;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.exceptions.ExchangeException;
@@ -50,12 +51,13 @@ public class QuoineBasePollingService extends BaseExchangeService implements Bas
 
   protected String getDate() {
 
-    SimpleDateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z");
-    return format.format(new Date());
+      SimpleDateFormat format = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
+      format.setTimeZone(TimeZone.getTimeZone("GMT"));
+      return format.format(new Date());
   }
 
   protected String getNonce() {
 
-    return String.format("%032d", String.valueOf(exchange.getNonceFactory().createValue()));
+    return String.format("%032d", exchange.getNonceFactory().createValue());
   }
 }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineBasePollingService.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineBasePollingService.java
@@ -1,24 +1,30 @@
 package com.xeiam.xchange.quoine.service.polling;
 
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.exceptions.ExchangeException;
 import com.xeiam.xchange.quoine.QuoineAuthenticated;
 import com.xeiam.xchange.quoine.QuoineExchange;
+import com.xeiam.xchange.quoine.service.QuoineSignatureDigest;
 import com.xeiam.xchange.service.BaseExchangeService;
 import com.xeiam.xchange.service.polling.BasePollingService;
 
 import si.mazi.rescu.HttpStatusIOException;
+import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
 public class QuoineBasePollingService extends BaseExchangeService implements BasePollingService {
 
   protected QuoineAuthenticated quoine;
 
-  protected final String device;
+  protected final QuoineSignatureDigest signatureCreator;
+  protected final ParamsDigest contentMD5Creator;
+  protected final String contentType = "application/json";
   protected final String userID;
-  protected final String userToken;
+  protected final String secret;
 
   /**
    * Constructor
@@ -30,13 +36,26 @@ public class QuoineBasePollingService extends BaseExchangeService implements Bas
     super(exchange);
 
     quoine = RestProxyFactory.createProxy(QuoineAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    device = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_DEVICE_NAME);
-    userID = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_USER_ID);
-    userToken = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_USER_TOKEN);
+
+    this.userID = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_USER_ID);
+    this.secret = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_USER_SECRET);
+    this.signatureCreator = new QuoineSignatureDigest(this.userID, this.secret);
+    this.contentMD5Creator = signatureCreator.getContentMD5Digester();
   }
 
   protected RuntimeException handleHttpError(HttpStatusIOException exception) throws IOException {
+
     throw new ExchangeException(exception.getHttpBody(), exception);
   }
 
+  protected String getDate() {
+
+    SimpleDateFormat format = new SimpleDateFormat("EEE, d MMM yyyy HH:mm:ss Z");
+    return format.format(new Date());
+  }
+
+  protected String getNonce() {
+
+    return String.format("%032d", String.valueOf(exchange.getNonceFactory().createValue()));
+  }
 }

--- a/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineTradeServiceRaw.java
+++ b/xchange-quoine/src/main/java/com/xeiam/xchange/quoine/service/polling/QuoineTradeServiceRaw.java
@@ -40,11 +40,10 @@ public class QuoineTradeServiceRaw extends QuoineBasePollingService {
 
   public QuoineOrderResponse placeLimitOrder(CurrencyPair currencyPair, String type, BigDecimal tradableAmount, BigDecimal price) throws IOException {
 
-    QuoineNewOrderRequest quoineNewOrderRequest = useMargin
-        ? new QuoineNewMarginOrderRequest("limit", QuoineUtils.toPairString(currencyPair), type, tradableAmount, price, leverageLevel)
+    QuoineNewOrderRequest quoineNewOrderRequest = useMargin ? new QuoineNewMarginOrderRequest("limit", QuoineUtils.toPairString(currencyPair), type, tradableAmount, price, leverageLevel)
         : new QuoineNewOrderRequest("limit", QuoineUtils.toPairString(currencyPair), type, tradableAmount, price);
     try {
-      return quoine.placeOrder(device, userID, userToken, quoineNewOrderRequest);
+      return quoine.placeOrder(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator, quoineNewOrderRequest);
     } catch (HttpStatusIOException e) {
       throw handleHttpError(e);
     }
@@ -52,35 +51,37 @@ public class QuoineTradeServiceRaw extends QuoineBasePollingService {
 
   public QuoineOrderResponse placeMarketOrder(CurrencyPair currencyPair, String type, BigDecimal tradableAmount) throws IOException {
 
-    QuoineNewOrderRequest quoineNewOrderRequest = useMargin
-        ? new QuoineNewMarginOrderRequest("market", QuoineUtils.toPairString(currencyPair), type, tradableAmount, null, leverageLevel)
+    QuoineNewOrderRequest quoineNewOrderRequest = useMargin ? new QuoineNewMarginOrderRequest("market", QuoineUtils.toPairString(currencyPair), type, tradableAmount, null, leverageLevel)
         : new QuoineNewOrderRequest("market", QuoineUtils.toPairString(currencyPair), type, tradableAmount, null);
     try {
-      return quoine.placeOrder(device, userID, userToken, quoineNewOrderRequest);
+      return quoine.placeOrder(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator, quoineNewOrderRequest);
     } catch (HttpStatusIOException e) {
       throw handleHttpError(e);
     }
   }
 
   public QuoineOrderResponse cancelQuoineOrder(String orderID) throws IOException {
+
     try {
-      return quoine.cancelOrder(device, userID, userToken, orderID);
+      return quoine.cancelOrder(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator, orderID);
     } catch (HttpStatusIOException e) {
       throw handleHttpError(e);
     }
   }
 
   public QuoineOrderDetailsResponse getQuoineOrderDetails(String orderID) throws IOException {
+
     try {
-      return quoine.orderDetails(device, userID, userToken, orderID);
+      return quoine.orderDetails(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator, orderID);
     } catch (HttpStatusIOException e) {
       throw handleHttpError(e);
     }
   }
 
   public QuoineOrdersList listQuoineOrders(String currencyPair) throws IOException {
+
     try {
-      return quoine.listOrders(device, userID, userToken, currencyPair);
+      return quoine.listOrders(contentType, contentMD5Creator, getDate(), getNonce(), signatureCreator, currencyPair);
     } catch (HttpStatusIOException e) {
       throw handleHttpError(e);
     }


### PR DESCRIPTION
Quoine exchange provides 2 modes of authentication: token-based, which is the one currently supported by XChange, and secret-based, which is not. Token-based is deprecated and will be removed in a future release (see [https://developers.quoine.com/#1.1-token-based-(deprecated)](https://developers.quoine.com/#1.1-token-based-(deprecated)).

This pull request implements secret-based authentication for xchange-quoine. Token-based authentication is no longer possible after this pull request is merged, and thus it should be considered as not backwards compatible.