### PR TITLE
PollingTradeService.createOpenOrdersParams() implemented

### DIFF
--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/polling/ANXTradeService.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/polling/ANXTradeService.java
@@ -43,13 +43,12 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return new OpenOrders(ANXAdapters.adaptOrders(getANXOpenOrders()));
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return new OpenOrders(ANXAdapters.adaptOrders(getANXOpenOrders()));
   }
 
   @Override
@@ -120,6 +119,11 @@ public class ANXTradeService extends ANXTradeServiceRaw implements PollingTradeS
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new DefaultTradeHistoryParamsTimeSpan();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/polling/BitbayTradeService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/polling/BitbayTradeService.java
@@ -31,14 +31,13 @@ public class BitbayTradeService extends BitbayTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
-    List<BitbayOrder> response = getBitbayOpenOrders();
-    return BitbayAdapters.adaptOpenOrders(response);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    List<BitbayOrder> response = getBitbayOpenOrders();
+    return BitbayAdapters.adaptOpenOrders(response);
   }
 
   @Override
@@ -70,6 +69,11 @@ public class BitbayTradeService extends BitbayTradeServiceRaw implements Polling
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/polling/BitfinexTradeService.java
@@ -36,7 +36,11 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     BitfinexOrderStatusResponse[] activeOrders = getBitfinexOpenOrders();
 
     if (activeOrders.length <= 0) {
@@ -44,11 +48,6 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Pol
     } else {
       return BitfinexAdapters.adaptOrders(activeOrders);
     }
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -121,6 +120,11 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Pol
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     return new BitfinexTradeHistoryParams(new Date(0), 50, CurrencyPair.BTC_USD);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class BitfinexTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan

--- a/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/polling/BitMarketTradeService.java
+++ b/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/polling/BitMarketTradeService.java
@@ -37,14 +37,13 @@ public class BitMarketTradeService extends BitMarketTradeServiceRaw implements P
 
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
-    BitMarketOrdersResponse response = getBitMarketOpenOrders();
-    return BitMarketAdapters.adaptOpenOrders(response.getData());
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    BitMarketOrdersResponse response = getBitMarketOpenOrders();
+    return BitMarketAdapters.adaptOpenOrders(response.getData());
   }
 
   @Override
@@ -82,6 +81,11 @@ public class BitMarketTradeService extends BitMarketTradeServiceRaw implements P
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new BitMarketHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/polling/BitsoTradeService.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/polling/BitsoTradeService.java
@@ -46,7 +46,11 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements PollingTr
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, BitsoException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     BitsoOrder[] openOrders = getBitsoOpenOrders();
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
@@ -58,11 +62,6 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements PollingTr
           .add(new LimitOrder(orderType, bitsoOrder.getAmount(), new CurrencyPair(Currency.BTC, Currency.MXN), id, bitsoOrder.getTime(), price));
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -111,6 +110,11 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements PollingTr
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new DefaultTradeHistoryParamPaging(1000);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/polling/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/polling/BitstampTradeService.java
@@ -40,6 +40,12 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, BitstampException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use params instead of currencyPair from exchange specification
     CurrencyPair cp = (CurrencyPair) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(BitstampExchange.CURRENCY_PAIR);
     Collection<CurrencyPair> pairs = cp != null ? Collections.singleton(cp) : ALL_PAIRS;
     List<LimitOrder> limitOrders = new ArrayList<>();
@@ -53,11 +59,6 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Pol
       }
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -111,6 +112,11 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Pol
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new BitstampTradeHistoryParams(CurrencyPair.BTC_USD, 1000);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/polling/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/polling/BittrexTradeService.java
@@ -50,13 +50,12 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders()));
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders()));
   }
 
   @Override
@@ -73,6 +72,11 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Polli
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return PARAMS_ZERO;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/polling/BleutradeTradeService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/polling/BleutradeTradeService.java
@@ -32,13 +32,12 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements P
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return BleutradeAdapters.adaptBleutradeOpenOrders(getBleutradeOpenOrders());
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return BleutradeAdapters.adaptBleutradeOpenOrders(getBleutradeOpenOrders());
   }
 
   @Override
@@ -73,6 +72,11 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements P
   public TradeHistoryParams createTradeHistoryParams() {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/polling/BTCChinaTradeService.java
+++ b/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/polling/BTCChinaTradeService.java
@@ -56,7 +56,11 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     final List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
 
     List<LimitOrder> page;
@@ -70,11 +74,6 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
     } while (page.size() >= BTCChinaGetOrdersRequest.DEFAULT_LIMIT);
 
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -183,6 +182,11 @@ public class BTCChinaTradeService extends BTCChinaTradeServiceRaw implements Pol
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     return new BTCChinaTradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class BTCChinaTradeHistoryParams extends DefaultTradeHistoryParamPaging

--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/polling/BTCETradeService.java
@@ -44,14 +44,13 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    Map<Long, BTCEOrder> orders = getBTCEActiveOrders(null);
-    return BTCEAdapters.adaptOrders(orders);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    Map<Long, BTCEOrder> orders = getBTCEActiveOrders(null);
+    return BTCEAdapters.adaptOrders(orders);
   }
 
   /**
@@ -160,6 +159,11 @@ public class BTCETradeService extends BTCETradeServiceRaw implements PollingTrad
   @Override
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
     return new BTCETradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/polling/BTCMarketsTradeService.java
@@ -69,14 +69,15 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, BTCMarketsException {
-    BTCMarketsOrders openOrders = getBTCMarketsOpenOrders(currencyPair, 50, null);
-
-    return BTCMarketsAdapters.adaptOpenOrders(openOrders);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    // TODO use params instead of currencyPair from exchange specification
+    BTCMarketsOrders openOrders = getBTCMarketsOpenOrders(currencyPair, 50, null);
+
+    return BTCMarketsAdapters.adaptOpenOrders(openOrders);
   }
 
   @Override
@@ -102,6 +103,11 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
   @Override
   public HistoryParams createTradeHistoryParams() {
     return new HistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class HistoryParams implements TradeHistoryParamPaging, TradeHistoryParamsTimeSpan {

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/polling/BTCTradeTradeService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/polling/BTCTradeTradeService.java
@@ -39,13 +39,12 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return BTCTradeAdapters.adaptOpenOrders(getBTCTradeOrders(0, "open"));
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return BTCTradeAdapters.adaptOpenOrders(getBTCTradeOrders(0, "open"));
   }
 
   @Override
@@ -99,6 +98,11 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Pol
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new DefaultTradeHistoryParamsTimeSpan(new Date(0));
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-bter/src/main/java/org/knowm/xchange/bter/service/polling/BTERPollingTradeService.java
+++ b/xchange-bter/src/main/java/org/knowm/xchange/bter/service/polling/BTERPollingTradeService.java
@@ -37,16 +37,15 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    BTEROpenOrders openOrders = super.getBTEROpenOrders();
-    Collection<CurrencyPair> currencyPairs = exchange.getExchangeSymbols();
-
-    return BTERAdapters.adaptOpenOrders(openOrders, currencyPairs);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    BTEROpenOrders openOrders = super.getBTEROpenOrders();
+    Collection<CurrencyPair> currencyPairs = exchange.getExchangeSymbols();
+
+    return BTERAdapters.adaptOpenOrders(openOrders, currencyPairs);
   }
 
   @Override
@@ -92,6 +91,11 @@ public class BTERPollingTradeService extends BTERPollingTradeServiceRaw implemen
   public TradeHistoryParamCurrencyPair createTradeHistoryParams() {
 
     return new DefaultTradeHistoryParamCurrencyPair();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/polling/CampBXTradeService.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/polling/CampBXTradeService.java
@@ -48,6 +48,11 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
 
     MyOpenOrders myOpenOrders = getCampBXOpenOrders();
     logger.debug("myOpenOrders = {}", myOpenOrders);
@@ -79,11 +84,6 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements Polling
     } else {
       throw new ExchangeException("Error calling getOpenOrders(): " + myOpenOrders.getError());
     }
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -146,6 +146,11 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements Polling
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/pooling/CCEXTradeService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/pooling/CCEXTradeService.java
@@ -28,13 +28,12 @@ public class CCEXTradeService extends CCEXTradeServiceRaw implements PollingTrad
 
 	@Override
 	public OpenOrders getOpenOrders() throws IOException {
-		
-		return new OpenOrders(CCEXAdapters.adaptOpenOrders(getCCEXOpenOrders()));
+		return getOpenOrders(createOpenOrdersParams());
 	}
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return new OpenOrders(CCEXAdapters.adaptOpenOrders(getCCEXOpenOrders()));
   }
 
   @Override
@@ -64,6 +63,11 @@ public class CCEXTradeService extends CCEXTradeServiceRaw implements PollingTrad
 	public TradeHistoryParams createTradeHistoryParams() {
 		return PARAMS_ZERO;
 	}
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
+  }
 
   @Override
 	public Collection<Order> getOrder(String... orderIds) throws ExchangeException, NotAvailableFromExchangeException,

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/polling/CexIOTradeService.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/polling/CexIOTradeService.java
@@ -37,15 +37,14 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements PollingTr
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    List<CexIOOrder> cexIOOrderList = getCexIOOpenOrders();
-
-    return CexIOAdapters.adaptOpenOrders(cexIOOrderList);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    List<CexIOOrder> cexIOOrderList = getCexIOOpenOrders();
+
+    return CexIOAdapters.adaptOpenOrders(cexIOOrderList);
   }
 
   @Override
@@ -77,6 +76,11 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements PollingTr
   @Override
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/polling/CoinbaseTradeService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/polling/CoinbaseTradeService.java
@@ -38,14 +38,13 @@ public final class CoinbaseTradeService extends CoinbaseTradeServiceRaw implemen
   }
 
   @Override
-  public OpenOrders getOpenOrders() throws NotAvailableFromExchangeException {
-
-    throw new NotAvailableFromExchangeException();
+  public OpenOrders getOpenOrders() throws NotAvailableFromExchangeException, IOException {
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
@@ -100,6 +99,11 @@ public final class CoinbaseTradeService extends CoinbaseTradeServiceRaw implemen
     params.setPageNumber(0);
     params.setPageLength(100);
     return params;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
 }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/polling/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/polling/CoinmateTradeService.java
@@ -54,6 +54,12 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO rewrite to use OpenOrdersParams
     List<LimitOrder> orders = new ArrayList<>();
     for (CurrencyPair currencyPair : CoinmateAdapters.COINMATE_CURRENCY_PAIRS) {
       String currencyPairString = CoinmateUtils.getPair(currencyPair);
@@ -62,11 +68,6 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
       orders.addAll(CoinmateAdapters.adaptOpenOrders(coinmateOpenOrders, currencyPair));
     }
     return new OpenOrders(orders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -122,6 +123,11 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Pol
     params.setPageNumber(0);
     params.setOrder(TradeHistoryParamsSorted.Order.asc);
     return params;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/PollingTradeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/PollingTradeService.java
@@ -40,14 +40,16 @@ public interface PollingTradeService extends BasePollingService {
    * @throws NotYetImplementedForExchangeException - Indication that the exchange supports the requested function or data, but it has not yet been
    *         implemented
    * @throws IOException - Indication that a networking error occurred while fetching JSON data
+   * @deprecated Use {@link #getOpenOrders(OpenOrdersParams)} instead. Will be removed in the future release.
    */
+  @Deprecated
   OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException;
 
   /**
    * Gets the open orders
    *
    * @param params The parameters describing the filter. Note that {@link OpenOrdersParams} is an empty interface. Exchanges should implement its
-   * own params object.
+   * own params object. Params should be create with {@link #createOpenOrdersParams()}.
    *
    * @return the open orders, null if some sort of error occurred. Implementers should log the error.
    * @throws ExchangeException - Indication that the exchange reported some kind of error with the request or response
@@ -137,6 +139,13 @@ public interface PollingTradeService extends BasePollingService {
    * that created the object.
    */
   TradeHistoryParams createTradeHistoryParams();
+
+  /**
+   * Create {@link OpenOrdersParams} object specific to this exchange. Object created by this method may be used to discover supported and required
+   * {@link #getOpenOrders(OpenOrdersParams)} parameters and should be passed only to the method in the same class as the createOpenOrdersParams
+   * that created the object.
+   */
+  OpenOrdersParams createOpenOrdersParams();
 
   /**
    * Verify the order against the exchange meta data. Most implementations will require that {@link org.knowm.xchange.Exchange#remoteInit()} be called

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/DefaultOpenOrdersParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/DefaultOpenOrdersParamCurrencyPair.java
@@ -1,0 +1,27 @@
+package org.knowm.xchange.service.polling.trade.params.orders;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public class DefaultOpenOrdersParamCurrencyPair implements OpenOrdersParamCurrencyPair {
+
+  private CurrencyPair pair;
+
+  public DefaultOpenOrdersParamCurrencyPair() {
+  }
+
+  public DefaultOpenOrdersParamCurrencyPair(CurrencyPair pair) {
+    this.pair = pair;
+  }
+
+  @Override
+  public void setCurrencyPair(CurrencyPair pair) {
+
+    this.pair = pair;
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+
+    return pair;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/polling/trade/params/orders/OpenOrdersParams.java
@@ -2,7 +2,14 @@ package org.knowm.xchange.service.polling.trade.params.orders;
 
 /**
  * Root interface for all interfaces used as a parameter type for
- * {@link org.knowm.xchange.service.polling.trade.PollingTradeService#getOpenOrders(OpenOrdersParams)} .
+ * {@link org.knowm.xchange.service.polling.trade.PollingTradeService#getOpenOrders(OpenOrdersParams)}.
+ * <p>
+ * Each exchange should have its own class implementing at least one from following available interfaces:
+ * <ul>
+ *   <li>{@link OpenOrdersParamCurrencyPair}.</li>
+ * </ul>
+ * <p>
+ * When suitable exchange params definition can extend from default classes, eg. {@link DefaultOpenOrdersParamCurrencyPair}.
  */
 public interface OpenOrdersParams {
 }

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/polling/CryptoFacilitiesTradeService.java
@@ -35,14 +35,12 @@ public class CryptoFacilitiesTradeService extends CryptoFacilitiesTradeServiceRa
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return CryptoFacilitiesAdapters.adaptOpenOrders(super.getCryptoFacilitiesOpenOrders());
-
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return CryptoFacilitiesAdapters.adaptOpenOrders(super.getCryptoFacilitiesOpenOrders());
   }
 
   @Override
@@ -73,6 +71,11 @@ public class CryptoFacilitiesTradeService extends CryptoFacilitiesTradeServiceRa
   @Override
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
+    return null;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
     return null;
   }
 

--- a/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/polling/EmpoExTradeService.java
+++ b/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/polling/EmpoExTradeService.java
@@ -32,13 +32,12 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return EmpoExAdapters.adaptOpenOrders(super.getEmpoExOpenOrders());
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return EmpoExAdapters.adaptOpenOrders(super.getEmpoExOpenOrders());
   }
 
   @Override
@@ -73,6 +72,11 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements Polling
   public TradeHistoryParams createTradeHistoryParams() {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/polling/GatecoinTradeService.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/polling/GatecoinTradeService.java
@@ -47,7 +47,11 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     GatecoinOrderResult openOrdersResult = getGatecoinOpenOrders();
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
@@ -61,11 +65,6 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Pol
           DateUtils.fromMillisUtc(Long.valueOf(gatecoinOrder.getDate()) * 1000L), price));
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -136,6 +135,11 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Pol
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new GatecoinTradeHistoryParams(1000);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
@@ -30,15 +30,14 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements PollingTrad
 
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
-    GDAXOrder[] coinbaseExOpenOrders = getCoinbaseExOpenOrders();
-
-    return GDAXAdapters.adaptOpenOrders(coinbaseExOpenOrders);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    GDAXOrder[] coinbaseExOpenOrders = getCoinbaseExOpenOrders();
+
+    return GDAXAdapters.adaptOpenOrders(coinbaseExOpenOrders);
   }
 
   @Override
@@ -73,6 +72,11 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements PollingTrad
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
+    return null;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
     return null;
   }
 

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/polling/GeminiTradeService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/polling/GeminiTradeService.java
@@ -35,7 +35,11 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     GeminiOrderStatusResponse[] activeOrders = getGeminiOpenOrders();
 
     if (activeOrders.length <= 0) {
@@ -43,11 +47,6 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements Polling
     } else {
       return GeminiAdapters.adaptOrders(activeOrders);
     }
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -115,6 +114,11 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements Polling
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     return new GeminiTradeHistoryParams(new Date(0), 50, CurrencyPair.BTC_USD);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class GeminiTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/polling/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/polling/HitbtcTradeService.java
@@ -39,14 +39,13 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    HitbtcOrder[] openOrdersRaw = getOpenOrdersRaw();
-    return HitbtcAdapters.adaptOpenOrders(openOrdersRaw);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    HitbtcOrder[] openOrdersRaw = getOpenOrdersRaw();
+    return HitbtcAdapters.adaptOpenOrders(openOrdersRaw);
   }
 
   @Override
@@ -100,6 +99,11 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements Polling
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new HitbtcTradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class HitbtcTradeHistoryParams extends DefaultTradeHistoryParamPaging implements TradeHistoryParamCurrencyPair {

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/polling/GenericTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/polling/GenericTradeService.java
@@ -50,7 +50,12 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use params for currency pair
     List<LimitOrder> openOrders = new ArrayList<LimitOrder>();
     for (CurrencyPair currencyPair : exchange.getExchangeMetaData().getCurrencyPairs().keySet()) {
       HuobiOrder[] orders = tradeServiceRaw.getOrders(coinTypes.get(currencyPair));
@@ -65,11 +70,6 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
     }
 
     return new OpenOrders(openOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -122,5 +122,10 @@ public class GenericTradeService extends BaseExchangeService implements PollingT
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 }

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/polling/IndependentReserveTradeService.java
@@ -30,14 +30,14 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
    */
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    // get orders for all currencies
-    OpenOrders orders = IndependentReserveAdapters.adaptOpenOrders(getIndependentReserveOpenOrders(null, null, 1));
-    return orders;
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    // get orders for all currencies
+    OpenOrders orders = IndependentReserveAdapters.adaptOpenOrders(getIndependentReserveOpenOrders(null, null, 1));
+    return orders;
   }
 
   @Override
@@ -77,5 +77,10 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
   @Override
   public TradeHistoryParamPaging createTradeHistoryParams() {
     return new DefaultTradeHistoryParamPaging(null, 0);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 }

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitOpenOrdersParams.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitOpenOrdersParams.java
@@ -1,18 +1,6 @@
 package org.knowm.xchange.itbit.v1.service.polling;
 
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.polling.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 
-public class ItBitOpenOrdersParams implements OpenOrdersParamCurrencyPair {
-  private CurrencyPair currencyPair;
-
-  @Override
-  public void setCurrencyPair(CurrencyPair pair) {
-    this.currencyPair = pair;
-  }
-
-  @Override
-  public CurrencyPair getCurrencyPair() {
-    return currencyPair;
-  }
+public class ItBitOpenOrdersParams extends DefaultOpenOrdersParamCurrencyPair {
 }

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/polling/ItBitTradeService.java
@@ -1,7 +1,8 @@
 package org.knowm.xchange.itbit.v1.service.polling;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Date;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -30,12 +31,7 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    List<ItBitOrder> orders = new ArrayList<>();
-    for (CurrencyPair currencyPair : exchange.getExchangeSymbols()) {
-      orders.addAll(Arrays.asList(getItBitOpenOrders(currencyPair)));
-    }
-    ItBitOrder[] empty = {};
-    return ItBitAdapters.adaptPrivateOrders(orders.isEmpty() ? empty : Arrays.copyOf(orders.toArray(), orders.size(), ItBitOrder[].class));
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
@@ -47,12 +43,13 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
 
     // In case of no currency pair - return all currency pairs.
     if (currencyPair == null) {
-      return getOpenOrders();
+      throw new ExchangeException("CurrencyPair parameter must not be null.");
     }
 
     ItBitOrder[] itBitOpenOrders = getItBitOpenOrders(currencyPair);
     return ItBitAdapters.adaptPrivateOrders(itBitOpenOrders);
   }
+
 
   @Override
   public String placeMarketOrder(MarketOrder marketOrder) throws IOException {
@@ -90,6 +87,11 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements PollingTr
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new ItBitTradeHistoryParams(50, 0, null, null, null);
+  }
+
+  @Override
+  public ItBitOpenOrdersParams createOpenOrdersParams() {
+    return new ItBitOpenOrdersParams();
   }
 
   public static class ItBitTradeHistoryParams extends DefaultTradeHistoryParamPaging

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/polling/KrakenTradeService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/polling/KrakenTradeService.java
@@ -35,13 +35,12 @@ public class KrakenTradeService extends KrakenTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return KrakenAdapters.adaptOpenOrders(super.getKrakenOpenOrders());
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return KrakenAdapters.adaptOpenOrders(super.getKrakenOpenOrders());
   }
 
   @Override
@@ -94,6 +93,11 @@ public class KrakenTradeService extends KrakenTradeServiceRaw implements Polling
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     return new KrakenTradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class KrakenTradeHistoryParams extends DefaultTradeHistoryParamsTimeSpan implements TradeHistoryParamOffset {

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/polling/LakeBTCTradeService.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/polling/LakeBTCTradeService.java
@@ -32,12 +32,12 @@ public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements Polli
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    throw new NotYetImplementedForExchangeException();
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    throw new NotYetImplementedForExchangeException();
   }
 
   @Override
@@ -66,6 +66,11 @@ public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements Polli
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-loyalbit/src/main/java/org/knowm/xchange/loyalbit/service/polling/LoyalbitTradeService.java
+++ b/xchange-loyalbit/src/main/java/org/knowm/xchange/loyalbit/service/polling/LoyalbitTradeService.java
@@ -39,6 +39,11 @@ public class LoyalbitTradeService extends LoyalbitTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, LoyalbitException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     LoyalbitOrder[] openOrders = getLoyalbitOpenOrders();
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
@@ -46,11 +51,6 @@ public class LoyalbitTradeService extends LoyalbitTradeServiceRaw implements Pol
       limitOrders.add(LoyalbitAdapters.adaptOrder(loyalbitOrder));
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -91,6 +91,11 @@ public class LoyalbitTradeService extends LoyalbitTradeServiceRaw implements Pol
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new DefaultTradeHistoryParamPagingSorted(100, TradeHistoryParamsSorted.Order.desc);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/polling/MercadoBitcoinTradeService.java
@@ -45,7 +45,12 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use currency pair param
     MercadoBitcoinBaseTradeApiResult<MercadoBitcoinUserOrders> openOrdersBitcoinResult = getMercadoBitcoinUserOrders("btc_brl", null, "active", null,
         null, null, null);
     MercadoBitcoinBaseTradeApiResult<MercadoBitcoinUserOrders> openOrdersLitecoinResult = getMercadoBitcoinUserOrders("ltc_brl", null, "active", null,
@@ -57,11 +62,6 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
     limitOrders.addAll(MercadoBitcoinAdapters.adaptOrders(new CurrencyPair(Currency.LTC, Currency.BRL), openOrdersLitecoinResult));
 
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -155,6 +155,11 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new MercadoTradeHistoryParams(CurrencyPair.BTC_BRL);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class MercadoTradeHistoryParams extends DefaultTradeHistoryParamCurrencyPair

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinFuturesTradeService.java
@@ -53,6 +53,12 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use params for currency pair
     List<CurrencyPair> exchangeSymbols = exchange.getExchangeSymbols();
 
     List<OkCoinFuturesOrderResult> orderResults = new ArrayList<OkCoinFuturesOrderResult>(exchangeSymbols.size());
@@ -72,11 +78,6 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
     }
 
     return OkCoinAdapters.adaptOpenOrdersFutures(orderResults);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -180,6 +181,11 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
   @Override
   public OkCoinFuturesTradeHistoryParams createTradeHistoryParams() {
     return new OkCoinFuturesTradeHistoryParams(50, 0, CurrencyPair.BTC_USD, futuresContract, null);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   // TODO if Futures ever get a generic interface, move this interface to xchange-core

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/polling/OkCoinTradeService.java
@@ -48,7 +48,12 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use params to specify currency pair
     List<CurrencyPair> exchangeSymbols = exchange.getExchangeSymbols();
 
     List<OkCoinOrderResult> orderResults = new ArrayList<OkCoinOrderResult>(exchangeSymbols.size());
@@ -67,11 +72,6 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements Polling
     }
 
     return OkCoinAdapters.adaptOpenOrders(orderResults);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -160,6 +160,11 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements Polling
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     return new OkCoinTradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   public static class OkCoinTradeHistoryParams extends DefaultTradeHistoryParamPaging implements TradeHistoryParamCurrencyPair {

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/polling/PoloniexTradeService.java
@@ -40,14 +40,13 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    HashMap<String, PoloniexOpenOrder[]> poloniexOpenOrders = returnOpenOrders();
-    return PoloniexAdapters.adaptPoloniexOpenOrders(poloniexOpenOrders);
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    HashMap<String, PoloniexOpenOrder[]> poloniexOpenOrders = returnOpenOrders();
+    return PoloniexAdapters.adaptPoloniexOpenOrders(poloniexOpenOrders);
   }
 
   @Override
@@ -146,6 +145,11 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Pol
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new PoloniexTradeHistoryParams();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/polling/QuadrigaCxTradeService.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/polling/QuadrigaCxTradeService.java
@@ -43,7 +43,12 @@ public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, QuadrigaCxException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
 
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    // TODO use params to specify currency pair
     Collection<CurrencyPair> pairs = exchange.getExchangeSymbols();
     List<LimitOrder> limitOrders = new ArrayList<>();
 
@@ -57,11 +62,6 @@ public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements
       }
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -136,6 +136,11 @@ public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements
   public TradeHistoryParams createTradeHistoryParams() {
 
     return new QuadrigaCxTradeHistoryParams(CurrencyPair.BTC_CAD, 1000);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/polling/QuoineTradeService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/polling/QuoineTradeService.java
@@ -36,15 +36,13 @@ public class QuoineTradeService extends QuoineTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    QuoineOrdersList quoineOrdersList = listQuoineOrders(null);
-    return QuoineAdapters.adapteOpenOrders(quoineOrdersList);
-
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    QuoineOrdersList quoineOrdersList = listQuoineOrders(null);
+    return QuoineAdapters.adapteOpenOrders(quoineOrdersList);
   }
 
   @Override
@@ -87,6 +85,11 @@ public class QuoineTradeService extends QuoineTradeServiceRaw implements Polling
   public TradeHistoryParams createTradeHistoryParams() {
 
     throw new NotAvailableFromExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
 }

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/polling/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/polling/RippleTradeService.java
@@ -46,12 +46,12 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
    */
   @Override
   public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return RippleAdapters.adaptOpenOrders(getOpenAccountOrders(), ripple.getRoundingScale());
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return RippleAdapters.adaptOpenOrders(getOpenAccountOrders(), ripple.getRoundingScale());
   }
 
   @Override
@@ -135,5 +135,10 @@ public class RippleTradeService extends RippleTradeServiceRaw implements Polling
     final RippleTradeHistoryParams params = new RippleTradeHistoryParams();
     params.setAccount(exchange.getExchangeSpecification().getApiKey());
     return params;
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 }

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/polling/TaurusTradeService.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/polling/TaurusTradeService.java
@@ -38,6 +38,11 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements Polling
 
   @Override
   public OpenOrders getOpenOrders() throws IOException, TaurusException {
+    return getOpenOrders(createOpenOrdersParams());
+  }
+
+  @Override
+  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     TaurusOrder[] openOrders = getTaurusOpenOrders();
 
     List<LimitOrder> limitOrders = new ArrayList<LimitOrder>();
@@ -48,11 +53,6 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements Polling
       limitOrders.add(new LimitOrder(orderType, taurusOrder.getAmount(), CurrencyPair.BTC_CAD, id, taurusOrder.getDatetime(), price));
     }
     return new OpenOrders(limitOrders);
-  }
-
-  @Override
-  public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
   }
 
   @Override
@@ -96,6 +96,11 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements Polling
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     return new DefaultTradeHistoryParamPaging(1000);
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockOpenOrdersParams.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockOpenOrdersParams.java
@@ -1,18 +1,6 @@
 package org.knowm.xchange.therock.service.polling;
 
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.service.polling.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.polling.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 
-public class TheRockOpenOrdersParams implements OpenOrdersParamCurrencyPair {
-  private CurrencyPair currencyPair;
-
-  @Override
-  public void setCurrencyPair(CurrencyPair pair) {
-    this.currencyPair = pair;
-  }
-
-  @Override
-  public CurrencyPair getCurrencyPair() {
-    return currencyPair;
-  }
+public class TheRockOpenOrdersParams extends DefaultOpenOrdersParamCurrencyPair {
 }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/polling/TheRockTradeService.java
@@ -53,15 +53,20 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Polli
    * Not available from exchange since TheRock needs currency pair in order to return open orders
    */
   @Override
-  public OpenOrders getOpenOrders() throws NotAvailableFromExchangeException {
-    throw new NotAvailableFromExchangeException();
+  public OpenOrders getOpenOrders() throws IOException {
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     CurrencyPair currencyPair = null;
+
     if (params instanceof OpenOrdersParamCurrencyPair) {
       currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
+    }
+
+    if (currencyPair == null) {
+      throw new ExchangeException("CurrencyPair parameter must not be null.");
     }
 
     return TheRockAdapters.adaptOrders(getTheRockOrders(currencyPair));
@@ -116,5 +121,10 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Polli
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
     throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return new TheRockOpenOrdersParams();
   }
 }

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/polling/VaultoroTradeService.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/polling/VaultoroTradeService.java
@@ -54,14 +54,18 @@ public class VaultoroTradeService extends VaultoroTradeServiceRaw implements Pol
   }
 
   @Override
-  public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
+  }
 
-    return VaultoroAdapters.adaptVaultoroOpenOrders(getVaultoroOrders());
+  @Override
+  public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return VaultoroAdapters.adaptVaultoroOpenOrders(getVaultoroOrders());
   }
 
   @Override

--- a/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/polling/VircurexTradeService.java
+++ b/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/polling/VircurexTradeService.java
@@ -30,13 +30,12 @@ public class VircurexTradeService extends VircurexTradeServiceRaw implements Pol
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-
-    return getVircurexOpenOrders();
+    return getOpenOrders(createOpenOrdersParams());
   }
 
   @Override
   public OpenOrders getOpenOrders(OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return getOpenOrders();
+    return getVircurexOpenOrders();
   }
 
   @Override
@@ -67,6 +66,11 @@ public class VircurexTradeService extends VircurexTradeServiceRaw implements Pol
   public org.knowm.xchange.service.polling.trade.params.TradeHistoryParams createTradeHistoryParams() {
 
     throw new NotYetImplementedForExchangeException();
+  }
+
+  @Override
+  public OpenOrdersParams createOpenOrdersParams() {
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Core
- `PollingTradeService.createOpenOrdersParams()` introduced.
- `PollingTradeService.getOpenOraders()` marked as `@Deprecated`.
- `DefaultOpenOrdersCurrencyPairParam` created.

Exchange
- All `getOpenOrders()` call `getOpenOrders(createOpenOrdersParams())`.
- Implementations of `getOpenOrders` moved into `getOpenOrders(OpenOrdersParams params)`.
- Default implementation of `createOpenOrders` is returning null - I think it's better than `TradeHistoryParamsZero`.
- Exchanges that use more than one request for retrieval of open orders marked with TODO
- API BREAK: `ItBitTradeService.getOpenOrders()` don't return all currency pairs but only one via new method. User can write its retrieval of all currency pairs and then call getOpenOrders many times.

That's all. I didn't solve TODOs for exchanges (only for TheRock and ItBit - as I need it). It's not in my time scope but at least ten exchanges can be improved via `OpenOrdersParams` now :).
