### PR TITLE
[CryptoFacilities] add v2 api account + fills endpoints

### DIFF
--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/CryptoFacilitiesAuthenticated.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/CryptoFacilitiesAuthenticated.java
@@ -15,10 +15,12 @@ import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
 import com.xeiam.xchange.cryptofacilities.dto.account.CryptoFacilitiesBalance;
+import com.xeiam.xchange.cryptofacilities.dto.account.CryptoFacilitiesAccount;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesCancel;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesOpenOrders;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesOrder;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesTrades;
+import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesFills;
 
 
 /**
@@ -33,7 +35,14 @@ import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesTrades;
 	@POST
 	@Path("/balance")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Deprecated
 	public CryptoFacilitiesBalance balance(@HeaderParam("APIKey") String apiKey, @HeaderParam("Authent") ParamsDigest signer,
+		@HeaderParam("Nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+
+	@POST
+	@Path("/v2/account")
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+	public CryptoFacilitiesAccount account(@HeaderParam("APIKey") String apiKey, @HeaderParam("Authent") ParamsDigest signer,
 		@HeaderParam("Nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
 
 	@POST
@@ -58,7 +67,14 @@ import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesTrades;
 	@POST
 	@Path("/trades")
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+        @Deprecated
 	public CryptoFacilitiesTrades trades(@HeaderParam("APIKey") String apiKey, @HeaderParam("Authent") ParamsDigest signer,
 		@HeaderParam("Nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("number") Integer number) throws IOException;
+
+	@POST
+	@Path("/v2/fills")
+	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+	public CryptoFacilitiesFills fills(@HeaderParam("APIKey") String apiKey, @HeaderParam("Authent") ParamsDigest signer,
+		@HeaderParam("Nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
 
 }

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesAccount.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesAccount.java
@@ -1,0 +1,45 @@
+package com.xeiam.xchange.cryptofacilities.dto.account;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
+
+/**
+ * @author Panchen
+ */
+
+public class CryptoFacilitiesAccount extends CryptoFacilitiesResult {
+
+    private final CryptoFacilitiesAccountInfo accountInfo;
+    
+    public CryptoFacilitiesAccount(@JsonProperty("result") String result
+                  , @JsonProperty("serverTime") String strServerTime
+                  , @JsonProperty("error") String error
+                  , @JsonProperty("account") CryptoFacilitiesAccountInfo accountInfo ) {
+
+            super(result, error);
+            
+            this.accountInfo = accountInfo;
+    }
+
+    public Map<String, BigDecimal> getBalances() {
+            return accountInfo.getBalances();
+    }
+		
+    public Map<String, BigDecimal> getAuxiliary() {
+            return accountInfo.getAuxiliary();
+    }
+
+    public Map<String, BigDecimal> getMarginRequirements() {
+            return accountInfo.getMarginRequirements();
+    }
+
+    public Map<String, BigDecimal> getTriggerEstimates() {
+            return accountInfo.getTriggerEstimates();
+    }
+}

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesAccountInfo.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesAccountInfo.java
@@ -1,0 +1,77 @@
+package com.xeiam.xchange.cryptofacilities.dto.account;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+/**
+ * @author Panchen
+ */
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "balances", "auxiliary", "marginRequirements", "triggerEstimates" })
+public class CryptoFacilitiesAccountInfo {
+    
+    @JsonProperty("balances")
+    private Map<String, BigDecimal> balances;
+    @JsonProperty("auxiliary")
+    private Map<String, BigDecimal> auxiliary;
+    @JsonProperty("marginRequirements")
+    private Map<String, BigDecimal> marginRequirements;
+    @JsonProperty("triggerEstimates")
+    private Map<String, BigDecimal> triggerEstimates;
+    
+    @JsonProperty("balances")
+    public Map<String, BigDecimal> getBalances() {
+     
+        return balances;
+    }
+
+    @JsonProperty("balances")
+    public void setBalances(Map<String, BigDecimal> balances) {
+     
+        this.balances = balances;
+    }
+
+    @JsonProperty("auxiliary")
+    public Map<String, BigDecimal> getAuxiliary() {
+     
+        return auxiliary;
+    }
+
+    @JsonProperty("auxiliary")
+    public void setAuxiliary(Map<String, BigDecimal> auxiliary) {
+     
+        this.auxiliary = auxiliary;
+    }
+
+    @JsonProperty("marginRequirements")
+    public Map<String, BigDecimal> getMarginRequirements() {
+     
+        return marginRequirements;
+    }
+
+    @JsonProperty("marginRequirements")
+    public void setMarginRequirements(Map<String, BigDecimal> marginRequirements) {
+     
+        this.marginRequirements = marginRequirements;
+    }
+
+    @JsonProperty("triggerEstimates")
+    public Map<String, BigDecimal> getTriggerEstimates() {
+     
+        return triggerEstimates;
+    }
+
+    @JsonProperty("triggerEstimates")
+    public void setTriggerEstimates(Map<String, BigDecimal> triggerEstimates) {
+     
+        this.triggerEstimates = triggerEstimates;
+    }
+}

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesBalance.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/account/CryptoFacilitiesBalance.java
@@ -12,6 +12,7 @@ import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
  * @author Jean-Christophe Laruelle
  */
 
+@Deprecated
 public class CryptoFacilitiesBalance extends CryptoFacilitiesResult {
 
 	private final Map<String, BigDecimal> balances;

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFill.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFill.java
@@ -1,0 +1,88 @@
+package com.xeiam.xchange.cryptofacilities.dto.marketdata;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
+
+/**
+ * @author Panchen
+ */
+
+public class CryptoFacilitiesFill extends CryptoFacilitiesResult {
+
+	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+		
+	private final Date fillTime;
+	private final String order_id;
+	private final String fill_id;
+	private final String symbol;
+	private final String side;
+	private final BigDecimal size;
+	private final BigDecimal price;
+		
+	public CryptoFacilitiesFill(@JsonProperty("result") String result
+                        , @JsonProperty("error") String error
+			, @JsonProperty("fillTime") String strfillTime
+			, @JsonProperty("order_id") String order_id
+			, @JsonProperty("fill_id") String fill_id
+			, @JsonProperty("symbol") String symbol
+			, @JsonProperty("side") String side
+			, @JsonProperty("qty") BigDecimal size
+			, @JsonProperty("price") BigDecimal price
+			) throws ParseException {
+	
+		  super(result, error);
+		    
+		  this.fillTime = DATE_FORMAT.parse(strfillTime);
+		  this.order_id = order_id;
+		  this.fill_id = fill_id;
+		  this.symbol = symbol;
+		  this.side = side;
+		  this.size = size;
+		  this.price = price;
+	}
+
+	public String getSymbol() {
+		return symbol;
+	}
+	
+	public Date getFillTime() {
+		return fillTime;
+	}
+
+	public String getOrderId() {
+		return order_id;
+	}
+
+	public String getFillId() {
+		return fill_id;
+	}
+
+        public String getSide() {
+		return side;
+	}
+
+	public BigDecimal getSize() {
+		return size;
+	}
+
+	public BigDecimal getPrice() {
+		return price;
+	}
+
+	@Override
+	public String toString() {	
+		return "CryptoFacilitiesFill [order_id=" + order_id 
+                        + ", fill_id=" + fill_id
+			+ ", fillTime=" + DATE_FORMAT.format(fillTime)
+			+ ", symbol=" + symbol
+			+ ", side=" + side
+			+ ", size=" + size
+			+ ", price=" + price
+			+" ]";
+	}
+}

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFills.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFills.java
@@ -1,0 +1,55 @@
+package com.xeiam.xchange.cryptofacilities.dto.marketdata;
+
+import java.util.List;
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+/**
+ * @author Panchen
+ */
+
+public class CryptoFacilitiesFills extends CryptoFacilitiesResult {
+
+    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    private final Date serverTime;
+    private final List<CryptoFacilitiesFill> fills;
+
+
+    public CryptoFacilitiesFills(@JsonProperty("result") String result
+                  , @JsonProperty("serverTime") String strServerTime
+                  , @JsonProperty("error") String error
+                  , @JsonProperty("fills") List<CryptoFacilitiesFill> fills) throws ParseException {
+
+        super(result, error);
+
+        this.serverTime = DATE_FORMAT.parse(strServerTime);
+        this.fills = fills;	    
+    }
+
+    public List<CryptoFacilitiesFill> getFills() {
+          return fills;
+    }
+  
+    public Date getServerTime() {
+          return serverTime;
+    }
+
+    @Override
+    public String toString() {
+
+            String res = "CryptoFacilitiesFills [serverTime=" + DATE_FORMAT.format(serverTime) + ", fills=";
+            for(CryptoFacilitiesFill fill : fills)
+                    res = res + fill.toString() + ", ";
+            res = res + " ]";
+
+            return res;
+    }
+
+  
+
+}

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesTrade.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesTrade.java
@@ -12,6 +12,7 @@ import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
  * @author Jean-Christophe Laruelle
  */
 
+@Deprecated
 public class CryptoFacilitiesTrade extends CryptoFacilitiesResult {
 
 	private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd hh:mm:ss");

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesTrades.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesTrades.java
@@ -9,6 +9,7 @@ import com.xeiam.xchange.cryptofacilities.dto.CryptoFacilitiesResult;
  * @author Jean-Christophe Laruelle
  */
 
+@Deprecated
 public class CryptoFacilitiesTrades extends CryptoFacilitiesResult {
 
   private final List<CryptoFacilitiesTrade> trades;

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesAccountService.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesAccountService.java
@@ -29,7 +29,7 @@ public class CryptoFacilitiesAccountService extends CryptoFacilitiesAccountServi
   @Override
   public AccountInfo getAccountInfo() throws IOException {
 
-	  return CryptoFacilitiesAdapters.adaptBalance(getCryptoFacilitiesBalance(), exchange.getExchangeSpecification().getUserName());
+	  return CryptoFacilitiesAdapters.adaptAccount(getCryptoFacilitiesAccount(), exchange.getExchangeSpecification().getUserName());
 	  
   }
 

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesAccountServiceRaw.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesAccountServiceRaw.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.Map;
 
 import com.xeiam.xchange.Exchange;
+import com.xeiam.xchange.cryptofacilities.dto.account.CryptoFacilitiesAccount;
 import com.xeiam.xchange.cryptofacilities.dto.account.CryptoFacilitiesBalance;
 
 /**
@@ -23,11 +24,17 @@ public class CryptoFacilitiesAccountServiceRaw extends CryptoFacilitiesBasePolli
     super(exchange);
   }
 
+  @Deprecated
   public Map<String, BigDecimal> getCryptoFacilitiesBalance() throws IOException {
 
     CryptoFacilitiesBalance balanceResult = cryptoFacilities.balance(exchange.getExchangeSpecification().getApiKey(), signatureCreator, exchange.getNonceFactory());
     
     return balanceResult.getBalances();
+  }
+
+  public CryptoFacilitiesAccount getCryptoFacilitiesAccount() throws IOException {
+
+    return cryptoFacilities.account(exchange.getExchangeSpecification().getApiKey(), signatureCreator, exchange.getNonceFactory());    
   }
 
 }

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
@@ -71,7 +71,7 @@ public class CryptoFacilitiesTradeService extends CryptoFacilitiesTradeServiceRa
     @Override
     public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
-        return CryptoFacilitiesAdapters.adaptTrades(super.getCryptoFacilitiesTrades(100));
+        return CryptoFacilitiesAdapters.adaptFills(super.getCryptoFacilitiesFills());
     }
 
     @Override

--- a/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeServiceRaw.java
+++ b/xchange-cryptofacilities/src/main/java/com/xeiam/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeServiceRaw.java
@@ -8,6 +8,7 @@ import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesCancel;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesOpenOrders;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesOrder;
 import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesTrades;
+import com.xeiam.xchange.cryptofacilities.dto.marketdata.CryptoFacilitiesFills;
 import com.xeiam.xchange.currency.CurrencyPair;
 import com.xeiam.xchange.dto.Order.OrderType;
 import com.xeiam.xchange.dto.trade.LimitOrder;
@@ -64,6 +65,7 @@ public class CryptoFacilitiesTradeServiceRaw extends CryptoFacilitiesBasePolling
 	  return openOrders;
   }
 
+  @Deprecated
   public CryptoFacilitiesTrades getCryptoFacilitiesTrades(int number) throws IOException
   {
 	  CryptoFacilitiesTrades trades = null;
@@ -78,4 +80,16 @@ public class CryptoFacilitiesTradeServiceRaw extends CryptoFacilitiesBasePolling
   }
 
   
+  public CryptoFacilitiesFills getCryptoFacilitiesFills() throws IOException
+  {
+	  CryptoFacilitiesFills fills = null;
+	  
+	  try {
+		fills = cryptoFacilities.fills(exchange.getExchangeSpecification().getApiKey(), signatureCreator, exchange.getNonceFactory());
+	} catch (Exception e) {
+		return null;
+	}
+	  
+	  return fills;
+  }
 }

--- a/xchange-cryptofacilities/src/test/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesAccountJSONTest.java
+++ b/xchange-cryptofacilities/src/test/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesAccountJSONTest.java
@@ -1,0 +1,58 @@
+package com.xeiam.xchange.cryptofacilities.dto.marketdata;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.xeiam.xchange.cryptofacilities.dto.account.CryptoFacilitiesAccount;
+
+/**
+ * @author Panchen
+ */
+
+public class CryptoFacilitiesAccountJSONTest {
+
+	@Test
+	public void testUnmarshal() throws IOException {
+
+	    // Read in the JSON from the example resources
+	    InputStream is = CryptoFacilitiesAccountJSONTest.class.getResourceAsStream("/marketdata/example-account-data.json");
+
+	    // Use Jackson to parse it
+	    ObjectMapper mapper = new ObjectMapper();
+	    CryptoFacilitiesAccount cryptoFacilitiesAccount = mapper.readValue(is, CryptoFacilitiesAccount.class);
+	    
+	    // Verify that the example data was unmarshalled correctly
+	    assertThat(cryptoFacilitiesAccount.isSuccess()).isTrue();
+
+            assertThat(cryptoFacilitiesAccount.getBalances().get("f-xbt:usd-feb16-w4")).isEqualTo(new BigDecimal("50"));
+            assertThat(cryptoFacilitiesAccount.getBalances().get("f-xbt:usd-mar16-w1")).isEqualTo(new BigDecimal("-15"));
+            assertThat(cryptoFacilitiesAccount.getBalances().get("xbt")).isEqualTo(new BigDecimal("141.31756797"));
+            
+            assertThat(cryptoFacilitiesAccount.getAuxiliary().get("af")).isEqualTo(new BigDecimal("100.73891563"));
+            assertThat(cryptoFacilitiesAccount.getAuxiliary().get("pnl")).isEqualTo(new BigDecimal("12.42134766"));
+            assertThat(cryptoFacilitiesAccount.getAuxiliary().get("pv")).isEqualTo(new BigDecimal("153.73891563"));
+            assertThat(cryptoFacilitiesAccount.getAuxiliary().get("usd")).isEqualTo(new BigDecimal("-119012.92"));
+
+            assertThat(cryptoFacilitiesAccount.getMarginRequirements().get("im")).isEqualTo(new BigDecimal("52.8"));
+            assertThat(cryptoFacilitiesAccount.getMarginRequirements().get("mm")).isEqualTo(new BigDecimal("23.76"));
+            assertThat(cryptoFacilitiesAccount.getMarginRequirements().get("lt")).isEqualTo(new BigDecimal("39.6"));
+            assertThat(cryptoFacilitiesAccount.getMarginRequirements().get("tt")).isEqualTo(new BigDecimal("15.84"));
+                
+            assertThat(cryptoFacilitiesAccount.getTriggerEstimates().get("im")).isEqualTo(new BigDecimal("311"));
+            assertThat(cryptoFacilitiesAccount.getTriggerEstimates().get("mm")).isEqualTo(new BigDecimal("300"));
+            assertThat(cryptoFacilitiesAccount.getTriggerEstimates().get("lt")).isEqualTo(new BigDecimal("289"));
+            assertThat(cryptoFacilitiesAccount.getTriggerEstimates().get("tt")).isEqualTo(new BigDecimal("283"));
+
+        }
+
+
+}

--- a/xchange-cryptofacilities/src/test/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFillsJSONTest.java
+++ b/xchange-cryptofacilities/src/test/java/com/xeiam/xchange/cryptofacilities/dto/marketdata/CryptoFacilitiesFillsJSONTest.java
@@ -1,0 +1,50 @@
+package com.xeiam.xchange.cryptofacilities.dto.marketdata;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Panchen
+ */
+
+public class CryptoFacilitiesFillsJSONTest {
+
+	@Test
+	public void testUnmarshal() throws IOException {
+
+	    // Read in the JSON from the example resources
+	    InputStream is = CryptoFacilitiesFillsJSONTest.class.getResourceAsStream("/marketdata/example-fills-data.json");
+
+	    // Use Jackson to parse it
+	    ObjectMapper mapper = new ObjectMapper();
+	    CryptoFacilitiesFills cryptoFacilitiesFills = mapper.readValue(is, CryptoFacilitiesFills.class);
+	    
+	    // Verify that the example data was unmarshalled correctly
+	    assertThat(cryptoFacilitiesFills.isSuccess()).isTrue();
+	    
+	    List<CryptoFacilitiesFill> fills = cryptoFacilitiesFills.getFills();
+	    
+	    assertThat(fills.size()).isEqualTo(2);
+	    
+	    Iterator<CryptoFacilitiesFill> it = fills.iterator();
+	    CryptoFacilitiesFill fill = it.next();
+	    
+	    assertThat(fill.getOrderId()).isEqualTo("c18f0c17-9971-40e6-8e5b-10df05d422f0");
+	    assertThat(fill.getFillId()).isEqualTo("522d4e08-96e7-4b44-9694-bfaea8fe215e");
+            assertThat(fill.getSymbol()).isEqualTo("f-xbt:usd-sep16");	    
+	    assertThat(fill.getSide()).isEqualTo("buy");
+	    assertThat(fill.getSize()).isEqualTo(new BigDecimal("2"));	    
+	    assertThat(fill.getPrice()).isEqualTo(new BigDecimal("425.5"));
+	  }
+
+
+}

--- a/xchange-cryptofacilities/src/test/resources/marketdata/example-account-data.json
+++ b/xchange-cryptofacilities/src/test/resources/marketdata/example-account-data.json
@@ -1,0 +1,34 @@
+{
+    "result": "success",
+    "serverTime": "2016-02-25T09:45:53.818Z",
+    "account":
+        {
+            "balances":
+                {
+                    "f-xbt:usd-feb16-w4": 50,
+                    "f-xbt:usd-mar16-w1": -15,
+                    "xbt": 141.31756797
+                },
+            "auxiliary":
+                {
+                    "af": 100.73891563,
+                    "pnl": 12.42134766,
+                    "pv": 153.73891563,
+                    "usd": -119012.92
+                },
+            "marginRequirements":
+                {
+                    "im": 52.8,
+                    "mm": 23.76,
+                    "lt": 39.6,
+                    "tt": 15.84
+                },
+            "triggerEstimates":
+                {
+                    "im": 311,
+                    "mm": 300,
+                    "lt": 289,
+                    "tt": 283
+                }
+        }
+}

--- a/xchange-cryptofacilities/src/test/resources/marketdata/example-fills-data.json
+++ b/xchange-cryptofacilities/src/test/resources/marketdata/example-fills-data.json
@@ -1,0 +1,24 @@
+{
+        "result" : "success",
+        "serverTime" : "2016-02-25T09:45:53.818Z",
+        "fills" : [
+                {
+                        "fillTime" : "2016-02-25T09:47:01.000Z",
+                        "order_id" : "c18f0c17-9971-40e6-8e5b-10df05d422f0",
+                        "fill_id" : "522d4e08-96e7-4b44-9694-bfaea8fe215e",
+                        "symbol" : "f-xbt:usd-sep16",
+                        "side" : "buy",
+                        "size" : 2,
+                        "price" : 425.5
+                },
+                {
+                        "fillTime" : "2016-02-25T09:47:01.000Z",
+                        "order_id" : "c18f0c17-9971-40e6-8e5b-10df05d422f0",
+                        "fill_id" : "865cc3d0-12ee-4ac5-8418-233ea40e6b39",
+                        "symbol" : "f-xbt:usd-sep16",
+                        "side" : "buy",
+                        "size" : 3,
+                        "price" : 425.5
+                }
+        ]
+}


### PR DESCRIPTION
Addition of account and fills functionality from version 2 of the CF
api to the raw interface and hook up to the generic interface. #1204 

- getTradeHistory now returns associated order id's with trades(fills) using the new /v2/fills endpoint replacing the /trades endpoint.

- getAccountInfo now returns available BTC = total deposited BTC - BTC held for margin using the new /v2/account endpoint replacing the /balance endpoint.

/trades and /balance endpoints are deprecated but still available from the raw interface.