### PR TITLE
Implemented remoteInit() for Bitfinex/Bittrex, and fixed a DTO for Poloniex.

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -9,9 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.knowm.xchange.bitfinex.v1.dto.account.BitfinexBalancesResponse;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexDepth;
 import org.knowm.xchange.bitfinex.v1.dto.marketdata.BitfinexLendLevel;
@@ -30,6 +27,9 @@ import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
+import org.knowm.xchange.dto.meta.CurrencyMetaData;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.FixedRateLoanOrder;
 import org.knowm.xchange.dto.trade.FloatingRateLoanOrder;
 import org.knowm.xchange.dto.trade.LimitOrder;
@@ -37,6 +37,8 @@ import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.utils.DateUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BitfinexAdapters {
 
@@ -288,5 +290,24 @@ public final class BitfinexAdapters {
 
     BigDecimal timestampInMillis = timestamp.multiply(new BigDecimal("1000"));
     return new Date(timestampInMillis.longValue());
+  }
+
+  public static ExchangeMetaData adaptMetaData(List<CurrencyPair> currencyPairs, ExchangeMetaData metaData) {
+
+    Map<CurrencyPair, CurrencyPairMetaData> pairsMap = metaData.getCurrencyPairs();
+    Map<Currency, CurrencyMetaData> currenciesMap = metaData.getCurrencies();
+    for (CurrencyPair c : currencyPairs) {
+      if (!pairsMap.keySet().contains(c)) {
+        pairsMap.put(c, null);
+      }
+      if (!currenciesMap.keySet().contains(c.base)) {
+        currenciesMap.put(c.base, null);
+      }
+      if (!currenciesMap.keySet().contains(c.base)) {
+        currenciesMap.put(c.counter, null);
+      }
+    }
+
+    return metaData;
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexExchange.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexExchange.java
@@ -1,13 +1,16 @@
 package org.knowm.xchange.bitfinex.v1;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.bitfinex.v1.service.polling.BitfinexAccountService;
 import org.knowm.xchange.bitfinex.v1.service.polling.BitfinexMarketDataService;
+import org.knowm.xchange.bitfinex.v1.service.polling.BitfinexMarketDataServiceRaw;
 import org.knowm.xchange.bitfinex.v1.service.polling.BitfinexTradeService;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.nonce.AtomicLongIncrementalTime2013NonceFactory;
 
@@ -46,12 +49,10 @@ public class BitfinexExchange extends BaseExchange implements Exchange {
   @Override
   public void remoteInit() throws IOException, ExchangeException {
 
-    // TODO Implement this. Should implement the `/symbols_details` endpoint  at http://docs.bitfinex.com/#symbols too , and build a complete ExchangeMetaData object.
-    //    List<String> symbols = ((BitfinexMarketDataServiceRaw) pollingMarketDataService).getBitfinexSymbols();
-    // TODO take all the info and create a `ExchangeMetaData` object via a new method in `BitfinexAdapters`
-    //    exchangeMetaData = BitfinexAdapters.adaptToExchangeMetaData(blah, blah);
-
-    super.remoteInit();
+    BitfinexMarketDataServiceRaw dataService = (BitfinexMarketDataServiceRaw) this.pollingMarketDataService;
+    List<CurrencyPair> currencyPairs = dataService.getExchangeSymbols();
+    exchangeMetaData = BitfinexAdapters.adaptMetaData(currencyPairs, exchangeMetaData);
+    
   }
 
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAdapters.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAdapters.java
@@ -5,9 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.List;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Map;
 
 import org.knowm.xchange.bittrex.v1.dto.account.BittrexBalance;
 import org.knowm.xchange.bittrex.v1.dto.marketdata.BittrexLevel;
@@ -26,8 +24,13 @@ import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
+import org.knowm.xchange.dto.meta.CurrencyMetaData;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.UserTrade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BittrexAdapters {
 
@@ -171,6 +174,27 @@ public final class BittrexAdapters {
     }
 
     return new UserTrade(orderType, amount, currencyPair, price, date, orderId, orderId, trade.getCommission(), currencyPair.counter);
+  }
+  
+  public static ExchangeMetaData adaptMetaData(List<BittrexSymbol> rawSymbols, ExchangeMetaData metaData) {
+
+    List<CurrencyPair> currencyPairs = BittrexAdapters.adaptCurrencyPairs(rawSymbols);
+
+    Map<CurrencyPair, CurrencyPairMetaData> pairsMap = metaData.getCurrencyPairs();
+    Map<Currency, CurrencyMetaData> currenciesMap = metaData.getCurrencies();
+    for (CurrencyPair c : currencyPairs) {
+      if (!pairsMap.keySet().contains(c)) {
+        pairsMap.put(c, null);
+      }
+      if (!currenciesMap.keySet().contains(c.base)) {
+        currenciesMap.put(c.base, null);
+      }
+      if (!currenciesMap.keySet().contains(c.base)) {
+        currenciesMap.put(c.counter, null);
+      }
+    }
+
+    return metaData;
   }
 
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexExchange.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexExchange.java
@@ -1,12 +1,15 @@
 package org.knowm.xchange.bittrex.v1;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.bittrex.v1.dto.marketdata.BittrexSymbol;
 import org.knowm.xchange.bittrex.v1.service.polling.BittrexAccountService;
 import org.knowm.xchange.bittrex.v1.service.polling.BittrexMarketDataService;
+import org.knowm.xchange.bittrex.v1.service.polling.BittrexMarketDataServiceRaw;
 import org.knowm.xchange.bittrex.v1.service.polling.BittrexTradeService;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.nonce.AtomicLongIncrementalTime2013NonceFactory;
@@ -45,13 +48,10 @@ public class BittrexExchange extends BaseExchange implements Exchange {
 
   @Override
   public void remoteInit() throws IOException, ExchangeException {
-
-    // TODO Implement this.
-    // ArrayList<BittrexSymbol> bittrexSymbols = ((BittrexMarketDataServiceRaw) pollingMarketDataService). getBittrexSymbols();
-    // other endpoints?
-    // hard-coded meta data from json file not available at an endpoint?
-    // TODO take all the info and create a `ExchangeMetaData` object via a new method in `*Adapters` class
-    //    exchangeMetaData = *Adapters.adaptToExchangeMetaData(blah, blah);
-    super.remoteInit();
+    
+	  BittrexMarketDataServiceRaw dataService = (BittrexMarketDataServiceRaw) this.pollingMarketDataService;
+	  List<BittrexSymbol> bittrexSymbols = dataService.getBittrexSymbols();
+	  exchangeMetaData = BittrexAdapters.adaptMetaData(bittrexSymbols, exchangeMetaData);
+	  
   }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/SymbolsDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/marketdata/SymbolsDemo.java
@@ -20,7 +20,14 @@ public class SymbolsDemo {
     // Interested in the public polling market data feed (no authentication)
     PollingMarketDataService marketDataService = bitfinex.getPollingMarketDataService();
 
+    generic(bitfinex);
     raw((BitfinexMarketDataServiceRaw) marketDataService);
+  }
+  
+  private static void generic(Exchange bitfinex) {
+    
+    System.out.println(bitfinex.getExchangeSymbols().toString());
+    
   }
 
   private static void raw(BitfinexMarketDataServiceRaw marketDataService) throws IOException {

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/marketdata/PoloniexCurrencyInfo.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/marketdata/PoloniexCurrencyInfo.java
@@ -6,20 +6,41 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class PoloniexCurrencyInfo {
 
+  private final int id;
+  private final String name;
   private final BigDecimal txFee;
   private final int minConf;
+  private final String depositAddress;
   private final boolean disabled;
   private final boolean frozen;
   private final boolean delisted;
 
-  public PoloniexCurrencyInfo(@JsonProperty("txFee") BigDecimal txFee, @JsonProperty("minConf") int minConf,
-      @JsonProperty("disabled") boolean disabled, @JsonProperty("frozen") boolean frozen, @JsonProperty("delisted") boolean delisted) {
+  public PoloniexCurrencyInfo(@JsonProperty("id") int id, @JsonProperty("name") String name, @JsonProperty("txFee") BigDecimal txFee, @JsonProperty("minConf") int minConf,
+     @JsonProperty("depositAddress") String depositAddress, @JsonProperty("disabled") boolean disabled, @JsonProperty("frozen") boolean frozen, @JsonProperty("delisted") boolean delisted) {
 
+    this.id = id;
+    this.name = name;
     this.txFee = txFee;
     this.minConf = minConf;
+    this.depositAddress = depositAddress;
     this.disabled = disabled;
     this.frozen = frozen;
     this.delisted = delisted;
+  }
+  
+  public String getDepositAddress() {
+    
+    return depositAddress;
+  }
+  
+  public String getName() {
+    
+    return name;
+  }
+  
+  public int getId() {
+    
+    return id;
   }
 
   public BigDecimal getTxFee() {
@@ -50,7 +71,8 @@ public class PoloniexCurrencyInfo {
   @Override
   public String toString() {
 
-    return "PoloniexCurrencyInfo [txFee=" + txFee + ", minConf=" + minConf + ", disabled=" + disabled + ", frozen=" + frozen + ", delisted="
-        + delisted + "]";
+    return "PoloniexCurrencyInfo [id=" + id + ", name=" + name + ", txFee=" + txFee + ", minConf=" + minConf + ", depositAddress=" + depositAddress + ", disabled=" + disabled + ", frozen=" + frozen
+        + ", delisted=" + delisted + "]";
   }
+
 }


### PR DESCRIPTION
Simple implementation of `remoteInit()` for these two exchanges. I haven't yet added `CurrencyMetaData` or `CurrencyPairMetaData`, but this solution works if you just need dynamic currency pairs.