### PR TITLE
Don't give false exception on balance

### DIFF
--- a/xchange-core/src/main/java/com/xeiam/xchange/dto/account/Balance.java
+++ b/xchange-core/src/main/java/com/xeiam/xchange/dto/account/Balance.java
@@ -101,7 +101,7 @@ public final class Balance implements Comparable<Balance> {
 
     if (total != null && available != null) {
       BigDecimal sum = available.add(frozen).subtract(borrowed).add(loaned).add(withdrawing).add(depositing);
-      if (!total.equals(sum)) {
+      if (0 != total.compareTo(sum)) {
         log.warn("{} = total != available + frozen - borrowed + loaned + withdrawing + depositing = {}", total, sum);
       }
     }


### PR DESCRIPTION
Don't give an false log warning if the calculated balance is equal to the expected one but has a different number of decimals.