### PR TITLE
Removed removed markets in json file

### DIFF
--- a/xchange-cexio/src/main/resources/cexio.json
+++ b/xchange-cexio/src/main/resources/cexio.json
@@ -12,10 +12,6 @@
       "priceScale": 3,
       "minimumAmount": 1.200000000
     },
-    "DOGE/USD": {
-      "priceScale": 8,
-      "minimumAmount": 15500.00000
-    },
     "DRK/USD": {
       "priceScale": 5
     },
@@ -27,65 +23,14 @@
       "priceScale": 8,
       "minimumAmount": 1.200000000
     },
-    "DOGE/BTC": {
-      "priceScale": 8
-    },
     "DRK/BTC": {
-      "priceScale": 8
-    },
-    "NMC/BTC": {
-      "priceScale": 8
-    },
-    "IXC/BTC": {
-      "priceScale": 8
-    },
-    "POT/BTC": {
-      "priceScale": 8
-    },
-    "ANC/BTC": {
-      "priceScale": 8
-    },
-    "MEC/BTC": {
-      "priceScale": 8
-    },
-    "WDC/BTC": {
-      "priceScale": 8
-    },
-    "FTC/BTC": {
-      "priceScale": 8
-    },
-    "DGB/BTC": {
-      "priceScale": 8
-    },
-    "USDE/BTC": {
-      "priceScale": 8
-    },
-    "MYR/BTC": {
-      "priceScale": 8
-    },
-    "AUR/BTC": {
       "priceScale": 8
     },
     "GHS/LTC": {
       "priceScale": 8,
       "minimumAmount": 1.000000000
     },
-    "DOGE/LTC": {
-      "priceScale": 8
-    },
     "DRK/LTC": {
-      "priceScale": 8
-    },
-    "MEC/LTC": {
-      "priceScale": 8
-    },
-    "WDC/LTC": {
-      "priceScale": 8
-    },
-    "ANC/LTC": {
-      "priceScale": 8
-    },
-    "FTC/LTC": {
       "priceScale": 8
     },
     "BTC/EUR": {
@@ -95,9 +40,6 @@
     "LTC/EUR": {
       "priceScale": 3,
       "minimumAmount": 1.200000000
-    },
-    "DOGE/EUR": {
-      "priceScale": 8
     }
   },
   "currency": {},


### PR DESCRIPTION
Many markets are removed on cexio. 
Using the old markets gives an exception in getting open orders.