### PR TITLE
Added 'DAY' option to BitstampTime enum

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampMarketDataServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampMarketDataServiceRaw.java
@@ -55,6 +55,6 @@ public class BitstampMarketDataServiceRaw extends BitstampBasePollingService {
   }
 
   public enum BitstampTime {
-    HOUR, MINUTE
+    DAY, HOUR, MINUTE
   }
 }


### PR DESCRIPTION
Added `DAY` option in enum which is used in `getBitstampTransactions`.

*Bitstamp documentation:*
Transactions GET https://www.bitstamp.net/api/transactions/
Params: time - time frame for transaction export ("minute" - 1 minute, "hour" - 1 hour, "day" - 1 day). 