### PR TITLE
Corrected meta data reported fee on bleutrade.

### DIFF
--- a/xchange-bleutrade/src/main/java/com/xeiam/xchange/bleutrade/BleutradeAdapters.java
+++ b/xchange-bleutrade/src/main/java/com/xeiam/xchange/bleutrade/BleutradeAdapters.java
@@ -151,12 +151,7 @@ public class BleutradeAdapters {
     }
 
     // https://bleutrade.com/help/fees_and_deadlines 11/25/2015 all == 0.25%
-    BigDecimal singleTxFee = new BigDecimal("0.0025");
-    // bleutrade gives a fee per currency rather than per exchange
-    // I suppose that the fee for both currencies is charged when a trade is made
-    // z = 1 - (1 - y) * (1 - x)
-    singleTxFee = singleTxFee.negate().add(BigDecimal.ONE);
-    BigDecimal txFee = singleTxFee.multiply(singleTxFee).negate().add(BigDecimal.ONE);
+    BigDecimal txFee = new BigDecimal("0.0025");
 
     for (BleutradeMarket bleutradeMarket : bleutradeMarkets) {
       CurrencyPair currencyPair = CurrencyPairDeserializer.getCurrencyPairFromString(bleutradeMarket.getMarketName());

--- a/xchange-bleutrade/src/test/java/com/xeiam/xchange/bleutrade/BleutradeExchangeTest.java
+++ b/xchange-bleutrade/src/test/java/com/xeiam/xchange/bleutrade/BleutradeExchangeTest.java
@@ -172,8 +172,8 @@ public class BleutradeExchangeTest extends BleutradeServiceTestSupport {
     Map<CurrencyPair, MarketMetaData> marketMetaDataMap = exchange.getMetaData().getMarketMetaDataMap();
     assertThat(marketMetaDataMap).hasSize(2);
     assertThat(marketMetaDataMap.get(CurrencyPair.DOGE_BTC).toString()).isEqualTo(
-        "MarketMetaData{tradingFee=0.00499375, minimumAmount=0.10000000, priceScale=8}");
+        "MarketMetaData{tradingFee=0.0025, minimumAmount=0.10000000, priceScale=8}");
     assertThat(marketMetaDataMap.get(BLEU_BTC_CP).toString()).isEqualTo(
-        "MarketMetaData{tradingFee=0.00499375, minimumAmount=1E-8, priceScale=8}");
+        "MarketMetaData{tradingFee=0.0025, minimumAmount=1E-8, priceScale=8}");
   }
 }

--- a/xchange-bleutrade/src/test/java/com/xeiam/xchange/bleutrade/BleutradeTestData.java
+++ b/xchange-bleutrade/src/test/java/com/xeiam/xchange/bleutrade/BleutradeTestData.java
@@ -92,15 +92,15 @@ public class BleutradeTestData {
 
   protected static MarketMetaData[] expectedMetaDataList() {
     return new MarketMetaData[]{
-      new MarketMetaData(new BigDecimal("0.00499375"), new BigDecimal("0.10000000"), 8),
-      new MarketMetaData(new BigDecimal("0.00499375"), new BigDecimal("0.00000001"), 8)
+      new MarketMetaData(new BigDecimal("0.0025"), new BigDecimal("0.10000000"), 8),
+      new MarketMetaData(new BigDecimal("0.0025"), new BigDecimal("0.00000001"), 8)
     };
   }
 
   protected static String[] expectedMetaDataStr() {
     return new String[]{
-      "MarketMetaData{tradingFee=0.00499375, minimumAmount=0.10000000, priceScale=8}",
-      "MarketMetaData{tradingFee=0.00499375, minimumAmount=1E-8, priceScale=8}"
+      "MarketMetaData{tradingFee=0.0025, minimumAmount=0.10000000, priceScale=8}",
+      "MarketMetaData{tradingFee=0.0025, minimumAmount=1E-8, priceScale=8}"
     };
   }
 }


### PR DESCRIPTION
Tested on a real trade. A trade has 0.25 % fee. (old assumption that fee was calculated for base and counter coin was incorrect)