### PR TITLE
New method getOpenOrders(OpenOrdersParams)

### DIFF
--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/polling/ANXTradeService.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/polling/ANXTradeService.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.Assert;
 import org.knowm.xchange.utils.DateUtils;
 
@@ -44,6 +45,11 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
   public OpenOrders getOpenOrders() throws IOException {
 
     return new OpenOrders(ANXAdapters.adaptOrders(getANXOpenOrders()));
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/polling/BitbayTradeService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/polling/BitbayTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Z. Dolezal
@@ -33,6 +34,11 @@ public class BitbayTradeService extends BitbayTradeServiceRaw implements Polling
 
     List<BitbayOrder> response = getBitbayOpenOrders();
     return BitbayAdapters.adaptOpenOrders(response);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
@@ -21,11 +21,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 public class BitfinexTradeService extends BitfinexTradeServiceRaw implements PollingTradeService {
@@ -47,6 +44,11 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Pol
     } else {
       return BitfinexAdapters.adaptOrders(activeOrders);
     }
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/polling/BitMarketTradeService.java
+++ b/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/polling/BitMarketTradeService.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author kfonal
@@ -39,6 +40,11 @@ public class BitMarketTradeService extends BitMarketTradeServiceRaw implements P
 
     BitMarketOrdersResponse response = getBitMarketOpenOrders();
     return BitMarketAdapters.adaptOpenOrders(response.getData());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/polling/BitsoTradeService.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/polling/BitsoTradeService.java
@@ -27,6 +27,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Piotr Ładyżyński
@@ -57,6 +58,11 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements PollingTr
           .add(new LimitOrder(orderType, bitsoOrder.getAmount(), new CurrencyPair(Currency.BTC, Currency.MXN), id, bitsoOrder.getTime(), price));
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/polling/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/polling/BitstampTradeService.java
@@ -4,11 +4,7 @@ import static org.knowm.xchange.dto.Order.OrderType.BID;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitstamp.BitstampAdapters;
@@ -28,11 +24,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamOffset;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Matija Mazi
@@ -60,6 +53,11 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Pol
       }
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/polling/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/polling/BittrexTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class BittrexTradeService extends BittrexTradeServiceRaw implements PollingTradeService {
 
@@ -51,6 +52,11 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
   public OpenOrders getOpenOrders() throws IOException {
 
     return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders()));
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/polling/BleutradeTradeService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/polling/BleutradeTradeService.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class BleutradeTradeService extends BleutradeTradeServiceRaw implements PollingTradeService {
 
@@ -33,6 +34,11 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements P
   public OpenOrders getOpenOrders() throws IOException {
 
     return BleutradeAdapters.adaptBleutradeOpenOrders(getBleutradeOpenOrders());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -26,11 +26,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsIdSpan;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,6 +70,11 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
     } while (page.size() >= BTCChinaGetOrdersRequest.DEFAULT_LIMIT);
 
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
@@ -10,11 +10,7 @@ import org.knowm.xchange.btce.v3.BTCEAdapters;
 import org.knowm.xchange.btce.v3.BTCEAuthenticated;
 import org.knowm.xchange.btce.v3.BTCEExchange;
 import org.knowm.xchange.btce.v3.dto.marketdata.BTCEExchangeInfo;
-import org.knowm.xchange.btce.v3.dto.trade.BTCECancelOrderResult;
-import org.knowm.xchange.btce.v3.dto.trade.BTCEOrder;
-import org.knowm.xchange.btce.v3.dto.trade.BTCEPlaceOrderResult;
-import org.knowm.xchange.btce.v3.dto.trade.BTCETradeHistoryResult;
-import org.knowm.xchange.btce.v3.dto.trade.BTCETransHistoryResult;
+import org.knowm.xchange.btce.v3.dto.trade.*;
 import org.knowm.xchange.btce.v3.service.polling.trade.params.BTCETradeHistoryParams;
 import org.knowm.xchange.btce.v3.service.polling.trade.params.BTCETransHistoryParams;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -27,11 +23,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsIdSpan;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 /**
@@ -54,6 +47,11 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
 
     Map<Long, BTCEOrder> orders = getBTCEActiveOrders(null);
     return BTCEAdapters.adaptOrders(orders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   /**

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
@@ -28,6 +28,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Matija Mazi
@@ -71,6 +72,11 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
     BTCMarketsOrders openOrders = getBTCMarketsOpenOrders(currencyPair, 50, null);
 
     return BTCMarketsAdapters.adaptOpenOrders(openOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/polling/BTCTradeTradeService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/polling/BTCTradeTradeService.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements PollingTradeService {
@@ -40,6 +41,11 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
   public OpenOrders getOpenOrders() throws IOException {
 
     return BTCTradeAdapters.adaptOpenOrders(getBTCTradeOrders(0, "open"));
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-bter/src/main/java/org/knowm/xchange/bter/service/polling/BTERPollingTradeService.java
+++ b/xchange-bter/src/main/java/org/knowm/xchange/bter/service/polling/BTERPollingTradeService.java
@@ -21,6 +21,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implements PollingTradeService {
 
@@ -41,6 +42,11 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
     Collection<CurrencyPair> currencyPairs = exchange.getExchangeSymbols();
 
     return BTERAdapters.adaptOpenOrders(openOrders, currencyPairs);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/polling/CampBXTradeService.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/polling/CampBXTradeService.java
@@ -23,6 +23,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -78,6 +79,11 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements Polling
     } else {
       throw new ExchangeException("Error calling getOpenOrders(): " + myOpenOrders.getError());
     }
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/pooling/CCEXTradeService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/pooling/CCEXTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class CCEXTradeService extends CCEXTradeServiceRaw implements PollingTradeService{
 
@@ -31,7 +32,12 @@ public class CCEXTradeService extends CCEXTradeServiceRaw implements PollingTrad
 		return new OpenOrders(CCEXAdapters.adaptOpenOrders(getCCEXOpenOrders()));
 	}
 
-	@Override
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
+  }
+
+  @Override
 	public String placeMarketOrder(MarketOrder marketOrder) throws ExchangeException, NotAvailableFromExchangeException,
 			NotYetImplementedForExchangeException, IOException {
 		throw new NotAvailableFromExchangeException();
@@ -59,7 +65,7 @@ public class CCEXTradeService extends CCEXTradeServiceRaw implements PollingTrad
 		return PARAMS_ZERO;
 	}
 
-	@Override
+  @Override
 	public Collection<Order> getOrder(String... orderIds) throws ExchangeException, NotAvailableFromExchangeException,
 			NotYetImplementedForExchangeException, IOException {
 		throw new NotYetImplementedForExchangeException();

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/polling/CexIOTradeService.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/polling/CexIOTradeService.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * Author: brox Since: 2/6/14
@@ -40,6 +41,11 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements PollingTr
     List<CexIOOrder> cexIOOrderList = getCexIOOpenOrders();
 
     return CexIOAdapters.adaptOpenOrders(cexIOOrderList);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/polling/CoinbaseTradeService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/polling/CoinbaseTradeService.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author jamespedwards42
@@ -40,6 +41,11 @@ public final class CoinbaseTradeService extends CoinbaseTradeServiceRaw implemen
   public OpenOrders getOpenOrders() throws NotAvailableFromExchangeException {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/polling/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/polling/CoinmateTradeService.java
@@ -41,6 +41,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPagingSorted;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Martin Stachon
@@ -61,6 +62,11 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
       orders.addAll(CoinmateAdapters.adaptOpenOrders(coinmateOpenOrders, currencyPair));
     }
     return new OpenOrders(orders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/PollingTradeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/PollingTradeService.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.BasePollingService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * <p>
@@ -32,7 +33,7 @@ public interface PollingTradeService extends BasePollingService {
 
   /**
    * Gets the open orders
-   * 
+   *
    * @return the open orders, null if some sort of error occurred. Implementers should log the error.
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
    * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the requested function or data
@@ -40,11 +41,26 @@ public interface PollingTradeService extends BasePollingService {
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
-  public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
+  OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
+
+  /**
+   * Gets the open orders
+   *
+   * @param params The parameters describing the filter. Note that {@link OpenOrdersParams} is an empty interface. Exchanges should implement its
+   * own params object.
+   *
+   * @return the open orders, null if some sort of error occurred. Implementers should log the error.
+   * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
+   * @throws NotAvailableFromExchangeException - Indication that the exchange does not support the requested function or data
+   * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been
+   *         implemented
+   * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   */
+  OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
    * Place a market order
-   * 
+   *
    * @param marketOrder
    * @return the order ID
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
@@ -53,12 +69,12 @@ public interface PollingTradeService extends BasePollingService {
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
-  public String placeMarketOrder(MarketOrder marketOrder)
+  String placeMarketOrder(MarketOrder marketOrder)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
    * Place a limit order
-   * 
+   *
    * @param limitOrder
    * @return the order ID
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
@@ -67,12 +83,12 @@ public interface PollingTradeService extends BasePollingService {
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
-  public String placeLimitOrder(LimitOrder limitOrder)
+  String placeLimitOrder(LimitOrder limitOrder)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
    * cancels order with matching orderId
-   * 
+   *
    * @param orderId
    * @return true if order was successfully cancelled, false otherwise.
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
@@ -81,7 +97,7 @@ public interface PollingTradeService extends BasePollingService {
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
-  public boolean cancelOrder(String orderId)
+  boolean cancelOrder(String orderId)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
@@ -100,7 +116,7 @@ public interface PollingTradeService extends BasePollingService {
    * <p/>
    * Some exchanges allow extra parameters, not covered by any common interface. To access them, you will have to use the object returned by
    * {@link #createTradeHistoryParams()} and cast it to the exchange-specific type.
-   * 
+   *
    * @param params The parameters describing the filter. Note that {@link TradeHistoryParams} is an empty interface. Exact set of interfaces that are
    *        required or supported by this method is described by the type of object returned from {@link #createTradeHistoryParams()} and the javadoc
    *        of the method.
@@ -113,14 +129,14 @@ public interface PollingTradeService extends BasePollingService {
    * @see #createTradeHistoryParams()
    * @see org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsAll
    */
-  public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException;
+  UserTrades getTradeHistory(TradeHistoryParams params) throws IOException;
 
   /**
    * Create {@link TradeHistoryParams} object specific to this exchange. Object created by this method may be used to discover supported and required
    * {@link #getTradeHistory(TradeHistoryParams)} parameters and should be passed only to the method in the same class as the createTradeHistoryParams
    * that created the object.
    */
-  public TradeHistoryParams createTradeHistoryParams();
+  TradeHistoryParams createTradeHistoryParams();
 
   /**
    * Verify the order against the exchange meta data. Most implementations will require that {@link org.knowm.xchange.Exchange#remoteInit()} be called
@@ -136,7 +152,7 @@ public interface PollingTradeService extends BasePollingService {
 
   /**
    * get's the latest order form the order book that with matching orderId
-   * 
+   *
    * @param orderId
    * @return the order as it is on the exchange.
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
@@ -145,7 +161,7 @@ public interface PollingTradeService extends BasePollingService {
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
    */
-  public Collection<Order> getOrder(String... orderIds)
+  Collection<Order> getOrder(String... orderIds)
       throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParamCurrencyPair.java
@@ -1,0 +1,9 @@
+package org.knowm.xchange.service.polling.trade.params.orders;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public interface OpenOrdersParamCurrencyPair extends OpenOrdersParams {
+  void setCurrencyPair(CurrencyPair pair);
+
+  CurrencyPair getCurrencyPair();
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParams.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.service.polling.trade.params.orders;
+
+/**
+ * Root interface for all interfaces used as a parameter type for
+ * {@link org.knowm.xchange.service.polling.trade.PollingTradeService#getOpenOrders(OpenOrdersParams)} .
+ */
+public interface OpenOrdersParams {
+}

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Jean-Christophe Laruelle
@@ -37,6 +38,11 @@ public class CryptoFacilitiesTradeService extends CryptoFacilitiesTradeServiceRa
 
     return CryptoFacilitiesAdapters.adaptOpenOrders(super.getCryptoFacilitiesOpenOrders());
 
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/polling/EmpoExTradeService.java
+++ b/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/polling/EmpoExTradeService.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class EmpoExTradeService extends EmpoExTradeServiceRaw implements PollingTradeService {
 
@@ -33,6 +34,11 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements Polling
   public OpenOrders getOpenOrders() throws IOException {
 
     return EmpoExAdapters.adaptOpenOrders(super.getEmpoExOpenOrders());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockMetaDataDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/TheRockMetaDataDemo.java
@@ -1,0 +1,26 @@
+package org.knowm.xchange.examples.therock;
+
+import java.io.IOException;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.therock.TheRockExchange;
+
+public class TheRockMetaDataDemo {
+
+  public static void main(String[] args) throws IOException {
+
+    // Use the factory to get The Rock exchange API using default settings
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(TheRockExchange.class.getName());
+    ExchangeMetaData exchangeMetaData = exchange.getExchangeMetaData();
+    System.out.println(exchangeMetaData.toString());
+
+    for (CurrencyPair currencyPair : exchangeMetaData.getCurrencyPairs().keySet()) {
+      System.out.println(currencyPair.toString());
+    }
+
+  }
+
+}

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/polling/GatecoinTradeService.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/polling/GatecoinTradeService.java
@@ -28,6 +28,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamTransactionId;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 /**
@@ -60,6 +61,11 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Pol
           DateUtils.fromMillisUtc(Long.valueOf(gatecoinOrder.getDate()) * 1000L), price));
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
@@ -19,6 +19,7 @@ import org.knowm.xchange.gdax.dto.trade.GDAXOrder;
 import org.knowm.xchange.gdax.dto.trade.GDAXTradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class GDAXTradeService extends GDAXTradeServiceRaw implements PollingTradeService {
 
@@ -33,6 +34,11 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements PollingTrad
     GDAXOrder[] coinbaseExOpenOrders = getCoinbaseExOpenOrders();
 
     return GDAXAdapters.adaptOpenOrders(coinbaseExOpenOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/polling/GeminiTradeService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/polling/GeminiTradeService.java
@@ -20,11 +20,8 @@ import org.knowm.xchange.gemini.v1.GeminiOrderType;
 import org.knowm.xchange.gemini.v1.dto.trade.GeminiOrderStatusResponse;
 import org.knowm.xchange.gemini.v1.dto.trade.GeminiTradeResponse;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamsTimeSpan;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 public class GeminiTradeService extends GeminiTradeServiceRaw implements PollingTradeService {
@@ -46,6 +43,11 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements Polling
     } else {
       return GeminiAdapters.adaptOrders(activeOrders);
     }
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -23,6 +23,7 @@ import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPa
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class HitbtcTradeService extends HitbtcTradeServiceRaw implements PollingTradeService {
 
@@ -41,6 +42,11 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
 
     HitbtcOrder[] openOrdersRaw = getOpenOrdersRaw();
     return HitbtcAdapters.adaptOpenOrders(openOrdersRaw);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/polling/GenericTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/polling/GenericTradeService.java
@@ -1,12 +1,7 @@
 package org.knowm.xchange.huobi.service.polling;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -26,6 +21,7 @@ import org.knowm.xchange.huobi.service.TradeServiceRaw;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class GenericTradeService extends BaseExchangeService implements PollingTradeService {
 
@@ -69,6 +65,11 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
     }
 
     return new OpenOrders(openOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class IndependentReserveTradeService extends IndependentReserveTradeServiceRaw implements PollingTradeService {
 
@@ -32,6 +33,11 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
     // get orders for all currencies
     OpenOrders orders = IndependentReserveAdapters.adaptOpenOrders(getIndependentReserveOpenOrders(null, null, 1));
     return orders;
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitOpenOrdersParams.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitOpenOrdersParams.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.itbit.v1.service.polling;
+
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
+
+public class ItBitOpenOrdersParams implements OpenOrdersParamCurrencyPair {
+  private CurrencyPair currencyPair;
+
+  @Override
+  public void setCurrencyPair(CurrencyPair pair) {
+    this.currencyPair = pair;
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return currencyPair;
+  }
+}

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.itbit.v1.dto.trade.ItBitOrder;
 import org.knowm.xchange.itbit.v1.dto.trade.ItBitTradeHistory;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTradeService {
@@ -39,7 +40,18 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    CurrencyPair currencyPair = null;
+    if (params instanceof OpenOrdersParamCurrencyPair) {
+      currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    // In case of no currency pair - return all currency pairs.
+    if (currencyPair == null) {
+      return getOpenOrders();
+    }
+
+    ItBitOrder[] itBitOpenOrders = getItBitOpenOrders(currencyPair);
+    return ItBitAdapters.adaptPrivateOrders(itBitOpenOrders);
   }
 
   @Override

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -1,11 +1,7 @@
 package org.knowm.xchange.itbit.v1.service.polling;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -21,11 +17,8 @@ import org.knowm.xchange.itbit.v1.ItBitAdapters;
 import org.knowm.xchange.itbit.v1.dto.trade.ItBitOrder;
 import org.knowm.xchange.itbit.v1.dto.trade.ItBitTradeHistory;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamTransactionId;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTradeService {
 
@@ -42,6 +35,11 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
     }
     ItBitOrder[] empty = {};
     return ItBitAdapters.adaptPrivateOrders(orders.isEmpty() ? empty : Arrays.copyOf(orders.toArray(), orders.size(), ItBitOrder[].class));
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/polling/KrakenTradeService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/polling/KrakenTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamsT
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamOffset;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 public class KrakenTradeService extends KrakenTradeServiceRaw implements PollingTradeService {
@@ -36,6 +37,11 @@ public class KrakenTradeService extends KrakenTradeServiceRaw implements Polling
   public OpenOrders getOpenOrders() throws IOException {
 
     return KrakenAdapters.adaptOpenOrders(super.getKrakenOpenOrders());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/polling/LakeBTCTradeService.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/polling/LakeBTCTradeService.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.lakebtc.dto.trade.LakeBTCCancelResponse;
 import org.knowm.xchange.lakebtc.dto.trade.LakeBTCOrderResponse;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements PollingTradeService {
 
@@ -32,6 +33,11 @@ public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements Polli
   @Override
   public OpenOrders getOpenOrders() throws IOException {
     throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-loyalbit/src/main/java/org/knowm/xchange/loyalbit/service/polling/LoyalbitTradeService.java
+++ b/xchange-loyalbit/src/main/java/org/knowm/xchange/loyalbit/service/polling/LoyalbitTradeService.java
@@ -26,6 +26,7 @@ import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPa
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Matija Mazi
@@ -45,6 +46,11 @@ public class LoyalbitTradeService extends LoyalbitTradeServiceRaw implements Pol
       limitOrders.add(LoyalbitAdapters.adaptOrder(loyalbitOrder));
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
@@ -25,11 +25,8 @@ import org.knowm.xchange.mercadobitcoin.dto.MercadoBitcoinBaseTradeApiResult;
 import org.knowm.xchange.mercadobitcoin.dto.trade.MercadoBitcoinPlaceLimitOrderResult;
 import org.knowm.xchange.mercadobitcoin.dto.trade.MercadoBitcoinUserOrders;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsIdSpan;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Felipe Micaroni Lalli
@@ -60,6 +57,11 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
     limitOrders.addAll(MercadoBitcoinAdapters.adaptOrders(new CurrencyPair(Currency.LTC, Currency.BRL), openOrdersLitecoinResult));
 
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
@@ -1,13 +1,7 @@
 package org.knowm.xchange.okcoin.service.polling;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -31,6 +25,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -77,6 +72,11 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
     }
 
     return OkCoinAdapters.adaptOpenOrdersFutures(orderResults);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinTradeService.java
@@ -26,6 +26,7 @@ import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPa
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,11 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements Polling
     }
 
     return OkCoinAdapters.adaptOpenOrders(orderResults);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexTradeService.java
@@ -6,23 +6,14 @@ package org.knowm.xchange.poloniex.service.polling;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
-import org.knowm.xchange.dto.trade.LimitOrder;
-import org.knowm.xchange.dto.trade.MarketOrder;
-import org.knowm.xchange.dto.trade.OpenOrders;
-import org.knowm.xchange.dto.trade.UserTrade;
-import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
@@ -37,6 +28,7 @@ import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyP
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsAll;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.utils.DateUtils;
 
 public class PoloniexTradeService extends PoloniexTradeServiceRaw implements PollingTradeService {
@@ -51,6 +43,11 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Pol
 
     HashMap<String, PoloniexOpenOrder[]> poloniexOpenOrders = returnOpenOrders();
     return PoloniexAdapters.adaptPoloniexOpenOrders(poloniexOpenOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/polling/QuadrigaCxTradeService.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/polling/QuadrigaCxTradeService.java
@@ -27,6 +27,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements PollingTradeService {
 
@@ -56,6 +57,11 @@ public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements
       }
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/polling/QuoineTradeService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/polling/QuoineTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.quoine.dto.trade.QuoineOrderResponse;
 import org.knowm.xchange.quoine.dto.trade.QuoineOrdersList;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 /**
  * @author Matija Mazi
@@ -39,6 +40,11 @@ public class QuoineTradeService extends QuoineTradeServiceRaw implements Polling
     QuoineOrdersList quoineOrdersList = listQuoineOrders(null);
     return QuoineAdapters.adapteOpenOrders(quoineOrdersList);
 
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/polling/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/polling/RippleTradeService.java
@@ -24,6 +24,7 @@ import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class RippleTradeService extends RippleTradeServiceRaw implements PollingTradeService {
 
@@ -46,6 +47,11 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     return RippleAdapters.adaptOpenOrders(getOpenAccountOrders(), ripple.getRoundingScale());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/polling/TaurusTradeService.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/polling/TaurusTradeService.java
@@ -20,11 +20,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
-import org.knowm.xchange.service.polling.trade.params.DefaultTradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamOffset;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsSorted;
+import org.knowm.xchange.service.polling.trade.params.*;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.taurus.TaurusAdapters;
 import org.knowm.xchange.taurus.dto.TaurusException;
 import org.knowm.xchange.taurus.dto.trade.TaurusOrder;
@@ -51,6 +48,11 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements Polling
       limitOrders.add(new LimitOrder(orderType, taurusOrder.getAmount(), CurrencyPair.BTC_CAD, id, taurusOrder.getDatetime(), price));
     }
     return new OpenOrders(limitOrders);
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAdapters.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAdapters.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.therock.dto.account.TheRockBalance;
@@ -27,6 +28,7 @@ import org.knowm.xchange.therock.dto.marketdata.TheRockTrade;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTrade.Side;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTrades;
 import org.knowm.xchange.therock.dto.trade.TheRockOrder;
+import org.knowm.xchange.therock.dto.trade.TheRockOrders;
 import org.knowm.xchange.therock.dto.trade.TheRockUserTrade;
 import org.knowm.xchange.therock.dto.trade.TheRockUserTrades;
 
@@ -74,7 +76,7 @@ public final class TheRockAdapters {
     for (int i = 0; i < trades.getCount(); i++) {
       TheRockTrade trade = trades.getTrades()[i];
       if (trade.getSide() != Side.buy && trade.getSide() != Side.sell) {
-          continue;     // process buys and sells only
+        continue;     // process buys and sells only
       }
       long tradeId = trade.getId();
       if (tradeId > lastTradeId)
@@ -88,29 +90,49 @@ public final class TheRockAdapters {
     final String tradeId = String.valueOf(trade.getId());
     return new Trade(trade.getSide() == Side.sell ? OrderType.ASK : BID, trade.getAmount(), currencyPair, trade.getPrice(), trade.getDate(), tradeId);
   }
-  
+
   public static UserTrade adaptUserTrade(TheRockUserTrade trade, CurrencyPair currencyPair) throws InvalidFormatException {
-      final String tradeId = String.valueOf(trade.getId());
-      //return new UserTrade(trade.getSide() == Side.sell ? OrderType.ASK : BID, trade.getAmount(), currencyPair, trade.getPrice(), trade.getDate(), tradeId);
-      return new UserTrade.Builder().id(tradeId).tradableAmount(trade.getAmount()).currencyPair(currencyPair).price(trade.getPrice())
-              .timestamp(trade.getDate()).orderId(String.valueOf(trade.getOrderId()))
-              .type(trade.getSide() == Side.buy ? OrderType.BID : OrderType.ASK)
-              .feeAmount(trade.getFeeAmount()).feeCurrency(trade.getFeeCurrency() == null ? null : new Currency(trade.getFeeCurrency()))
-              .build(); 
+    final String tradeId = String.valueOf(trade.getId());
+    //return new UserTrade(trade.getSide() == Side.sell ? OrderType.ASK : BID, trade.getAmount(), currencyPair, trade.getPrice(), trade.getDate(), tradeId);
+    return new UserTrade.Builder().id(tradeId).tradableAmount(trade.getAmount()).currencyPair(currencyPair).price(trade.getPrice())
+        .timestamp(trade.getDate()).orderId(String.valueOf(trade.getOrderId()))
+        .type(trade.getSide() == Side.buy ? OrderType.BID : OrderType.ASK)
+        .feeAmount(trade.getFeeAmount()).feeCurrency(trade.getFeeCurrency() == null ? null : new Currency(trade.getFeeCurrency()))
+        .build();
   }
+
   public static UserTrades adaptUserTrades(TheRockUserTrades trades, CurrencyPair currencyPair) throws InvalidFormatException {
 
-      List<UserTrade> tradesList = new ArrayList<>(trades.getCount());
-      long lastTradeId = 0;
-      for (int i = 0; i < trades.getCount(); i++) {
-        TheRockUserTrade trade = trades.getTrades()[i];
-        long tradeId = trade.getId();
-        if (tradeId > lastTradeId)
-          lastTradeId = tradeId;
-        tradesList.add(adaptUserTrade(trade, currencyPair));
-      }
-      return new UserTrades(tradesList, lastTradeId, Trades.TradeSortType.SortByID);
+    List<UserTrade> tradesList = new ArrayList<>(trades.getCount());
+    long lastTradeId = 0;
+    for (int i = 0; i < trades.getCount(); i++) {
+      TheRockUserTrade trade = trades.getTrades()[i];
+      long tradeId = trade.getId();
+      if (tradeId > lastTradeId)
+        lastTradeId = tradeId;
+      tradesList.add(adaptUserTrade(trade, currencyPair));
     }
+    return new UserTrades(tradesList, lastTradeId, Trades.TradeSortType.SortByID);
+  }
+
+  public static LimitOrder adaptOrder(TheRockOrder o) {
+    return new LimitOrder(adaptOrderType(o.getSide()), o.getAmount(), o.getFundId().pair,
+        Long.toString(o.getId()), null, o.getPrice());
+  }
+
+  public static Order.OrderType adaptOrderType(TheRockOrder.Side orderSide) {
+    return orderSide.equals(TheRockOrder.Side.buy) ? Order.OrderType.BID : Order.OrderType.ASK;
+  }
+
+  public static OpenOrders adaptOrders(TheRockOrders theRockOrders) {
+    List<LimitOrder> orders = new ArrayList<>(theRockOrders.getOrders().length);
+
+    for (TheRockOrder theRockOrder : theRockOrders.getOrders()) {
+      orders.add(adaptOrder(theRockOrder));
+    }
+
+    return new OpenOrders(orders);
+  }
 
   /*
    * public static LimitOrder adaptOrder(TheRockOrder o) { return new LimitOrder(adaptOrderType(o.getSide()), o.getAmount(), o.getFundId().pair,

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockOpenOrdersParams.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockOpenOrdersParams.java
@@ -1,0 +1,18 @@
+package org.knowm.xchange.therock.service.polling;
+
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
+
+public class TheRockOpenOrdersParams implements OpenOrdersParamCurrencyPair {
+  private CurrencyPair currencyPair;
+
+  @Override
+  public void setCurrencyPair(CurrencyPair pair) {
+    this.currencyPair = pair;
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return currencyPair;
+  }
+}

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyP
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsIdSpan;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.therock.TheRockAdapters;
 import org.knowm.xchange.therock.dto.trade.TheRockOrder;
 
@@ -51,6 +52,11 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Polli
   @Override
   public OpenOrders getOpenOrders() throws NotAvailableFromExchangeException {
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   /**

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Date;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
@@ -18,6 +19,7 @@ import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamCurrencyP
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsIdSpan;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParamsTimeSpan;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.therock.TheRockAdapters;
 import org.knowm.xchange.therock.dto.trade.TheRockOrder;
@@ -56,7 +58,12 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Polli
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    CurrencyPair currencyPair = null;
+    if (params instanceof OpenOrdersParamCurrencyPair) {
+      currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    return TheRockAdapters.adaptOrders(getTheRockOrders(currencyPair));
   }
 
   /**

--- a/xchange-therock/src/test/java/org/knowm/xchange/therock/service/trade/TheRockTradeServiceIntegrationTest.java
+++ b/xchange-therock/src/test/java/org/knowm/xchange/therock/service/trade/TheRockTradeServiceIntegrationTest.java
@@ -7,6 +7,8 @@ import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.therock.service.polling.TheRockOpenOrdersParams;
 import org.knowm.xchange.therock.service.polling.TheRockTradeService;
 import org.knowm.xchange.therock.service.polling.TheRockTradeServiceRaw;
 
@@ -29,6 +31,17 @@ public abstract class TheRockTradeServiceIntegrationTest extends AbstractTheRock
     LimitOrder limitOrder = new LimitOrder(OrderType.BID, amount, CurrencyPair.BTC_EUR, null, null, price);
     String id = unit.placeLimitOrder(limitOrder);
     assert id != null;
+  }
+
+  @Test
+  public void testOpenOrders() throws IOException {
+    TheRockTradeService unit = createUnit();
+
+    TheRockOpenOrdersParams openOrdersParams = new TheRockOpenOrdersParams();
+    openOrdersParams.setCurrencyPair(CurrencyPair.BTC_EUR);
+
+    OpenOrders openOrders = unit.getOpenOrders(openOrdersParams);
+    assert openOrders != null;
   }
 
 }

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/polling/VaultoroTradeService.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/polling/VaultoroTradeService.java
@@ -14,6 +14,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.vaultoro.VaultoroAdapters;
 import org.knowm.xchange.vaultoro.dto.trade.VaultoroCancelOrderResponse;
 import org.knowm.xchange.vaultoro.dto.trade.VaultoroNewOrderResponse;
@@ -56,6 +57,11 @@ public class VaultoroTradeService extends VaultoroTradeServiceRaw implements Pol
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     return VaultoroAdapters.adaptVaultoroOpenOrders(getVaultoroOrders());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override

--- a/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/polling/VircurexTradeService.java
+++ b/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/polling/VircurexTradeService.java
@@ -14,6 +14,7 @@ import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.polling.trade.PollingTradeService;
 import org.knowm.xchange.service.polling.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParams;
 
 public class VircurexTradeService extends VircurexTradeServiceRaw implements PollingTradeService {
 
@@ -31,6 +32,11 @@ public class VircurexTradeService extends VircurexTradeServiceRaw implements Pol
   public OpenOrders getOpenOrders() throws IOException {
 
     return getVircurexOpenOrders();
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders();
   }
 
   @Override


### PR DESCRIPTION
Hi,

Implemented new method as discussed in #1357. I've implemented it in TheRockExchange as a reference and tested it towards live API through already present "integration tests".

I had a fast look over various TradingServices and it will be common for many exchanges to have currency pair attribute. But for now, new method is returning previous getOpenOrders until someone wants it rewritten.