### PR TITLE
Kraken removed NMC market

### DIFF
--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -52,10 +52,6 @@
       "priceScale": 5,
       "minimumAmount": 0.010000000      
     },
-    "BTC/NMC": {
-      "priceScale": 5,
-      "minimumAmount": 0.010000000      
-    },
     "BTC/DOGE": {
       "priceScale": 1,
       "minimumAmount": 0.010000000      


### PR DESCRIPTION
Kraken removed NMC market, http://blog.kraken.com/post/144921846637/kraken-delists-namecoin