### PR TITLE
Switched the base and counter in PoloniexUtils

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
@@ -20,7 +20,7 @@ public class PoloniexUtils {
 
   public static String toPairString(CurrencyPair currencyPair) {
 
-    String pairString = currencyPair.counter.getCurrencyCode().toUpperCase() + "_" + currencyPair.base.getCurrencyCode().toUpperCase();
+    String pairString = currencyPair.base.getCurrencyCode().toUpperCase() + "_" + currencyPair.counter.getCurrencyCode().toUpperCase();
     return pairString;
   }
 


### PR DESCRIPTION
I kept getting errors about unknown currency pairs on Polonies. PoloniexUtils has the base and counter the wrong way around.