### PR TITLE
[bitstamp] Resolve Nullpointer for Ripple withdrawal

### DIFF
--- a/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountService.java
+++ b/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountService.java
@@ -36,6 +36,9 @@ public class BitstampAccountService extends BitstampAccountServiceRaw implements
   public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
 
     final BitstampWithdrawal response = withdrawBitstampFunds(currency, amount, address);
+    if (response.getId() == null) {
+      return null;
+    }
     return Integer.toString(response.getId());
   }
 


### PR DESCRIPTION
According to [Bitstamp docs](https://www.bitstamp.net/api/) Bitcoin withdrawal returns an integer ID but ripple withdrawal returns `true`. So in this case of ripple withdrawal it's null. Check the following line https://github.com/nakedpony/XChange/blob/a1f3a29d28f1a360e154a52972fc27c9ffcd6386/xchange-bitstamp/src/main/java/com/xeiam/xchange/bitstamp/service/polling/BitstampAccountServiceRaw.java#L53
