### PR TITLE
LimitPrice fix for BitBay's open orders.

### DIFF
--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayAdapters.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/BitbayAdapters.java
@@ -147,6 +147,7 @@ public class BitbayAdapters {
       throw new IllegalArgumentException(e);
     }
 
-    return new LimitOrder(type, bitbayOrder.getAmount(), currencyPair, String.valueOf(bitbayOrder.getId()), date, bitbayOrder.getPrice());
+    return new LimitOrder(type, bitbayOrder.getAmount(), currencyPair, String.valueOf(bitbayOrder.getId()), date, bitbayOrder.getStartPrice()
+        .divide(bitbayOrder.getStartAmount()));
   }
 }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/dto/trade/BitbayOrder.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/dto/trade/BitbayOrder.java
@@ -17,7 +17,7 @@ public class BitbayOrder {
   private final String status;
   private final BigDecimal amount;
   private final BigDecimal startAmount;
-  private final BigDecimal price;
+  private final BigDecimal currentPrice;
   private final BigDecimal startPrice;
 
   /**
@@ -35,7 +35,7 @@ public class BitbayOrder {
   public BitbayOrder(@JsonProperty("order_id") long id, @JsonProperty("order_currency") String currency, @JsonProperty("order_date") String date,
                      @JsonProperty("payment_currency") String paymentCurrency, @JsonProperty("type") String type,
                      @JsonProperty("status") String status, @JsonProperty("units") BigDecimal amount, @JsonProperty("start_units") BigDecimal startAmount,
-                     @JsonProperty("current_price") BigDecimal price, @JsonProperty("start_price") BigDecimal startPrice) {
+                     @JsonProperty("current_price") BigDecimal currentPrice, @JsonProperty("start_price") BigDecimal startPrice) {
 
     this.id = id;
     this.currency = currency;
@@ -46,7 +46,7 @@ public class BitbayOrder {
     this.status = status;
     this.amount = amount;
     this.startAmount = startAmount;
-    this.price = price;
+    this.currentPrice = currentPrice;
     this.startPrice = startPrice;
   }
 
@@ -82,8 +82,8 @@ public class BitbayOrder {
     return startAmount;
   }
 
-  public BigDecimal getPrice() {
-    return price;
+  public BigDecimal getCurrentPrice() {
+    return currentPrice;
   }
 
   public BigDecimal getStartPrice() {

--- a/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/BitbayAdapterTest.java
+++ b/xchange-bitbay/src/test/java/org/knowm/xchange/bitbay/BitbayAdapterTest.java
@@ -57,13 +57,13 @@ public class BitbayAdapterTest {
     OpenOrders openOrders = BitbayAdapters.adaptOpenOrders(orders);
 
     assertThat(openOrders.getOpenOrders().size()).isEqualTo(2);
-    assertThat(openOrders.getOpenOrders().get(0).getLimitPrice()).isEqualTo("140.00000000");
+    assertThat(openOrders.getOpenOrders().get(0).getLimitPrice()).isEqualByComparingTo("1400");
     assertThat(openOrders.getOpenOrders().get(0).getTradableAmount()).isEqualTo("0.10000000");
     assertThat(openOrders.getOpenOrders().get(0).getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
     assertThat(openOrders.getOpenOrders().get(0).getType()).isEqualTo(Order.OrderType.ASK);
     assertThat(openOrders.getOpenOrders().get(0).getId()).isEqualTo("59057271");
 
-    assertThat(openOrders.getOpenOrders().get(1).getLimitPrice()).isEqualTo("150.00000000");
+    assertThat(openOrders.getOpenOrders().get(1).getLimitPrice()).isEqualByComparingTo("1500");
     assertThat(openOrders.getOpenOrders().get(1).getTradableAmount()).isEqualTo("0.10000000");
     assertThat(openOrders.getOpenOrders().get(1).getCurrencyPair()).isEqualTo(CurrencyPair.BTC_EUR);
     assertThat(openOrders.getOpenOrders().get(1).getType()).isEqualTo(Order.OrderType.ASK);

--- a/xchange-bitbay/src/test/resources/trade/example-orders-data.json
+++ b/xchange-bitbay/src/test/resources/trade/example-orders-data.json
@@ -1,6 +1,6 @@
 [
   {
-    "current_price": "140.00000000",
+    "current_price": "4.00000000",
     "order_currency": "BTC",
     "order_date": "2017-01-02 16:20:37",
     "order_id": 59057271,
@@ -12,7 +12,7 @@
     "units": "0.10000000"
   },
   {
-    "current_price": "150.00000000",
+    "current_price": "50.00000000",
     "order_currency": "BTC",
     "order_date": "2017-01-02 16:20:12",
     "order_id": 59057261,
@@ -24,7 +24,7 @@
     "units": "0.10000000"
   },
   {
-    "current_price": "150.00000000",
+    "current_price": "50.00000000",
     "order_currency": "BTC",
     "order_date": "2017-01-02 16:20:12",
     "order_id": 59057261,


### PR DESCRIPTION
Bitbay is returning "actual" price instead of "limitPrice" for the orders.