### PR TITLE
[independentreserve] fixed the ISO8601 timestamp parsing

### DIFF
--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
@@ -45,7 +45,7 @@ public class IndependentReserveAdapters {
 
     List<LimitOrder> bids = adaptOrders(independentReserveOrderBook.getBuyOrders(), Order.OrderType.BID, currencyPair);
     List<LimitOrder> asks = adaptOrders(independentReserveOrderBook.getSellOrders(), Order.OrderType.ASK, currencyPair);
-    Date timestamp = new Date(independentReserveOrderBook.getCreatedTimestampUtc());
+    Date timestamp = independentReserveOrderBook.getCreatedTimestamp();
 
     return new OrderBook(timestamp, asks, bids);
   }
@@ -94,7 +94,7 @@ public class IndependentReserveAdapters {
       Currency secondary = Currency.getInstanceNoCreate(order.getSecondaryCurrencyCode());
       CurrencyPair currencyPair = new CurrencyPair(primary, secondary);
 
-      LimitOrder limitOrder = new LimitOrder(type, order.getOutstanding(), currencyPair, order.getOrderGuid(), order.getCreatedTimestampUtc(),
+      LimitOrder limitOrder = new LimitOrder(type, order.getOutstanding(), currencyPair, order.getOrderGuid(), order.getCreatedTimestamp(),
           order.getPrice());
       limitOrders.add(limitOrder);
     }
@@ -129,7 +129,7 @@ public class IndependentReserveAdapters {
 
       CurrencyPair currencyPair = new CurrencyPair(primary, secondary);
 
-      UserTrade ut = new UserTrade(type, trade.getVolumeTraded(), currencyPair, trade.getPrice(), trade.getTradeTimestampUtc(), trade.getTradeGuid(),
+      UserTrade ut = new UserTrade(type, trade.getVolumeTraded(), currencyPair, trade.getPrice(), trade.getTradeTimestamp(), trade.getTradeGuid(),
           trade.getOrderGuid(), null, (Currency) null);
 
       userTrades.add(ut);

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveOrderBook.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveOrderBook.java
@@ -1,8 +1,9 @@
 package org.knowm.xchange.independentreserve.dto.marketdata;
 
+import java.util.Date;
 import java.util.List;
 
-import org.knowm.xchange.utils.DateUtils;
+import javax.xml.bind.DatatypeConverter;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -11,7 +12,7 @@ import com.fasterxml.jackson.databind.exc.InvalidFormatException;
  * Author: Kamil Zbikowski Date: 4/9/15
  */
 public class IndependentReserveOrderBook {
-  private final Long createdTimestampUtc;
+  private final Date createdTimestamp;
   private final List<OrderBookOrder> buyOrders;
   private final List<OrderBookOrder> sellOrders;
 
@@ -23,7 +24,7 @@ public class IndependentReserveOrderBook {
       @JsonProperty("SecondaryCurrencyCode") String secondaryCurrencyCode, @JsonProperty("CreatedTimestampUtc") String createdTimestampUtc)
       throws InvalidFormatException {
     this.buyOrders = buyOrders;
-    this.createdTimestampUtc = DateUtils.fromISO8601DateString(createdTimestampUtc).getTime();
+    this.createdTimestamp = DatatypeConverter.parseDateTime(createdTimestampUtc).getTime();
     this.sellOrders = sellOrders;
     this.primaryCurrencyCode = primaryCurrencyCode;
     this.secondaryCurrencyCode = secondaryCurrencyCode;
@@ -33,8 +34,8 @@ public class IndependentReserveOrderBook {
     return buyOrders;
   }
 
-  public Long getCreatedTimestampUtc() {
-    return createdTimestampUtc;
+  public Date getCreatedTimestamp() {
+    return createdTimestamp;
   }
 
   public String getPrimaryCurrencyCode() {

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/trade/IndependentReserveOpenOrder.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/trade/IndependentReserveOpenOrder.java
@@ -3,6 +3,8 @@ package org.knowm.xchange.independentreserve.dto.trade;
 import java.math.BigDecimal;
 import java.util.Date;
 
+import javax.xml.bind.DatatypeConverter;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -10,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class IndependentReserveOpenOrder {
   private final BigDecimal avgPrice;
-  private final Date createdTimestampUtc;
+  private final Date createdTimestamp;
   private final BigDecimal feePercent;
   private final String orderGuid;
   private final String orderType;
@@ -22,13 +24,13 @@ public class IndependentReserveOpenOrder {
   private final BigDecimal value;
   private final BigDecimal volume;
 
-  public IndependentReserveOpenOrder(@JsonProperty("AvgPrice") BigDecimal avgPrice, @JsonProperty("CreatedTimestampUtc") Date createdTimestampUtc,
+  public IndependentReserveOpenOrder(@JsonProperty("AvgPrice") BigDecimal avgPrice, @JsonProperty("CreatedTimestampUtc") String createdTimestampUtc,
       @JsonProperty("FeePercent") BigDecimal feePercent, @JsonProperty("OrderGuid") String orderGuid, @JsonProperty("OrderType") String orderType,
       @JsonProperty("Outstanding") BigDecimal outstanding, @JsonProperty("Price") BigDecimal price,
       @JsonProperty("PrimaryCurrencyCode") String primaryCurrencyCode, @JsonProperty("SecondaryCurrencyCode") String secondaryCurrencyCode,
       @JsonProperty("Status") String status, @JsonProperty("Value") BigDecimal value, @JsonProperty("Volume") BigDecimal volume) {
     this.avgPrice = avgPrice;
-    this.createdTimestampUtc = createdTimestampUtc;
+    this.createdTimestamp = DatatypeConverter.parseDateTime(createdTimestampUtc).getTime();
     this.feePercent = feePercent;
     this.orderGuid = orderGuid;
     this.orderType = orderType;
@@ -45,8 +47,8 @@ public class IndependentReserveOpenOrder {
     return avgPrice;
   }
 
-  public Date getCreatedTimestampUtc() {
-    return createdTimestampUtc;
+  public Date getCreatedTimestamp() {
+    return createdTimestamp;
   }
 
   public BigDecimal getFeePercent() {
@@ -91,7 +93,7 @@ public class IndependentReserveOpenOrder {
 
   @Override
   public String toString() {
-    return "IndependentReserveOpenOrder{" + "avgPrice=" + avgPrice + ", createdTimestampUtc=" + createdTimestampUtc + ", feePercent=" + feePercent
+    return "IndependentReserveOpenOrder{" + "avgPrice=" + avgPrice + ", createdTimestamp=" + createdTimestamp + ", feePercent=" + feePercent
         + ", orderGuid='" + orderGuid + '\'' + ", orderType='" + orderType + '\'' + ", outstanding=" + outstanding + ", price=" + price
         + ", primaryCurrencyCode='" + primaryCurrencyCode + '\'' + ", secondaryCurrencyCode='" + secondaryCurrencyCode + '\'' + ", status='" + status
         + '\'' + ", value=" + value + ", volume=" + volume + '}';

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/trade/IndependentReserveTrade.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/trade/IndependentReserveTrade.java
@@ -3,6 +3,8 @@ package org.knowm.xchange.independentreserve.dto.trade;
 import java.math.BigDecimal;
 import java.util.Date;
 
+import javax.xml.bind.DatatypeConverter;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -10,25 +12,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 public class IndependentReserveTrade {
   private final String tradeGuid;
-  private final Date tradeTimestampUtc;
+  private final Date tradeTimestamp;
   private final String orderGuid;
   private final String orderType;
-  private final Date orderTimestampUtc;
+  private final Date orderTimestamp;
   private final BigDecimal volumeTraded;
   private final BigDecimal price;
   private final String primaryCurrencyCode;
   private final String secondaryCurrencyCode;
 
   public IndependentReserveTrade(@JsonProperty("OrderGuid") String orderGuid, @JsonProperty("TradeGuid") String tradeGuid,
-      @JsonProperty("TradeTimestampUtc") Date tradeTimestampUtc, @JsonProperty("OrderType") String orderType,
-      @JsonProperty("OrderTimestampUtc") Date orderTimestampUtc, @JsonProperty("VolumeTraded") BigDecimal volumeTraded,
+      @JsonProperty("TradeTimestampUtc") String tradeTimestampUtc, @JsonProperty("OrderType") String orderType,
+      @JsonProperty("OrderTimestampUtc") String orderTimestampUtc, @JsonProperty("VolumeTraded") BigDecimal volumeTraded,
       @JsonProperty("Price") BigDecimal price, @JsonProperty("PrimaryCurrencyCode") String primaryCurrencyCode,
       @JsonProperty("SecondaryCurrencyCode") String secondaryCurrencyCode) {
     this.orderGuid = orderGuid;
     this.tradeGuid = tradeGuid;
-    this.tradeTimestampUtc = tradeTimestampUtc;
+    this.tradeTimestamp = DatatypeConverter.parseDateTime(tradeTimestampUtc).getTime();
     this.orderType = orderType;
-    this.orderTimestampUtc = orderTimestampUtc;
+    this.orderTimestamp = DatatypeConverter.parseDateTime(orderTimestampUtc).getTime();
     this.volumeTraded = volumeTraded;
     this.price = price;
     this.primaryCurrencyCode = primaryCurrencyCode;
@@ -40,7 +42,7 @@ public class IndependentReserveTrade {
   }
 
   public Date getOrderTimestampUtc() {
-    return orderTimestampUtc;
+    return orderTimestamp;
   }
 
   public String getOrderType() {
@@ -63,8 +65,8 @@ public class IndependentReserveTrade {
     return tradeGuid;
   }
 
-  public Date getTradeTimestampUtc() {
-    return tradeTimestampUtc;
+  public Date getTradeTimestamp() {
+    return tradeTimestamp;
   }
 
   public BigDecimal getVolumeTraded() {


### PR DESCRIPTION
use the data type converter in JAXB, since JAXB must be able to parse ISO8601 date string according to the XML Schema specification