### PR TITLE
Withdraw to Ripple for Bitstamp if address starts with 'r'

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAuthenticated.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/BitstampAuthenticated.java
@@ -1,27 +1,16 @@
 package com.xeiam.xchange.bitstamp;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import com.xeiam.xchange.bitstamp.dto.BitstampException;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampDepositAddress;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampRippleDepositAddress;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampWithdrawal;
-import com.xeiam.xchange.bitstamp.dto.account.DepositTransaction;
-import com.xeiam.xchange.bitstamp.dto.account.WithdrawalRequest;
+import com.xeiam.xchange.bitstamp.dto.account.*;
 import com.xeiam.xchange.bitstamp.dto.trade.BitstampOrder;
 import com.xeiam.xchange.bitstamp.dto.trade.BitstampUserTransaction;
-
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.math.BigDecimal;
 
 /**
  * @author Benedikt Bünz See https://www.bitstamp.net/api/ for up-to-date docs.

--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountService.java
@@ -1,8 +1,5 @@
 package com.xeiam.xchange.bitstamp.service.polling;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-
 import com.xeiam.xchange.Exchange;
 import com.xeiam.xchange.bitstamp.BitstampAdapters;
 import com.xeiam.xchange.bitstamp.dto.account.BitstampDepositAddress;
@@ -10,6 +7,9 @@ import com.xeiam.xchange.bitstamp.dto.account.BitstampWithdrawal;
 import com.xeiam.xchange.currency.Currency;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.service.polling.account.PollingAccountService;
+
+import java.io.IOException;
+import java.math.BigDecimal;
 
 /**
  * @author Matija Mazi
@@ -35,7 +35,7 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
   @Override
   public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
 
-    final BitstampWithdrawal response = withdrawBitstampFunds(amount, address);
+    final BitstampWithdrawal response = withdrawBitstampFunds(currency, amount, address);
     return Integer.toString(response.getId());
   }
 

--- a/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/account/BitstampAccountDemo.java
+++ b/xchange-examples/src/main/java/com/xeiam/xchange/examples/bitstamp/account/BitstampAccountDemo.java
@@ -1,20 +1,16 @@
 package com.xeiam.xchange.examples.bitstamp.account;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.List;
-
 import com.xeiam.xchange.Exchange;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampBalance;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampDepositAddress;
-import com.xeiam.xchange.bitstamp.dto.account.BitstampWithdrawal;
-import com.xeiam.xchange.bitstamp.dto.account.DepositTransaction;
-import com.xeiam.xchange.bitstamp.dto.account.WithdrawalRequest;
+import com.xeiam.xchange.bitstamp.dto.account.*;
 import com.xeiam.xchange.bitstamp.service.polling.BitstampAccountServiceRaw;
 import com.xeiam.xchange.currency.Currency;
 import com.xeiam.xchange.dto.account.AccountInfo;
 import com.xeiam.xchange.examples.bitstamp.BitstampDemoUtils;
 import com.xeiam.xchange.service.polling.account.PollingAccountService;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
 
 /**
  * <p>
@@ -74,7 +70,7 @@ public class BitstampAccountDemo {
       System.out.println(unconfirmedDeposit);
     }
 
-    BitstampWithdrawal withdrawResult = accountService.withdrawBitstampFunds(new BigDecimal(1).movePointLeft(4),
+    BitstampWithdrawal withdrawResult = accountService.withdrawBitstampFunds(Currency.BTC, new BigDecimal(1).movePointLeft(4),
         "1PxYUsgKdw75sdLmM7HYP2p74LEq3mxM6L");
     System.out.println("BitstampBooleanResponse = " + withdrawResult);
   }


### PR DESCRIPTION
Bitstamp Bitcoin addresses start with 1 and Ripple with r. So I think it's a pretty safe implementation.