### PR TITLE
[bittrex] open order and trade query changes

### DIFF
--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexAdapters.java
@@ -5,6 +5,7 @@ import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexLevel;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexSymbol;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTicker;
 import com.xeiam.xchange.bittrex.v1.dto.marketdata.BittrexTrade;
+import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexLimitOrder;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexOpenOrder;
 import com.xeiam.xchange.bittrex.v1.dto.trade.BittrexUserTrade;
 import com.xeiam.xchange.currency.Currency;
@@ -62,13 +63,14 @@ public final class BittrexAdapters {
     return openOrders;
   }
 
-  public static LimitOrder adaptOpenOrder(BittrexOpenOrder bittrexOpenOrder) {
+  public static BittrexLimitOrder adaptOpenOrder(BittrexOpenOrder bittrexOpenOrder) {
 
     OrderType type = bittrexOpenOrder.getOrderType().equalsIgnoreCase("LIMIT_SELL") ? OrderType.ASK : OrderType.BID;
     String[] currencies = bittrexOpenOrder.getExchange().split("-");
     CurrencyPair pair = new CurrencyPair(currencies[1], currencies[0]);
 
-    return new LimitOrder(type, bittrexOpenOrder.getQuantityRemaining(), pair, bittrexOpenOrder.getOrderUuid(), null, bittrexOpenOrder.getLimit());
+    return new BittrexLimitOrder(type, bittrexOpenOrder.getQuantityRemaining(), pair, bittrexOpenOrder.getOrderUuid(), null,
+        bittrexOpenOrder.getLimit(), bittrexOpenOrder.getQuantityRemaining(), bittrexOpenOrder.getPricePerUnit());
   }
 
   public static List<LimitOrder> adaptOrders(BittrexLevel[] orders, CurrencyPair currencyPair, String orderType, String id) {
@@ -163,7 +165,7 @@ public final class BittrexAdapters {
 
     OrderType orderType = trade.getOrderType().equalsIgnoreCase("LIMIT_BUY") ? OrderType.BID : OrderType.ASK;
     BigDecimal amount = trade.getQuantity().subtract(trade.getQuantityRemaining());
-    Date date = BittrexUtils.toDate(trade.getTimeStamp());
+    Date date = BittrexUtils.toDate(trade.getClosed());
     String orderId = String.valueOf(trade.getOrderUuid());
 
     BigDecimal price = trade.getPricePerUnit();

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexUtils.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/BittrexUtils.java
@@ -5,12 +5,19 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.xeiam.xchange.currency.CurrencyPair;
 
 /**
  * A central place for shared Bittrex properties
  */
 public final class BittrexUtils {
+
+  private static final Date EPOCH = new Date(0);
+
+  private static final Logger logger = LoggerFactory.getLogger(BittrexUtils.class);
 
   /**
    * private Constructor
@@ -24,27 +31,23 @@ public final class BittrexUtils {
     return currencyPair.counter.getCurrencyCode().toUpperCase() + "-" + currencyPair.base.getCurrencyCode().toUpperCase();
   }
 
-  public static Date toDate(String timeStamp) {
+  public static Date toDate(String datetime) {
+    // Bittrex can truncate the millisecond component of datetime fields (e.g. 2015-12-20T02:07:51.5)  
+    // to the point where if the milliseconds are zero then they are not shown (e.g. 2015-12-26T09:55:23).
+
+    SimpleDateFormat sdf;
+    if (datetime.length() == 19) {
+      sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    } else {
+      sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+    }
+    sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
 
     try {
-
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'.'SSS");
-      sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-      return sdf.parse(timeStamp);
-
+      return sdf.parse(datetime);
     } catch (ParseException e) {
-
-      try {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
-        return sdf.parse(timeStamp);
-
-      } catch (ParseException e1) {
-
-        e1.printStackTrace();
-        return new Date(0L);
-
-      }
+      logger.warn("Unable to parse datetime={}", datetime, e);
+      return EPOCH;
     }
   }
 

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexLimitOrder.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexLimitOrder.java
@@ -1,0 +1,40 @@
+package com.xeiam.xchange.bittrex.v1.dto.trade;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import com.xeiam.xchange.currency.CurrencyPair;
+import com.xeiam.xchange.dto.trade.LimitOrder;
+
+public class BittrexLimitOrder extends LimitOrder {
+
+  private final BigDecimal quantityRemaining;
+  private final BigDecimal pricePerUnit;
+
+  public BittrexLimitOrder(OrderType type, BigDecimal tradableAmount, CurrencyPair currencyPair, String id, Date timestamp, BigDecimal limitPrice,
+      BigDecimal quantityRemaining, BigDecimal pricePerUnit) {
+    super(type, tradableAmount, currencyPair, id, timestamp, limitPrice);
+
+    this.quantityRemaining = quantityRemaining;
+    this.pricePerUnit = pricePerUnit;
+  }
+
+  /**
+   * If an order has not yet received any fills then the quantity remaining will be the same as the total tradable amount. The quantity remaining
+   * reduces to zero as fills occur.
+   * 
+   * @return the volume of the order that has not yet executed
+   */
+  public BigDecimal getQuantityRemaining() {
+    return quantityRemaining;
+  }
+
+  /**
+   * The average price obtained for any trades that have filled the order.
+   * 
+   * @return
+   */
+  public BigDecimal getPricePerUnit() {
+    return pricePerUnit;
+  }
+}

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexOpenOrder.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexOpenOrder.java
@@ -38,7 +38,7 @@ public class BittrexOpenOrder {
   @JsonProperty("Price")
   private BigDecimal price;
   @JsonProperty("PricePerUnit")
-  private Object pricePerUnit;
+  private BigDecimal pricePerUnit;
   @JsonProperty("Opened")
   private String opened;
   @JsonProperty("Closed")
@@ -165,13 +165,13 @@ public class BittrexOpenOrder {
   }
 
   @JsonProperty("PricePerUnit")
-  public Object getPricePerUnit() {
+  public BigDecimal getPricePerUnit() {
 
     return pricePerUnit;
   }
 
   @JsonProperty("PricePerUnit")
-  public void setPricePerUnit(Object pricePerUnit) {
+  public void setPricePerUnit(BigDecimal pricePerUnit) {
 
     this.pricePerUnit = pricePerUnit;
   }

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexUserTrade.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/dto/trade/BittrexUserTrade.java
@@ -16,7 +16,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "OrderUuid", "Exchange", "TimeStamp", "OrderType", "Limit", "Quantity", "QuantityRemaining", "Commission", "Price",
-    "PricePerUnit", "IsConditional", "Condition", "ConditionTarget", "ImmediateOrCancel" })
+    "PricePerUnit", "IsConditional", "Condition", "ConditionTarget", "ImmediateOrCancel", "Closed" })
 public class BittrexUserTrade {
 
   @JsonProperty("OrderUuid")
@@ -47,6 +47,8 @@ public class BittrexUserTrade {
   private Object conditionTarget;
   @JsonProperty("ImmediateOrCancel")
   private Boolean immediateOrCancel;
+  @JsonProperty("Closed")
+  private String closed;
   @JsonIgnore
   private Map<String, Object> additionalProperties = new HashMap<String, Object>();
 
@@ -84,6 +86,18 @@ public class BittrexUserTrade {
   public void setTimeStamp(String timeStamp) {
 
     this.timeStamp = timeStamp;
+  }
+
+  @JsonProperty("Closed")
+  public String getClosed() {
+
+    return closed;
+  }
+
+  @JsonProperty("Closed")
+  public void setClosed(String closed) {
+
+    this.closed = closed;
   }
 
   @JsonProperty("OrderType")

--- a/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexAccountService.java
+++ b/xchange-bittrex/src/main/java/com/xeiam/xchange/bittrex/v1/service/polling/BittrexAccountService.java
@@ -7,7 +7,6 @@ import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.bittrex.v1.BittrexAdapters;
 import com.xeiam.xchange.currency.Currency;
 import com.xeiam.xchange.dto.account.AccountInfo;
-import com.xeiam.xchange.exceptions.NotAvailableFromExchangeException;
 import com.xeiam.xchange.service.polling.account.PollingAccountService;
 
 public class BittrexAccountService extends BittrexAccountServiceRaw implements PollingAccountService {


### PR DESCRIPTION
Related to issue #1153. 

* Open order query has been changed to return BittrexLimitOrder objects allowing access to quantity remaining and price per unit. 
* Trade query altered so that trade time is order close time rather than order creation time. 
* Fix timestamp parsing method to not generate parsing exceptions for times without millisecond component. 