### PR TITLE
[therock] fixed the exception structure for error messages

### DIFF
--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/dto/TheRockException.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/dto/TheRockException.java
@@ -30,7 +30,7 @@ public class TheRockException extends HttpStatusExceptionSupport {
   public static class Error {
     private String message;
     private Integer code;
-    private Map<String, String> meta;
+    private Map<String, Object> meta;
 
     public String getMessage() {
       return message;
@@ -40,7 +40,7 @@ public class TheRockException extends HttpStatusExceptionSupport {
       return code;
     }
 
-    public Map<String, String> getMeta() {
+    public Map<String, Object> getMeta() {
       return meta;
     }
 


### PR DESCRIPTION
the meta structure could not fir error messages sent by therock
for example 
`{"errors":[{"message":"Not enough balance","code":"21","meta":{"amount":{"value":0.5,"currency":"BTC"},"trading_balance":{"value":0.19913927,"currency":"BTC"}}}]}`

the "meta" object is more complex than "Map<String, String>"