### PR TITLE
Cexio now also supports eth

### DIFF
--- a/xchange-cexio/src/main/resources/cexio.json
+++ b/xchange-cexio/src/main/resources/cexio.json
@@ -12,6 +12,10 @@
       "priceScale": 3,
       "minimumAmount": 1.200000000
     },
+    "ETH/USD": {
+      "priceScale": 3,
+      "minimumAmount": 0.300000000
+    },
     "GHS/BTC": {
       "priceScale": 8,
       "minimumAmount": 1.000000000
@@ -20,6 +24,10 @@
       "priceScale": 8,
       "minimumAmount": 1.200000000
     },
+    "ETH/BTC": {
+      "priceScale": 8,
+      "minimumAmount": 0.300000000
+    },    
     "BTC/EUR": {
       "priceScale": 4,
       "minimumAmount": 0.010000000


### PR DESCRIPTION
Cexio now also supports eth:
Welcome the launch of Ethers on CEX.IO!
We are glad to announce launching Ether trading on CEX.IO.
From now on, you can trade ETH/BTC and ETH/USD, as well as simply buy Ethers with your Visa or MasterCard, or via bank transfer.
We at CEX.IO are glad to support outstanding innovations, such as Ethereum, and welcome everyone to buy, sell, and trade Ethers.