### PR TITLE
Add back new order multi and cancel order multi

### DIFF
--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/BitfinexAuthenticated.java
@@ -19,9 +19,13 @@ import com.xeiam.xchange.bitfinex.v1.dto.account.BitfinexWithdrawalResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActiveCreditsRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActivePositionsResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOfferRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNonceOnlyRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusRequest;
@@ -44,6 +48,11 @@ public interface BitfinexAuthenticated extends Bitfinex {
       @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexNewOrderRequest newOrderRequest) throws IOException, BitfinexException;
 
   @POST
+  @Path("order/new/multi")
+  BitfinexNewOrderMultiResponse newOrderMulti(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
+      @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexNewOrderMultiRequest newOrderMultiRequest) throws IOException, BitfinexException;
+
+  @POST
   @Path("offer/new")
   BitfinexOfferStatusResponse newOffer(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
       @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexNewOfferRequest newOfferRequest) throws IOException, BitfinexException;
@@ -57,6 +66,11 @@ public interface BitfinexAuthenticated extends Bitfinex {
   @Path("order/cancel")
   BitfinexOrderStatusResponse cancelOrders(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
       @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexCancelOrderRequest cancelOrderRequest) throws IOException, BitfinexException;
+
+  @POST
+  @Path("order/cancel/multi")
+  BitfinexCancelOrderMultiResponse cancelOrderMulti(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
+      @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexCancelOrderMultiRequest cancelOrderRequest) throws IOException, BitfinexException;
 
   @POST
   @Path("offer/cancel")

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
@@ -13,10 +13,14 @@ import com.xeiam.xchange.bitfinex.v1.dto.account.BitfinexWithdrawalResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActiveCreditsRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexActivePositionsResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewHiddenOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOfferRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrder;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiRequest;
+import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiResponse;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexNonceOnlyRequest;
 import com.xeiam.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusRequest;
@@ -48,8 +52,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexOrderStatusResponse[] getBitfinexOpenOrders() throws IOException {
 
     try {
-      BitfinexOrderStatusResponse[] activeOrders =
-          bitfinex.activeOrders(apiKey, payloadCreator, signatureCreator, new BitfinexNonceOnlyRequest("/v1/orders", String.valueOf(exchange.getNonceFactory().createValue())));
+      BitfinexOrderStatusResponse[] activeOrders = bitfinex.activeOrders(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNonceOnlyRequest("/v1/orders", String.valueOf(exchange.getNonceFactory().createValue())));
       return activeOrders;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -59,8 +63,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexOfferStatusResponse[] getBitfinexOpenOffers() throws IOException {
 
     try {
-      BitfinexOfferStatusResponse[] activeOffers =
-          bitfinex.activeOffers(apiKey, payloadCreator, signatureCreator, new BitfinexNonceOnlyRequest("/v1/offers", String.valueOf(exchange.getNonceFactory().createValue())));
+      BitfinexOfferStatusResponse[] activeOffers = bitfinex.activeOffers(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNonceOnlyRequest("/v1/offers", String.valueOf(exchange.getNonceFactory().createValue())));
       return activeOffers;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -74,16 +78,17 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
     String orderType = bitfinexOrderType.toString();
 
     try {
-      BitfinexOrderStatusResponse newOrder =
-          bitfinex.newOrder(apiKey, payloadCreator, signatureCreator, new BitfinexNewOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, marketOrder.getTradableAmount(),
-              BigDecimal.ONE, "bitfinex", type, orderType));
+      BitfinexOrderStatusResponse newOrder = bitfinex.newOrder(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNewOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, marketOrder.getTradableAmount(), BigDecimal.ONE,
+              "bitfinex", type, orderType));
       return newOrder;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
     }
   }
 
-  public BitfinexOrderStatusResponse placeBitfinexLimitOrder(LimitOrder limitOrder, BitfinexOrderType bitfinexOrderType, boolean hidden) throws IOException {
+  public BitfinexOrderStatusResponse placeBitfinexLimitOrder(LimitOrder limitOrder, BitfinexOrderType bitfinexOrderType, boolean hidden)
+      throws IOException {
 
     String pair = BitfinexUtils.toPairString(limitOrder.getCurrencyPair());
     String type = limitOrder.getType().equals(Order.OrderType.BID) ? "buy" : "sell";
@@ -91,11 +96,11 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
 
     BitfinexNewOrderRequest request;
     if (hidden) {
-      request =
-          new BitfinexNewHiddenOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, limitOrder.getTradableAmount(), limitOrder.getLimitPrice(), "bitfinex", type, orderType);
-    }
-    else {
-      request = new BitfinexNewOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, limitOrder.getTradableAmount(), limitOrder.getLimitPrice(), "bitfinex", type, orderType);
+      request = new BitfinexNewHiddenOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, limitOrder.getTradableAmount(),
+          limitOrder.getLimitPrice(), "bitfinex", type, orderType);
+    } else {
+      request = new BitfinexNewOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), pair, limitOrder.getTradableAmount(),
+          limitOrder.getLimitPrice(), "bitfinex", type, orderType);
     }
 
     try {
@@ -106,58 +111,58 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
     }
   }
 
-  /*
-   * public BitfinexNewOrderMultiResponse placeBitfinexOrderMulti(List<Order> orders, BitfinexOrderType bitfinexOrderType)
-   * throws IOException {
-   * BitfinexNewOrder[] bitfinexOrders = new BitfinexNewOrder[orders.size()];
-   * for (int i = 0; i < bitfinexOrders.length; i++) {
-   * Order o = orders.get(i);
-   * if (o instanceof LimitOrder) {
-   * LimitOrder limitOrder = (LimitOrder) o;
-   * String pair = BitfinexUtils.toPairString(limitOrder.getCurrencyPair());
-   * String type = limitOrder.getType().equals(Order.OrderType.BID) ? "buy" : "sell";
-   * String orderType = bitfinexOrderType.toString();
-   * bitfinexOrders[i] = new BitfinexNewOrder(pair, "bitfinex", type, orderType, limitOrder.getTradableAmount(), limitOrder.getLimitPrice());
-   * } else if (o instanceof MarketOrder) {
-   * MarketOrder marketOrder = (MarketOrder) o;
-   * String pair = BitfinexUtils.toPairString(marketOrder.getCurrencyPair());
-   * String type = marketOrder.getType().equals(Order.OrderType.BID) ? "buy" : "sell";
-   * String orderType = bitfinexOrderType.toString();
-   * bitfinexOrders[i] = new BitfinexNewOrder(pair, "bitfinex", type, orderType, marketOrder.getTradableAmount(), BigDecimal.ONE);
-   * }
-   * }
-   * BitfinexNewOrderMultiRequest request = new BitfinexNewOrderMultiRequest(String.valueOf(exchange.getNonceFactory().createValue()), bitfinexOrders);
-   * try {
-   * BitfinexNewOrderMultiResponse response = bitfinex.newOrderMulti(apiKey, payloadCreator, signatureCreator, request);
-   * return response;
-   * } catch (BitfinexException e) {
-   * throw new ExchangeException(e.getMessage());
-   * }
-   * }
-   */
+  public BitfinexNewOrderMultiResponse placeBitfinexOrderMulti(List<Order> orders, BitfinexOrderType bitfinexOrderType) throws IOException {
+    
+    BitfinexNewOrder[] bitfinexOrders = new BitfinexNewOrder[orders.size()];
+    
+    for (int i = 0; i < bitfinexOrders.length; i++) {
+      Order o = orders.get(i);
+      if (o instanceof LimitOrder) {
+        LimitOrder limitOrder = (LimitOrder) o;
+        String pair = BitfinexUtils.toPairString(limitOrder.getCurrencyPair());
+        String type = limitOrder.getType().equals(Order.OrderType.BID) ? "buy" : "sell";
+        String orderType = bitfinexOrderType.toString();
+        bitfinexOrders[i] = new BitfinexNewOrder(pair, "bitfinex", type, orderType, limitOrder.getTradableAmount(), limitOrder.getLimitPrice());
+      } else if (o instanceof MarketOrder) {
+        MarketOrder marketOrder = (MarketOrder) o;
+        String pair = BitfinexUtils.toPairString(marketOrder.getCurrencyPair());
+        String type = marketOrder.getType().equals(Order.OrderType.BID) ? "buy" : "sell";
+        String orderType = bitfinexOrderType.toString();
+        bitfinexOrders[i] = new BitfinexNewOrder(pair, "bitfinex", type, orderType, marketOrder.getTradableAmount(), BigDecimal.ONE);
+      }
+    }
+    BitfinexNewOrderMultiRequest request = new BitfinexNewOrderMultiRequest(String.valueOf(exchange.getNonceFactory().createValue()), bitfinexOrders);
+    try {
+      BitfinexNewOrderMultiResponse response = bitfinex.newOrderMulti(apiKey, payloadCreator, signatureCreator, request);
+      return response;
+    } catch (BitfinexException e) {
+      throw new ExchangeException(e.getMessage());
+    }
+  }
 
   public BitfinexOfferStatusResponse placeBitfinexFixedRateLoanOrder(FixedRateLoanOrder loanOrder, BitfinexOrderType orderType) throws IOException {
 
     String direction = loanOrder.getType() == OrderType.BID ? "loan" : "lend";
 
     try {
-      BitfinexOfferStatusResponse newOrderResponse =
-          bitfinex.newOffer(apiKey, payloadCreator, signatureCreator, new BitfinexNewOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), loanOrder.getCurrency(), loanOrder
-              .getTradableAmount(), loanOrder.getRate(), loanOrder.getDayPeriod(), direction));
+      BitfinexOfferStatusResponse newOrderResponse = bitfinex.newOffer(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNewOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), loanOrder.getCurrency(),
+              loanOrder.getTradableAmount(), loanOrder.getRate(), loanOrder.getDayPeriod(), direction));
       return newOrderResponse;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
     }
   }
 
-  public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRateLoanOrder loanOrder, BitfinexOrderType orderType) throws IOException {
+  public BitfinexOfferStatusResponse placeBitfinexFloatingRateLoanOrder(FloatingRateLoanOrder loanOrder, BitfinexOrderType orderType)
+      throws IOException {
 
     String direction = loanOrder.getType() == OrderType.BID ? "loan" : "lend";
 
     try {
-      BitfinexOfferStatusResponse newOrderResponse =
-          bitfinex.newOffer(apiKey, payloadCreator, signatureCreator, new BitfinexNewOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), loanOrder.getCurrency(), loanOrder
-              .getTradableAmount(), new BigDecimal("0.0"), loanOrder.getDayPeriod(), direction));
+      BitfinexOfferStatusResponse newOrderResponse = bitfinex.newOffer(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNewOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), loanOrder.getCurrency(),
+              loanOrder.getTradableAmount(), new BigDecimal("0.0"), loanOrder.getDayPeriod(), direction));
       return newOrderResponse;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -167,13 +172,13 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public boolean cancelBitfinexOrder(String orderId) throws IOException {
 
     try {
-      bitfinex.cancelOrders(apiKey, payloadCreator, signatureCreator, new BitfinexCancelOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
+      bitfinex.cancelOrders(apiKey, payloadCreator, signatureCreator,
+          new BitfinexCancelOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
       return true;
     } catch (BitfinexException e) {
       if (e.getMessage().equals("Order could not be cancelled.")) {
         return false;
-      }
-      else {
+      } else {
         throw new ExchangeException(e.getMessage());
       }
     }
@@ -188,7 +193,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
     }
 
     try {
-      // bitfinex.cancelOrderMulti(apiKey, payloadCreator, signatureCreator, new BitfinexCancelOrderMultiRequest(String.valueOf(exchange.getNonceFactory().createValue()), cancelOrderIds));
+      bitfinex.cancelOrderMulti(apiKey, payloadCreator, signatureCreator,
+          new BitfinexCancelOrderMultiRequest(String.valueOf(exchange.getNonceFactory().createValue()), cancelOrderIds));
       return true;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -198,8 +204,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexOfferStatusResponse cancelBitfinexOffer(String offerId) throws IOException {
 
     try {
-      BitfinexOfferStatusResponse cancelResponse =
-          bitfinex.cancelOffer(apiKey, payloadCreator, signatureCreator, new BitfinexCancelOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(offerId)));
+      BitfinexOfferStatusResponse cancelResponse = bitfinex.cancelOffer(apiKey, payloadCreator, signatureCreator,
+          new BitfinexCancelOfferRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(offerId)));
       return cancelResponse;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -209,8 +215,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexOrderStatusResponse getBitfinexOrderStatus(String orderId) throws IOException {
 
     try {
-      BitfinexOrderStatusResponse orderStatus =
-          bitfinex.orderStatus(apiKey, payloadCreator, signatureCreator, new BitfinexOrderStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
+      BitfinexOrderStatusResponse orderStatus = bitfinex.orderStatus(apiKey, payloadCreator, signatureCreator,
+          new BitfinexOrderStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
       return orderStatus;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -221,8 +227,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexOfferStatusResponse getBitfinexOfferStatusResponse(String offerId) throws IOException {
 
     try {
-      BitfinexOfferStatusResponse offerStatus =
-          bitfinex.offerStatus(apiKey, payloadCreator, signatureCreator, new BitfinexOfferStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(offerId)));
+      BitfinexOfferStatusResponse offerStatus = bitfinex.offerStatus(apiKey, payloadCreator, signatureCreator,
+          new BitfinexOfferStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(offerId)));
       return offerStatus;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -232,8 +238,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexTradeResponse[] getBitfinexTradeHistory(String symbol, long timestamp, int limit) throws IOException {
 
     try {
-      BitfinexTradeResponse[] trades =
-          bitfinex.pastTrades(apiKey, payloadCreator, signatureCreator, new BitfinexPastTradesRequest(String.valueOf(exchange.getNonceFactory().createValue()), symbol, timestamp, limit));
+      BitfinexTradeResponse[] trades = bitfinex.pastTrades(apiKey, payloadCreator, signatureCreator,
+          new BitfinexPastTradesRequest(String.valueOf(exchange.getNonceFactory().createValue()), symbol, timestamp, limit));
       return trades;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -243,7 +249,8 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
   public BitfinexCreditResponse[] getBitfinexActiveCredits() throws IOException {
 
     try {
-      BitfinexCreditResponse[] credits = bitfinex.activeCredits(apiKey, payloadCreator, signatureCreator, new BitfinexActiveCreditsRequest(String.valueOf(exchange.getNonceFactory().createValue())));
+      BitfinexCreditResponse[] credits = bitfinex.activeCredits(apiKey, payloadCreator, signatureCreator,
+          new BitfinexActiveCreditsRequest(String.valueOf(exchange.getNonceFactory().createValue())));
       return credits;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());
@@ -252,17 +259,16 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
 
   public String withdraw(String withdrawType, String walletSelected, BigDecimal amount, String address) throws IOException {
 
-    BitfinexWithdrawalResponse[] withdrawRepsonse =
-        bitfinex.withdraw(apiKey, payloadCreator, signatureCreator, new BitfinexWithdrawalRequest(String.valueOf(exchange.getNonceFactory().createValue()), withdrawType, walletSelected, amount,
-            address));
+    BitfinexWithdrawalResponse[] withdrawRepsonse = bitfinex.withdraw(apiKey, payloadCreator, signatureCreator,
+        new BitfinexWithdrawalRequest(String.valueOf(exchange.getNonceFactory().createValue()), withdrawType, walletSelected, amount, address));
     return withdrawRepsonse[0].getWithdrawalId();
   }
 
   public BitfinexActivePositionsResponse[] getBitfinexActivePositions() throws IOException {
 
     try {
-      BitfinexActivePositionsResponse[] activePositions =
-          bitfinex.activePositions(apiKey, payloadCreator, signatureCreator, new BitfinexNonceOnlyRequest("/v1/positions", String.valueOf(exchange.getNonceFactory().createValue())));
+      BitfinexActivePositionsResponse[] activePositions = bitfinex.activePositions(apiKey, payloadCreator, signatureCreator,
+          new BitfinexNonceOnlyRequest("/v1/positions", String.valueOf(exchange.getNonceFactory().createValue())));
       return activePositions;
     } catch (BitfinexException e) {
       throw new ExchangeException(e.getMessage());

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
@@ -111,7 +111,7 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
     }
   }
 
-  public BitfinexNewOrderMultiResponse placeBitfinexOrderMulti(List<Order> orders, BitfinexOrderType bitfinexOrderType) throws IOException {
+  public BitfinexNewOrderMultiResponse placeBitfinexOrderMulti(List<? extends Order> orders, BitfinexOrderType bitfinexOrderType) throws IOException {
     
     BitfinexNewOrder[] bitfinexOrders = new BitfinexNewOrder[orders.size()];
     

--- a/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/com/xeiam/xchange/bitfinex/v1/service/polling/BitfinexTradeServiceRaw.java
@@ -131,6 +131,7 @@ public class BitfinexTradeServiceRaw extends BitfinexBasePollingService {
         bitfinexOrders[i] = new BitfinexNewOrder(pair, "bitfinex", type, orderType, marketOrder.getTradableAmount(), BigDecimal.ONE);
       }
     }
+    
     BitfinexNewOrderMultiRequest request = new BitfinexNewOrderMultiRequest(String.valueOf(exchange.getNonceFactory().createValue()), bitfinexOrders);
     try {
       BitfinexNewOrderMultiResponse response = bitfinex.newOrderMulti(apiKey, payloadCreator, signatureCreator, request);


### PR DESCRIPTION
I am not sure why this was removed. It was perhaps a little quirky to get working initially because the list of orders for new order multi was < Order > and not <? extends Order>, forcing a cast, but I have corrected that. There are other diffs for formatting that can be reverted if desired. I would like to know why the code was commented out if anyone knows.