### PR TITLE
LimitOrder.Builder does not set order status properly

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -154,7 +154,7 @@ public abstract class Order {
    * @param id An id (usually provided by the exchange)
    * @param timestamp the absolute time for this order according to the exchange's server, null if not provided
    * @param averagePrice the averagePrice of fill belonging to the order
-   * @param orderStatus the status of the order at the exchange
+   * @param status the status of the order at the exchange
    */
   public Order(OrderType type, BigDecimal tradableAmount, CurrencyPair currencyPair, String id, Date timestamp, BigDecimal averagePrice,
       BigDecimal cumulativeAmount, OrderStatus status) {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -120,7 +120,8 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     public static Builder from(Order order) {
 
       Builder builder = (Builder) new Builder(order.getType(), order.getCurrencyPair()).tradableAmount(order.getTradableAmount())
-          .timestamp(order.getTimestamp()).id(order.getId()).flags(order.getOrderFlags());
+          .timestamp(order.getTimestamp()).id(order.getId()).flags(order.getOrderFlags()).orderStatus(order.getStatus())
+          .averagePrice(order.getAveragePrice());
       if (order instanceof LimitOrder) {
         LimitOrder limitOrder = (LimitOrder) order;
         builder.limitPrice(limitOrder.getLimitPrice());
@@ -166,7 +167,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
 
     public LimitOrder build() {
 
-      LimitOrder order = new LimitOrder(orderType, tradableAmount, currencyPair, id, timestamp, limitPrice);
+      LimitOrder order = new LimitOrder(orderType, tradableAmount, currencyPair, id, timestamp, limitPrice, averagePrice, null, status);
       order.setOrderFlags(flags);
       return order;
     }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
@@ -21,6 +21,19 @@ public class MarketOrder extends Order {
    * @param tradableAmount The amount to trade
    * @param currencyPair The identifier (e.g. BTC/USD)
    * @param id An id (usually provided by the exchange)
+   * @param timestamp a Date object representing the order's timestamp according to the exchange's server, null if not provided
+   * @param averagePrice the weighted average price of any fills belonging to the order
+   * @param status the status of the order at the exchange or broker
+   */
+  public MarketOrder(OrderType type, BigDecimal tradableAmount, CurrencyPair currencyPair, String id, Date timestamp, BigDecimal averagePrice, BigDecimal cumulativeAmount, OrderStatus status) {
+    super(type, tradableAmount, currencyPair, id, timestamp, averagePrice, cumulativeAmount, status);
+  }
+
+  /**
+   * @param type Either BID (buying) or ASK (selling)
+   * @param tradableAmount The amount to trade
+   * @param currencyPair The identifier (e.g. BTC/USD)
+   * @param id An id (usually provided by the exchange)
    * @param timestamp the absolute time for this order
    */
   public MarketOrder(OrderType type, BigDecimal tradableAmount, CurrencyPair currencyPair, String id, Date timestamp) {
@@ -59,7 +72,7 @@ public class MarketOrder extends Order {
     public static Builder from(Order order) {
 
       return (Builder) new Builder(order.getType(), order.getCurrencyPair()).tradableAmount(order.getTradableAmount()).timestamp(order.getTimestamp())
-          .id(order.getId()).flags(order.getOrderFlags());
+          .id(order.getId()).flags(order.getOrderFlags()).averagePrice(order.getAveragePrice()).orderStatus(order.getStatus());
     }
 
     @Override
@@ -106,10 +119,8 @@ public class MarketOrder extends Order {
 
     public MarketOrder build() {
 
-      MarketOrder order = new MarketOrder(orderType, tradableAmount, currencyPair, id, timestamp);
+      MarketOrder order = new MarketOrder(orderType, tradableAmount, currencyPair, id, timestamp, averagePrice, null, status);
       order.setOrderFlags(flags);
-      order.setAveragePrice(averagePrice);
-      order.setOrderStatus(status);
       return order;
     }
   }

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
@@ -8,6 +8,7 @@ import java.util.Date;
 
 import org.junit.Test;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.IOrderFlags;
 import org.knowm.xchange.dto.Order.OrderType;
 
@@ -24,9 +25,10 @@ public class LimitOrderTest {
     final BigDecimal limitPrice = new BigDecimal("251.64");
     final Date timestamp = new Date();
     final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
 
     final LimitOrder.Builder builder = (LimitOrder.Builder) new LimitOrder.Builder(type, currencyPair).tradableAmount(tradableAmount)
-        .limitPrice(limitPrice).timestamp(timestamp).id(id).flag(TestFlags.TEST1);
+        .limitPrice(limitPrice).timestamp(timestamp).id(id).flag(TestFlags.TEST1).orderStatus(status);
     final LimitOrder copy = builder.build();
 
     assertThat(copy.getType()).isEqualTo(type);
@@ -38,6 +40,7 @@ public class LimitOrderTest {
     assertThat(copy.getOrderFlags()).hasSize(1);
     assertThat(copy.getOrderFlags()).contains(TestFlags.TEST1);
     assertThat(copy.hasFlag(TestFlags.TEST1));
+    assertThat(copy.getStatus()).isEqualTo(status);
   }
 
   @Test
@@ -48,10 +51,12 @@ public class LimitOrderTest {
     final BigDecimal limitPrice = new BigDecimal("250.34");
     final Date timestamp = new Date();
     final String id = "id";
+    final Order.OrderStatus status = Order.OrderStatus.FILLED;
 
     final LimitOrder original = new LimitOrder(type, tradableAmount, currencyPair, id, timestamp, limitPrice);
     original.addOrderFlag(TestFlags.TEST1);
     original.addOrderFlag(TestFlags.TEST3);
+    original.setOrderStatus(status);
     final LimitOrder copy = LimitOrder.Builder.from(original).build();
 
     assertThat(copy.getType()).isEqualTo(original.getType());
@@ -65,6 +70,7 @@ public class LimitOrderTest {
     assertThat(copy.hasFlag(TestFlags.TEST1));
     assertThat(copy.getOrderFlags()).contains(TestFlags.TEST3);
     assertThat(copy.hasFlag(TestFlags.TEST3));
+    assertThat(copy.getStatus()).isEqualTo(status);
   }
 
   @Test


### PR DESCRIPTION
I've found that LimitOrder.Builder does not reflect status set to the builder when is building the order.

Is it bug? Attached failing unit test. Can attach fix if agreed.