### PR TITLE
Open orders on gatecoin contains wrong order type

### DIFF
--- a/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/service/polling/GatecoinTradeService.java
+++ b/xchange-gatecoin/src/main/java/com/xeiam/xchange/gatecoin/service/polling/GatecoinTradeService.java
@@ -52,7 +52,8 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Pol
 
         List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
         for (GatecoinOrder gatecoinOrder : openOrdersResult.getOrders()) {
-            OrderType orderType = gatecoinOrder.getType() == 0 ? OrderType.BID : OrderType.ASK;
+            /* get side is order side (ask or bid) get type is order type, (limit or market) */
+            OrderType orderType = gatecoinOrder.getSide() == 0 ? OrderType.BID : OrderType.ASK;
             String id = gatecoinOrder.getClOrderId();
             BigDecimal price = gatecoinOrder.getPrice();
             CurrencyPair ccyPair = new CurrencyPair(gatecoinOrder.getCode().substring(0, 3), gatecoinOrder.getCode().substring(3, 6));


### PR DESCRIPTION
Order type for open orders was reported wrong. 
Xchange order type is order side for gatecoin (ask or bid)
Gatecoin order type is limit order or market order.