### PR TITLE
Bitstamp balance withdrawing

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAdapters.java
@@ -1,5 +1,7 @@
 package com.xeiam.xchange.bitstamp;
 
+import static java.math.BigDecimal.ZERO;
+
 import java.math.BigDecimal;
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -16,13 +18,13 @@ import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.account.AccountInfo;
+import com.xeiam.xchange.dto.account.Balance;
 import com.xeiam.xchange.dto.account.Wallet;
 import com.xeiam.xchange.dto.marketdata.OrderBook;
 import com.xeiam.xchange.dto.marketdata.Ticker;
 import com.xeiam.xchange.dto.marketdata.Trade;
 import com.xeiam.xchange.dto.marketdata.Trades;
 import com.xeiam.xchange.dto.marketdata.Trades.TradeSortType;
-import com.xeiam.xchange.dto.account.Balance;
 import com.xeiam.xchange.dto.trade.LimitOrder;
 import com.xeiam.xchange.dto.trade.UserTrade;
 import com.xeiam.xchange.dto.trade.UserTrades;
@@ -50,10 +52,12 @@ public final class BitstampAdapters {
   public static AccountInfo adaptAccountInfo(BitstampBalance bitstampBalance, String userName) {
 
     // Adapt to XChange DTOs
+    final BigDecimal usdWithdrawing = bitstampBalance.getUsdBalance().subtract(bitstampBalance.getUsdAvailable()).subtract(bitstampBalance.getUsdReserved());
+    final BigDecimal btcWithdrawing = bitstampBalance.getBtcBalance().subtract(bitstampBalance.getBtcAvailable()).subtract(bitstampBalance.getBtcReserved());
     Balance usdBalance = new Balance(Currency.USD, bitstampBalance.getUsdBalance(), bitstampBalance.getUsdAvailable(),
-        bitstampBalance.getUsdReserved());
+        bitstampBalance.getUsdReserved(), ZERO, ZERO, usdWithdrawing, ZERO);
     Balance btcBalance = new Balance(Currency.BTC, bitstampBalance.getBtcBalance(), bitstampBalance.getBtcAvailable(),
-        bitstampBalance.getBtcReserved());
+        bitstampBalance.getBtcReserved(), ZERO, ZERO, btcWithdrawing, ZERO);
 
     return new AccountInfo(userName, bitstampBalance.getFee(), new Wallet(usdBalance, btcBalance));
   }

--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/account/Balance.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/account/Balance.java
@@ -2,6 +2,9 @@ package com.xeiam.xchange.dto.account;
 
 import java.math.BigDecimal;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.xeiam.xchange.currency.Currency;
 
 /**
@@ -16,6 +19,8 @@ import com.xeiam.xchange.currency.Currency;
  * </p>
  */
 public final class Balance implements Comparable<Balance> {
+
+  private static final Logger log = LoggerFactory.getLogger(Balance.class);
 
   private final Currency currency;
 
@@ -97,7 +102,7 @@ public final class Balance implements Comparable<Balance> {
     if (total != null && available != null) {
       BigDecimal sum = available.add(frozen).subtract(borrowed).add(loaned).add(withdrawing).add(depositing);
       if (!total.equals(sum)) {
-        throw new IllegalArgumentException("total != available + frozen - borrowed + loaned + withdrawing + depositing");
+        log.warn("{} = total != available + frozen - borrowed + loaned + withdrawing + depositing = {}", total, sum);
       }
     }
     this.currency = currency;


### PR DESCRIPTION
Two commits, two changes:
- Bistamp balance withdrawing amount
- Log a warning instead of an exception when balances don't add up. I don't think the situation when balances don't add up is critical (individual balances are still useful). Also, I suspect many exchange implementations currently have issues in the implementation here (like Bitstamp) so I suggest we fail more gracefully to allow us some time to fix these.

The code was tested with Bitstamp.

@baffo32, please review. Thanks!