### PR TITLE
Added flagging capability for ExchangeFactory

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/BaseExchange.java
@@ -36,9 +36,14 @@ public abstract class BaseExchange implements Exchange {
   protected PollingTradeService pollingTradeService;
   protected PollingAccountService pollingAccountService;
   protected StreamingExchangeService streamingExchangeService;
-
+  
   @Override
   public void applySpecification(ExchangeSpecification exchangeSpecification) {
+    applySpecification(exchangeSpecification, true);
+  }
+
+  @Override
+  public void applySpecification(ExchangeSpecification exchangeSpecification, boolean doRemoteInit) {
 
     ExchangeSpecification defaultSpecification = getDefaultExchangeSpecification();
 
@@ -113,13 +118,15 @@ public abstract class BaseExchange implements Exchange {
     }
 
     initServices();
-
-    try {
-      remoteInit();
-    } catch (ExchangeException e) {
-      throw e;
-    } catch (IOException e) {
-      throw new ExchangeException(e.getMessage());
+    
+    if (doRemoteInit) {
+      try {
+        remoteInit();
+      } catch (ExchangeException e) {
+        throw e;
+      } catch (IOException e) {
+        throw new ExchangeException(e.getMessage());
+      }
     }
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/Exchange.java
@@ -67,6 +67,14 @@ public interface Exchange {
    * @param exchangeSpecification The {@link ExchangeSpecification}
    */
   void applySpecification(ExchangeSpecification exchangeSpecification);
+  
+  /**
+   * Applies any exchange specific parameters
+   * 
+   * @param exchangeSpecification The {@link ExchangeSpecification}
+   * @param doRemoteInit Call {@link remoteInit}
+   */
+  void applySpecification(ExchangeSpecification exchangeSpecification, boolean doRemoteInit);
 
   /**
    * <p>

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
@@ -17,6 +17,12 @@ import org.knowm.xchange.utils.Assert;
 public enum ExchangeFactory {
 
   INSTANCE;
+    
+  private boolean doRemoteInit = true;
+  
+  // flags
+  public static final int DO_REMOTE_INIT_TRUE = 10000;
+  public static final int DO_REMOTE_INIT_FALSE = 10001;
 
   private final Logger log = LoggerFactory.getLogger(ExchangeFactory.class);
 
@@ -25,6 +31,27 @@ public enum ExchangeFactory {
    */
   private ExchangeFactory() {
 
+  }
+  
+  /**
+   * Adds a flag, for example, disabling remoteInit when the {@link Exchange} is created
+   * @param flag See public static final ints in this class
+   * @return this
+   */
+  public ExchangeFactory setFlag(int flag) {
+
+    switch (flag) {
+    case DO_REMOTE_INIT_TRUE:
+      doRemoteInit = true;
+      break;
+    case DO_REMOTE_INIT_FALSE:
+      doRemoteInit = false;
+      break;
+    default:
+      throw new IllegalArgumentException("That is not a valid flag for ExchangeFactory.");
+    }
+
+    return this;
   }
 
   /**
@@ -53,7 +80,7 @@ public enum ExchangeFactory {
       if (Exchange.class.isAssignableFrom(exchangeProviderClass)) {
         // Instantiate through the default constructor and use the default exchange specification
         Exchange exchange = (Exchange) exchangeProviderClass.newInstance();
-        exchange.applySpecification(exchange.getDefaultExchangeSpecification());
+        exchange.applySpecification(exchange.getDefaultExchangeSpecification(), doRemoteInit);
         return exchange;
       } else {
         throw new ExchangeException("Class '" + exchangeClassName + "' does not implement Exchange");
@@ -104,5 +131,7 @@ public enum ExchangeFactory {
     // Cannot be here due to exceptions
 
   }
+  
+  
 
 }


### PR DESCRIPTION
When creating an Exchange with ExchangeFactory, you can now use
setFlag() to set certain options for your ExchangeFactory.

Example:
`ExchangeFactory.INSTANCE.setFlag(ExchangeFactory.DO_REMOTE_INIT_FALSE);`