### PR TITLE
FIX: either api url has changed or this newer worked.

### DIFF
--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRock.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRock.java
@@ -15,14 +15,17 @@ import org.knowm.xchange.therock.dto.marketdata.TheRockOrderBook;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTicker;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
 
-@Path("v1")
+//see https://www.therocktrading.com/pages/api
+@Path("api")
 @Produces(MediaType.APPLICATION_JSON)
 public interface TheRock {
 
+  //TODO review - inconistent https://www.therocktrading.com/pages/api
   @GET
   @Path("funds/{id}/ticker")
   TheRockTicker getTicker(@PathParam("id") Pair currencyPair) throws TheRockException, IOException;
 
+  //TODO review - inconistent https://www.therocktrading.com/pages/api
   @GET
   @Path("funds/{id}/orderbook")
   TheRockOrderBook getOrderbook(@PathParam("id") Pair currencyPair) throws TheRockException, IOException;


### PR DESCRIPTION
TheRock returns 404 because URL is different.

+ look at getTicker and getOrderbook because API documentation says other paths.