### PR TITLE
Btce signals DASH as DSH

### DIFF
--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
@@ -134,7 +134,7 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
     if (params instanceof TradeHistoryParamCurrencyPair) {
       CurrencyPair pair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
       if (pair != null) {
-        btcrPair = BTCEAdapters.adaptCurrencyPair(pair);
+        btcrPair = BTCEAdapters.getPair(pair);
       }
     }
 


### PR DESCRIPTION
Btce added eth and DASH. But dash is signaled as dsh which is a different coin. 
Translate the incorrect dsh in dash.