### PR TITLE
Updated cexio with new fee structure

### DIFF
--- a/xchange-cexio/src/main/resources/cexio.json
+++ b/xchange-cexio/src/main/resources/cexio.json
@@ -2,42 +2,52 @@
   "currencyPair": {
     "BTC/USD": {
       "priceScale": 4,
+      "tradingFee": 0.002,
       "minimumAmount": 0.010000000
     },
     "GHS/USD": {
       "priceScale": 8,
+      "tradingFee": 0.002,
       "minimumAmount": 1.000000000
     },
     "LTC/USD": {
       "priceScale": 3,
+      "tradingFee": 0.002,
       "minimumAmount": 1.200000000
-    },
-    "ETH/USD": {
-      "priceScale": 3,
-      "minimumAmount": 0.500000000
     },
     "GHS/BTC": {
       "priceScale": 8,
+      "tradingFee": 0.0000,
       "minimumAmount": 1.000000000
     },
     "LTC/BTC": {
       "priceScale": 8,
+      "tradingFee": 0.0000,
       "minimumAmount": 1.200000000
     },
     "ETH/BTC": {
       "priceScale": 8,
+      "tradingFee": 0.0000,
       "minimumAmount": 0.500000000
-    },    
+    },
+    "ETH/USD": {
+      "priceScale": 3,
+      "tradingFee": 0.002,
+      "minimumAmount": 0.500000000
+    },
     "BTC/EUR": {
       "priceScale": 4,
+      "tradingFee": 0.001,
       "minimumAmount": 0.010000000
     },
     "LTC/EUR": {
       "priceScale": 3,
+      "tradingFee": 0.001,
       "minimumAmount": 1.200000000
     },
     "BTC/RUB": {
       "priceScale": 2,
+      "tradingFee": 0.001,
       "minimumAmount": 0.010000000
     }
   },


### PR DESCRIPTION
https://cex.io/transaction-fee

Meet great news from CEX.IO!

To express our support for crypto, we have set the fee for trading cryptocurrency pairs to 0%. EUR and RUB pairs experienced fee halving down to 0.1%, which in our opinion will drive growth of respective markets at CEX.IO

The full updated fee schedule is now as follows:

ETH/BTC: 	0%
LTC/BTC: 	0%
GHS/BTC: 	0%
BTC/EUR: 	0.1%
LTC/EUR: 	0.1%
BTC/RUB: 	0.1%
BTC/USD: 	0.2%
LTC/USD: 	0.2%
ETH/USD: 	0.2%
GHS/USD: 	0.2%

We welcome you to enjoy the ease of instant deposits and withdrawals to payment cards, extremely low fees for SEPA payments, as well as trading at far better conditions. Thank you for using CEX.IO.