### PR TITLE
[poloniex] removed deprecated maxDailyWithdrawal from currency info, [bittrex] added fee information to trade history

### DIFF
--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
@@ -172,7 +172,7 @@ public final class BittrexAdapters {
       price = trade.getLimit();
     }
 
-    return new UserTrade(orderType, amount, currencyPair, price, date, orderId, orderId);
+    return new UserTrade(orderType, amount, currencyPair, price, date, orderId, orderId, trade.getCommission(), currencyPair.counter);
   }
 
 }

--- a/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexCurrencyInfo.java
+++ b/xchange-poloniex/src/main/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexCurrencyInfo.java
@@ -6,28 +6,21 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class PoloniexCurrencyInfo {
 
-  private final BigDecimal maxDailyWithdrawal;
   private final BigDecimal txFee;
   private final int minConf;
   private final boolean disabled;
   private final boolean frozen;
   private final boolean delisted;
 
-  public PoloniexCurrencyInfo(@JsonProperty("maxDailyWithdrawal") BigDecimal maxDailyWithdrawal, @JsonProperty("txFee") BigDecimal txFee,
-      @JsonProperty("minConf") int minConf, @JsonProperty("disabled") boolean disabled, @JsonProperty("frozen") boolean frozen,
+  public PoloniexCurrencyInfo(@JsonProperty("txFee") BigDecimal txFee, @JsonProperty("minConf") int minConf, 
+      @JsonProperty("disabled") boolean disabled, @JsonProperty("frozen") boolean frozen, 
       @JsonProperty("delisted") boolean delisted) {
 
-    this.maxDailyWithdrawal = maxDailyWithdrawal;
     this.txFee = txFee;
     this.minConf = minConf;
     this.disabled = disabled;
     this.frozen = frozen;
     this.delisted = delisted;
-  }
-
-  public BigDecimal getMaxDailyWithdrawal() {
-
-    return maxDailyWithdrawal;
   }
 
   public BigDecimal getTxFee() {
@@ -58,7 +51,7 @@ public class PoloniexCurrencyInfo {
   @Override
   public String toString() {
 
-    return "PoloniexCurrencyInfo [maxDailyWithdrawal=" + maxDailyWithdrawal + ", txFee=" + txFee + ", minConf=" + minConf + ", disabled=" + disabled
+    return "PoloniexCurrencyInfo [txFee=" + txFee + ", minConf=" + minConf + ", disabled=" + disabled
         + ", frozen=" + frozen + ", delisted=" + delisted + "]";
   }
 }

--- a/xchange-poloniex/src/test/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexMarketDataTest.java
+++ b/xchange-poloniex/src/test/java/com/xeiam/xchange/poloniex/dto/marketdata/PoloniexMarketDataTest.java
@@ -29,7 +29,6 @@ public class PoloniexMarketDataTest {
     assertThat(currencyInfo).hasSize(2);
 
     PoloniexCurrencyInfo abyCurrencyInfo = currencyInfo.get("ABY");
-    assertThat(abyCurrencyInfo.getMaxDailyWithdrawal()).isEqualTo("10000000");
     assertThat(abyCurrencyInfo.getTxFee()).isEqualTo("0.01");
     assertThat(abyCurrencyInfo.getMinConf()).isEqualTo(8);
     assertThat(abyCurrencyInfo.isDisabled()).isFalse();

--- a/xchange-poloniex/src/test/resources/marketdata/currency-info.json
+++ b/xchange-poloniex/src/test/resources/marketdata/currency-info.json
@@ -1,12 +1,10 @@
 {
    "1CR":{
-      "maxDailyWithdrawal":10000,
       "txFee":0.01,
       "minConf":3,
       "disabled":0
    },
    "ABY":{
-      "maxDailyWithdrawal":10000000,
       "txFee":0.01,
       "minConf":8,
       "disabled":0


### PR DESCRIPTION
* There was a [Poloniex upgrade yesterday](https://twitter.com/Poloniex/status/678258485704990720) - I guess that is when the maxDailyWithdrawal field was deprecated, field is still present but is a string with the text "DEPRECATED". 

* Bittrex returns commission information in its trade history response, but this was not being copied to the UserTrade object. 
