### PR TITLE
Fix for  #1269

### DIFF
--- a/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/dto/trade/OpenOrdersJSONTest.java
+++ b/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/dto/trade/OpenOrdersJSONTest.java
@@ -27,7 +27,7 @@ public class OpenOrdersJSONTest {
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     ANXOpenOrder[] anxOpenOrders = mapper.readValue(is, ANXOpenOrder[].class);
 
-    // System.out.println(new Date(anxOpenOrders[0].getDate()));
+    // System.out.println(new Date(anxOpenOrders[0].getTimestamp()));
 
     // Verify that the example data was unmarshalled correctly
     Assert.assertEquals("7eecf4b2-5785-4500-a5d4-f3f8c924395c", anxOpenOrders[1].getOid());

--- a/xchange-core/src/main/java/org/knowm/xchange/utils/DateUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/DateUtils.java
@@ -59,6 +59,8 @@ public class DateUtils {
   public static Date fromISODateString(String isoFormattedDate) throws InvalidFormatException {
 
     SimpleDateFormat isoDateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    // set UTC time zone - 'Z' indicates it
+    isoDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
     try {
       return isoDateFormat.parse(isoFormattedDate);
     } catch (ParseException e) {

--- a/xchange-core/src/test/java/org/knowm/xchange/utils/DateUtilsTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/utils/DateUtilsTest.java
@@ -1,0 +1,39 @@
+package org.knowm.xchange.utils;
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import org.junit.Test;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import static org.junit.Assert.assertEquals;
+
+public class DateUtilsTest {
+
+    private final DateFormat dateFormat;
+
+    public DateUtilsTest() {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        dateFormat.setTimeZone(tz);
+    }
+
+    @Test
+    public void testFromISODateString() throws Exception {
+        String input = "2016-06-10T12:16:11.717Z";
+        Date expectedOutput = dateFormat.parse("2016-06-10T12:16:11.717");
+
+        assertEquals(expectedOutput, DateUtils.fromISODateString(input));
+    }
+
+    @Test(expected = InvalidFormatException.class)
+    public void testFromISODateStringWrongTimezone() throws Exception {
+
+        String input = "2016-06-10T12:16:11.717";
+        Date expectedOutput = dateFormat.parse("2016-06-10T12:16:11.717");
+
+        assertEquals(expectedOutput, DateUtils.fromISODateString(input));
+    }
+}

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/ItBitAdapters.java
@@ -13,6 +13,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.TimeZone;
 
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
@@ -35,11 +36,16 @@ import org.knowm.xchange.itbit.v1.dto.marketdata.ItBitTrades;
 import org.knowm.xchange.itbit.v1.dto.trade.ItBitOrder;
 import org.knowm.xchange.utils.DateUtils;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public final class ItBitAdapters {
 
   private static final OpenOrders noOpenOrders = new OpenOrders(Collections.<LimitOrder> emptyList());
   private static final String DATE_FORMAT_STRING = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
   private static final DecimalFormatSymbols CUSTOM_SYMBOLS = new DecimalFormatSymbols();
+  private static Pattern TIMESTAMP_PATTERN = Pattern.compile("(.*\\.[0-9]{3})0000Z$");
+
   static {
     CUSTOM_SYMBOLS.setDecimalSeparator('.');
   }
@@ -90,7 +96,7 @@ public final class ItBitAdapters {
     return parse;
   }
 
-  public static Trades adaptTrades(ItBitTrades trades, CurrencyPair currencyPair) {
+  public static Trades adaptTrades(ItBitTrades trades, CurrencyPair currencyPair) throws InvalidFormatException {
 
     List<Trade> tradesList = new ArrayList<Trade>(trades.getCount());
     long lastTradeId = 0;
@@ -104,9 +110,16 @@ public final class ItBitAdapters {
     return new Trades(tradesList, lastTradeId, TradeSortType.SortByID);
   }
 
-  public static Trade adaptTrade(ItBitTrade trade, CurrencyPair currencyPair) {
+  public static Trade adaptTrade(ItBitTrade trade, CurrencyPair currencyPair) throws InvalidFormatException {
+    String timestamp = trade.getTimestamp();
 
-    Date date = DateUtils.fromMillisUtc(trade.getDate() * 1000L);
+    //matcher instantiated each time for adaptTrade to be thread-safe
+    Matcher matcher = TIMESTAMP_PATTERN.matcher(timestamp);
+    //truncate sub-millisecond zeros
+    if (matcher.matches()) {
+      timestamp = matcher.group(1) + "Z";
+    }
+    Date date = DateUtils.fromISODateString(timestamp);
     final String tradeId = String.valueOf(trade.getTid());
 
     return new Trade(null, trade.getAmount(), currencyPair, trade.getPrice(), date, tradeId);

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/dto/marketdata/ItBitTrade.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/dto/marketdata/ItBitTrade.java
@@ -1,21 +1,21 @@
 package org.knowm.xchange.itbit.v1.dto.marketdata;
 
-import java.math.BigDecimal;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
 
 public class ItBitTrade {
 
   private final BigDecimal amount;
-  private final long date;
+  private final String timestamp;
   private final BigDecimal price;
   private final long tid;
 
-  public ItBitTrade(@JsonProperty("amount") BigDecimal amount, @JsonProperty("date") long date, @JsonProperty("price") BigDecimal price,
+  public ItBitTrade(@JsonProperty("amount") BigDecimal amount, @JsonProperty("timestamp") String timestamp, @JsonProperty("price") BigDecimal price,
       @JsonProperty("tid") long tid) {
 
     this.amount = amount;
-    this.date = date;
+    this.timestamp = timestamp;
     this.price = price;
     this.tid = tid;
   }
@@ -25,9 +25,9 @@ public class ItBitTrade {
     return amount;
   }
 
-  public long getDate() {
+  public String getTimestamp() {
 
-    return date;
+    return timestamp;
   }
 
   public BigDecimal getPrice() {
@@ -46,8 +46,8 @@ public class ItBitTrade {
     StringBuilder builder = new StringBuilder();
     builder.append("ItBitTrade [amount=");
     builder.append(amount);
-    builder.append(", date=");
-    builder.append(date);
+    builder.append(", timestamp=");
+    builder.append(timestamp);
     builder.append(", price=");
     builder.append(price);
     builder.append(", tid=");


### PR DESCRIPTION
Two things fixed:
- ISO8601 parsing – if text ends with 'Z', it is always in UTC 
- change in itbit API – returns timestamp as ISO8601 text instead of date representing millis from start of era.