### PR TITLE
Adds missing value vwap for Ticker from Kraken

### DIFF
--- a/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/com/xeiam/xchange/kraken/KrakenAdapters.java
@@ -107,6 +107,7 @@ public class KrakenAdapters {
     builder.last(krakenTicker.getClose().getPrice());
     builder.high(krakenTicker.get24HourHigh());
     builder.low(krakenTicker.get24HourLow());
+    builder.vwap(krakenTicker.get24HourVolumeAvg());
     builder.volume(krakenTicker.get24HourVolume());
     builder.currencyPair(currencyPair);
     return builder.build();

--- a/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/com/xeiam/xchange/kraken/KrakenAdaptersTest.java
@@ -60,6 +60,7 @@ public class KrakenAdaptersTest {
     assertThat(ticker.getLow()).isEqualTo(new BigDecimal("560.00000"));
     assertThat(ticker.getHigh()).isEqualTo(new BigDecimal("591.11000"));
     assertThat(ticker.getLast()).isEqualTo(new BigDecimal("560.87711"));
+    assertThat(ticker.getVwap()).isEqualTo(new BigDecimal("576.77284"));
     assertThat(ticker.getVolume()).isEqualByComparingTo("600.91850325");
     assertThat(ticker.getCurrencyPair().baseSymbol).isEqualTo(currencyPair.baseSymbol);
   }


### PR DESCRIPTION
The vwap value will be the 24h weighted average provided by the kraken API:
https://www.kraken.com/help/api#get-ticker-info
