### PR TITLE
Poloniex: retrieve all balances (including margin + lending balances)

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
@@ -1,26 +1,19 @@
 package org.knowm.xchange.poloniex;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.HashMap;
-
-import javax.annotation.Nullable;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.knowm.xchange.poloniex.dto.account.PoloniexBalance;
 import org.knowm.xchange.poloniex.dto.account.WithdrawalResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexOpenOrder;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexTradeResponse;
 import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
-
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import javax.annotation.Nullable;
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
 
 /**
  * @author Zach Holmes
@@ -33,7 +26,7 @@ public interface PoloniexAuthenticated {
   @POST
   @FormParam("command")
   HashMap<String, PoloniexBalance> returnCompleteBalances(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+      @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("account") String account) throws PoloniexException, IOException;
 
   @POST
   @FormParam("command")

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexAccountServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexAccountServiceRaw.java
@@ -1,12 +1,5 @@
 package org.knowm.xchange.poloniex.service.polling;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.Balance;
@@ -14,6 +7,12 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.poloniex.PoloniexAdapters;
 import org.knowm.xchange.poloniex.PoloniexException;
 import org.knowm.xchange.poloniex.dto.account.PoloniexBalance;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * @author Zach Holmes
@@ -33,7 +32,8 @@ public class PoloniexAccountServiceRaw extends PoloniexBasePollingService {
 
   public List<Balance> getWallets() throws IOException {
     try {
-      HashMap<String, PoloniexBalance> response = poloniexAuthenticated.returnCompleteBalances(apiKey, signatureCreator, exchange.getNonceFactory());
+      // using account="all" for margin + lending balances
+      HashMap<String, PoloniexBalance> response = poloniexAuthenticated.returnCompleteBalances(apiKey, signatureCreator, exchange.getNonceFactory(), "all");
       return PoloniexAdapters.adaptPoloniexBalances(response);
     } catch (PoloniexException e) {
       throw new ExchangeException(e.getError());

--- a/xchange-poloniex/src/test/java/si/mazi/rescu/PoloniexAccountJsonTest.java
+++ b/xchange-poloniex/src/test/java/si/mazi/rescu/PoloniexAccountJsonTest.java
@@ -1,17 +1,15 @@
 package si.mazi.rescu;
 
-import java.lang.reflect.Method;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Assert;
 import org.junit.Test;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.knowm.xchange.poloniex.PoloniexAuthenticated;
 import org.knowm.xchange.poloniex.PoloniexException;
-
 import si.mazi.rescu.serialization.jackson.JacksonConfigureListener;
 import si.mazi.rescu.serialization.jackson.JacksonMapper;
 import si.mazi.rescu.serialization.jackson.JacksonResponseReader;
+
+import java.lang.reflect.Method;
 
 public class PoloniexAccountJsonTest {
 
@@ -27,7 +25,7 @@ public class PoloniexAccountJsonTest {
     InvocationResult invocationResult = new InvocationResult("{\"error\":\"Invalid API key\\/secret pair.\"}", 200);
 
     Method apiMethod = PoloniexAuthenticated.class.getDeclaredMethod("returnCompleteBalances", String.class, ParamsDigest.class,
-        SynchronizedValueFactory.class);
+        SynchronizedValueFactory.class, String.class);
     RestMethodMetadata balances = RestMethodMetadata.create(apiMethod, "", "");
 
     try {


### PR DESCRIPTION
added parameter "account='all'" for retrieving all balances (including margin + lending balances).

As described on https://poloniex.com/support/api/:
> (returnCompleteBalances) set the "account" POST parameter to "all" to include your margin and lending accounts. 