### PR TITLE
Minimal order size on anx of XRP has been changed

### DIFF
--- a/xchange-anx/src/main/resources/anxpro.json
+++ b/xchange-anx/src/main/resources/anxpro.json
@@ -123,7 +123,7 @@
       "priceScale": 8
     },
     "XRP/BTC": {
-      "minimumAmount": 500.00000,
+      "minimumAmount": 750.00000,
       "maximumAmount": 100000.00000000,
       "priceScale": 8
     }


### PR DESCRIPTION
Alison replied:
Hi,
Recently we have upgrade our website, the tradable Amount increased to 750.
Would you please try again?
Alison
Customer Support Team
ANX