### PR TITLE
Initial support for trading futures on BitVc

### DIFF
--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFutures.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFutures.java
@@ -2,41 +2,76 @@ package org.knowm.xchange.huobi;
 
 import java.io.IOException;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 
+import org.knowm.xchange.huobi.dto.account.BitVcFuturesAccountInfo;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcExchangeRate;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesDepth;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesTicker;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesTrade;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPlaceOrderResult;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPosition;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPositionByContract;
+import org.knowm.xchange.huobi.dto.trade.HuobiPlaceOrderResult;
+import si.mazi.rescu.ParamsDigest;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
 public interface BitVcFutures {
 
-  @GET
-  @Path("ticker_{symbol}_{contract}.js")
-  public BitVcFuturesTicker getTicker(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+    @GET
+    @Path("ticker_{symbol}_{contract}.js")
+    public BitVcFuturesTicker getTicker(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
 
-  @GET
-  @Path("depths_{symbol}_{contract}.js")
-  public BitVcFuturesDepth getDepths(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+    @GET
+    @Path("depths_{symbol}_{contract}.js")
+    public BitVcFuturesDepth getDepths(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
 
-  @GET
-  @Path("trades_{symbol}_{contract}.js")
-  public BitVcFuturesTrade[] getTrades(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
+    @GET
+    @Path("trades_{symbol}_{contract}.js")
+    public BitVcFuturesTrade[] getTrades(@PathParam("symbol") String symbol, @PathParam("contract") String contract) throws IOException;
 
-  /** Non-XChange compatible methods */
+    /**
+     * Non-XChange compatible methods
+     */
 
   /*
    * @GET
    * @Path("index_price_{symbol}") public BitVcIndex getIndex(@PathParam("symbol") String symbol) throws IOException;
    */
+    @GET
+    @Path("exchange_rate.js")
+    public BitVcExchangeRate getExchangeRate() throws IOException;
 
-  @GET
-  @Path("exchange_rate.js")
-  public BitVcExchangeRate getExchangeRate() throws IOException;
+    @POST
+    @Path("order/save")
+    public BitVcFuturesPlaceOrderResult placeLimitOrder(
+            @FormParam("accessKey") String accessKey,
+            @FormParam("coinType") int coinType,
+            @FormParam("contractType") String contractType,
+            @FormParam("created") long created,
+            @FormParam("sign") ParamsDigest sign,
+            @FormParam("orderType") int orderType,
+            @FormParam("tradeType") int tradeType,
+          /* @FormParam("joinedType") int joinedType ??? */
+            @FormParam("price") double price,
+            @FormParam("money") double amount) throws IOException;
+
+    @POST
+    @Path("balance")
+    public BitVcFuturesAccountInfo balance(
+            @FormParam("accessKey") String accessKey,
+            @FormParam("coinType") int coinType,
+            @FormParam("created") long created,
+            @FormParam("sign") ParamsDigest sign);
+
+    @POST
+    @Path("holdOrder/list")
+    public BitVcFuturesPositionByContract positions(
+            @FormParam("accessKey") String accessKey,
+            @FormParam("coinType") int coinType,
+            @FormParam("created") long created,
+            @FormParam("sign") ParamsDigest sign);
+
 }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFutures.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFutures.java
@@ -36,10 +36,6 @@ public interface BitVcFutures {
      * Non-XChange compatible methods
      */
 
-  /*
-   * @GET
-   * @Path("index_price_{symbol}") public BitVcIndex getIndex(@PathParam("symbol") String symbol) throws IOException;
-   */
     @GET
     @Path("exchange_rate.js")
     public BitVcExchangeRate getExchangeRate() throws IOException;
@@ -54,7 +50,6 @@ public interface BitVcFutures {
             @FormParam("sign") ParamsDigest sign,
             @FormParam("orderType") int orderType,
             @FormParam("tradeType") int tradeType,
-          /* @FormParam("joinedType") int joinedType ??? */
             @FormParam("price") double price,
             @FormParam("money") double amount) throws IOException;
 

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFuturesAdapter.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/BitVcFuturesAdapter.java
@@ -1,26 +1,41 @@
 package org.knowm.xchange.huobi;
 
+import static org.knowm.xchange.currency.Currency.BTC;
+import static org.knowm.xchange.currency.Currency.LTC;
+import static org.knowm.xchange.currency.Currency.USD;
 import static org.knowm.xchange.dto.Order.OrderType.ASK;
 import static org.knowm.xchange.dto.Order.OrderType.BID;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.dto.account.Balance;
+import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trade;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.huobi.dto.account.BitVcFuturesAccountInfo;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesDepth;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesTicker;
 import org.knowm.xchange.huobi.dto.marketdata.futures.BitVcFuturesTrade;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPosition;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPositionByContract;
 
 public class BitVcFuturesAdapter {
+  private static final OpenOrders NO_OPEN_ORDERS = new OpenOrders(Collections.EMPTY_LIST);
+  private static final Balance ZERO_USD_BALANCE = new Balance(USD, BigDecimal.ZERO);
+  private static final Balance ZERO_LTC_BALANCE = new Balance(LTC, BigDecimal.ZERO);
+
 
   public static Ticker adaptTicker(BitVcFuturesTicker ticker, CurrencyPair currencyPair) {
 
@@ -68,4 +83,23 @@ public class BitVcFuturesAdapter {
     return new Trade(type, trade.getAmount(), currencyPair, trade.getPrice(), trade.getDate(), trade.getId());
   }
 
+  public static AccountInfo adaptAccountInfo(final BitVcFuturesAccountInfo accountInfo) {
+    Balance btcBalance = new Balance(BTC, accountInfo.getAvailableMargin());
+
+    return new AccountInfo(new Wallet(btcBalance, ZERO_USD_BALANCE, ZERO_LTC_BALANCE));
+  }
+
+  public static OpenOrders adaptOpenOrders(final BitVcFuturesPositionByContract positions) {
+    final BitVcFuturesPosition[] weekPositions = positions.getWeekPositions();
+    if(weekPositions.length <= 0) {
+      return NO_OPEN_ORDERS;
+    }
+
+    List<LimitOrder> orders = new ArrayList<>(weekPositions.length);
+    for(BitVcFuturesPosition position : weekPositions) {
+      orders.add(new LimitOrder(position.getTradeType() == 1 ? OrderType.BID : OrderType.ASK, position.getAmount(), CurrencyPair.BTC_CNY, String.valueOf(position.getId()), new Date(), position.getPrice()));
+    }
+
+    return new OpenOrders(orders);
+  }
 }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/account/BitVcFuturesAccountInfo.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/account/BitVcFuturesAccountInfo.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.huobi.dto.account;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public class BitVcFuturesAccountInfo {
+
+    private final BigDecimal usedMargin;
+    private final BigDecimal availableMargin;
+    private final BigDecimal frozenMargin;
+
+    public BitVcFuturesAccountInfo(
+            @JsonProperty("masterUsedMargin") final BigDecimal usedMargin,
+            @JsonProperty("availableMargin") final BigDecimal availableMargin,
+            @JsonProperty("frozenMargin") final BigDecimal frozenMargin) {
+
+        this.usedMargin = usedMargin;
+        this.availableMargin = availableMargin;
+        this.frozenMargin = frozenMargin;
+    }
+
+    public BigDecimal getUsedMargin() {
+        return usedMargin;
+    }
+
+    public BigDecimal getAvailableMargin() {
+        return availableMargin;
+    }
+
+    public BigDecimal getFrozenMargin() {
+        return frozenMargin;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPlaceOrderResult.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPlaceOrderResult.java
@@ -1,0 +1,38 @@
+package org.knowm.xchange.huobi.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ *  fee : 0,             //手续费
+ id : 2489,              //订单ID
+ storeId : 0,            // 仓位ID
+ tradeType : 2,          //交易类型（1、买多  2、卖空）
+ price : 215.77,         //价格
+ orderType : 1,          //订单类型（1、开仓  2、平仓）
+ status : 0,             //订单状态（0、未成交 1、部分成交 2、已成交 3、撤单 7、队列中）
+ money : 200,            //下单金额
+ amount : 0.08130081,    // 订单比特币数量
+ lever : 10,             // 订单杠杆倍数
+ orderTime : 1409991500, //下单时间
+ lastTime : 1409991500,  //最后处理时间
+ processedMoney : 0,      //已处理金额
+ processedAmount : 0,    // 已处理比特币数量
+ margin : 0.008130081,   // 订单冻结保证金
+ processedPrice : 0      // 成交价格
+ */
+public class BitVcFuturesPlaceOrderResult {
+
+    private final long id;
+
+    public BitVcFuturesPlaceOrderResult(
+            @JsonProperty("id") final long id) {
+
+        this.id = id;
+    }
+
+    public long getId() {
+
+        return id;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPosition.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPosition.java
@@ -1,0 +1,60 @@
+package org.knowm.xchange.huobi.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public class BitVcFuturesPosition {
+    private final int id;
+    private final int tradeType;
+    private final BigDecimal price;
+    private final BigDecimal amount;
+    private final double holdProfitLoss;
+    private final double usedMargin;
+    private final int storeId;
+
+    public BitVcFuturesPosition(@JsonProperty("id") final int id,
+                                @JsonProperty("tradeType") final int tradeType,
+                                @JsonProperty("price") final BigDecimal price,
+                                @JsonProperty("money") final BigDecimal amount,
+                                @JsonProperty("holdProfitLoss") final double holdProfitLoss,
+                                @JsonProperty("usedMargin") final double usedMargin,
+                                @JsonProperty("storeId") final int storeId) {
+        this.id = id;
+        this.tradeType = tradeType;
+        this.price = price;
+        this.amount = amount;
+        this.holdProfitLoss = holdProfitLoss;
+        this.usedMargin = usedMargin;
+        this.storeId = storeId;
+    }
+
+    public int getTradeType() {
+        return tradeType;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public double getHoldProfitLoss() {
+        return holdProfitLoss;
+    }
+
+    public double getUsedMargin() {
+        return usedMargin;
+    }
+
+    public int getStoreId() {
+        return storeId;
+    }
+
+    public int getId() {
+
+        return id;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPositionByContract.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/dto/trade/BitVcFuturesPositionByContract.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.huobi.dto.trade;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+
+public class BitVcFuturesPositionByContract {
+
+    private final BitVcFuturesPosition[] weekPositions;
+    private final BitVcFuturesPosition[] nextWeekPositions;
+
+    public BitVcFuturesPositionByContract(@JsonProperty(value="week", required=false) final BitVcFuturesPosition[] weekPositions,
+                                          @JsonProperty(value="nextWeek", required=false) final BitVcFuturesPosition[] nextWeekPositions) {
+        this.weekPositions = weekPositions;
+        this.nextWeekPositions = nextWeekPositions;
+    }
+
+    public BitVcFuturesPosition[] getWeekPositions() {
+        return weekPositions;
+    }
+
+    public BitVcFuturesPosition[] getNextWeekPositions() {
+        return nextWeekPositions;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseTradeService.java
@@ -9,7 +9,7 @@ public class BitVcBaseTradeService extends HuobiBaseService {
 
   protected final BitVc bitvc;
   protected final String accessKey;
-  protected final HuobiDigest digest;
+  protected HuobiDigest digest;
 
   /**
    * Constructor
@@ -23,7 +23,7 @@ public class BitVcBaseTradeService extends HuobiBaseService {
     final String baseUrl = exchange.getExchangeSpecification().getSslUri();
     bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl);
     accessKey = exchange.getExchangeSpecification().getApiKey();
-    digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey());
+    digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secret_key");
   }
 
   protected long nextCreated() {

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesAccountService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesAccountService.java
@@ -1,0 +1,36 @@
+package org.knowm.xchange.huobi.service;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.dto.account.AccountInfo;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.huobi.BitVcFuturesAdapter;
+import org.knowm.xchange.huobi.dto.account.BitVcFuturesAccountInfo;
+import org.knowm.xchange.service.account.AccountService;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class BitVcFuturesAccountService extends BitVcFuturesServiceRaw implements AccountService {
+    public BitVcFuturesAccountService(final Exchange exchange) {
+        super(exchange);
+    }
+
+    @Override
+    public AccountInfo getAccountInfo() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        final BitVcFuturesAccountInfo accountInfo = bitvc.balance(accessKey, 1, requestTimestamp(), digest);
+        return BitVcFuturesAdapter.adaptAccountInfo(accountInfo);
+    }
+
+    @Override
+    public String withdrawFunds(final Currency currency, final BigDecimal bigDecimal, final String s) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return null;
+    }
+
+    @Override
+    public String requestDepositAddress(final Currency currency, final String... strings) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return null;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesMarketDataServiceRaw.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesMarketDataServiceRaw.java
@@ -27,7 +27,7 @@ public class BitVcFuturesMarketDataServiceRaw extends HuobiBaseService {
 
     super(exchange);
 
-    this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "rest://market.bitvc.com/futures/");
+    this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "http://market.bitvc.com/futures/");
     this.contract = contract;
   }
 

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesServiceRaw.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesServiceRaw.java
@@ -1,0 +1,25 @@
+package org.knowm.xchange.huobi.service;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.huobi.BitVc;
+import org.knowm.xchange.huobi.BitVcFutures;
+import si.mazi.rescu.RestProxyFactory;
+
+public class BitVcFuturesServiceRaw {
+
+    protected final BitVcFutures bitvc;
+    protected final String accessKey;
+    protected HuobiDigest digest;
+
+    public BitVcFuturesServiceRaw(Exchange exchange) {
+        this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "https://api.bitvc.com/futures");
+        this.accessKey = exchange.getExchangeSpecification().getApiKey();
+
+        /** BitVc Futures expect a different secret key digest name from BitVc spot and Huobi */
+        this.digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secretKey");
+    }
+
+    protected long requestTimestamp() {
+        return System.currentTimeMillis() / 1000;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesTradeService.java
@@ -1,0 +1,136 @@
+package org.knowm.xchange.huobi.service;
+
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.MarketOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrades;
+import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
+import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
+import org.knowm.xchange.huobi.BitVcFutures;
+import org.knowm.xchange.huobi.BitVcFuturesAdapter;
+import org.knowm.xchange.huobi.FuturesContract;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPlaceOrderResult;
+import org.knowm.xchange.huobi.dto.trade.BitVcFuturesPositionByContract;
+import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+import si.mazi.rescu.RestProxyFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+public class BitVcFuturesTradeService extends BitVcFuturesServiceRaw implements TradeService {
+    private final FuturesContract futuresContract;
+
+    private enum TradeTypes {
+        BUY(1, 1), SELL(1,2), CLOSE_BUY(2, 2), CLOSE_SELL(2, 1);
+
+        private int orderType;
+        private int tradeType;
+
+        TradeTypes(int orderType, int tradeType) {
+            this.orderType = orderType;
+            this.tradeType = tradeType;
+        }
+
+        public int getOrderType() {
+            return orderType;
+        }
+
+        public int getTradeType() {
+            return tradeType;
+        }
+    };
+
+
+    public BitVcFuturesTradeService(final Exchange exchange, final FuturesContract futuresContract) {
+        super(exchange);
+        
+        this.futuresContract = futuresContract;
+    }
+
+    @Override
+    public OpenOrders getOpenOrders() throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        final BitVcFuturesPositionByContract positions = bitvc.positions(accessKey, 1, requestTimestamp(), digest);
+        return BitVcFuturesAdapter.adaptOpenOrders(positions);
+    }
+
+    @Override
+    public OpenOrders getOpenOrders(final OpenOrdersParams openOrdersParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return getOpenOrders();
+    }
+
+    @Override
+    public String placeMarketOrder(final MarketOrder marketOrder) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return null;
+    }
+
+    @Override
+    public String placeLimitOrder(final LimitOrder limitOrder) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        final TradeTypes tradeTypes;
+        switch(limitOrder.getType()) {
+            case BID:
+                tradeTypes = TradeTypes.BUY;
+                break;
+
+            case ASK:
+                tradeTypes = TradeTypes.SELL;
+                break;
+
+            case EXIT_BID:
+                tradeTypes = TradeTypes.CLOSE_BUY;
+                break;
+
+            case EXIT_ASK:
+                tradeTypes = TradeTypes.CLOSE_SELL;
+                break;
+            default:
+                tradeTypes = null;
+                break;
+        }
+
+        final BitVcFuturesPlaceOrderResult result =
+                bitvc.placeLimitOrder(accessKey, 1, futuresContract.getName(), requestTimestamp(), digest,
+                        tradeTypes.getOrderType(), tradeTypes.getTradeType(), limitOrder.getLimitPrice().doubleValue(), limitOrder.getTradableAmount().doubleValue());
+
+        return String.valueOf(result);
+    }
+
+    @Override
+    public boolean cancelOrder(final String s) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return false;
+    }
+
+    @Override
+    public UserTrades getTradeHistory(final TradeHistoryParams tradeHistoryParams) throws IOException {
+        return null;
+    }
+
+    @Override
+    public TradeHistoryParams createTradeHistoryParams() {
+        return null;
+    }
+
+    @Override
+    public OpenOrdersParams createOpenOrdersParams() {
+        return null;
+    }
+
+    @Override
+    public void verifyOrder(final LimitOrder limitOrder) {
+
+    }
+
+    @Override
+    public void verifyOrder(final MarketOrder marketOrder) {
+
+    }
+
+    @Override
+    public Collection<Order> getOrder(final String... strings) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+        return null;
+    }
+}

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcFuturesTradeService.java
@@ -48,7 +48,7 @@ public class BitVcFuturesTradeService extends BitVcFuturesServiceRaw implements 
 
     public BitVcFuturesTradeService(final Exchange exchange, final FuturesContract futuresContract) {
         super(exchange);
-        
+
         this.futuresContract = futuresContract;
     }
 

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseTradeService.java
@@ -21,7 +21,7 @@ public class HuobiBaseTradeService extends HuobiBaseService {
 
     huobi = RestProxyFactory.createProxy(Huobi.class, exchange.getExchangeSpecification().getSslUri());
     accessKey = exchange.getExchangeSpecification().getApiKey();
-    digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey());
+    digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secret_key");
   }
 
   protected long nextCreated() {

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiDigest.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiDigest.java
@@ -21,6 +21,7 @@ public class HuobiDigest implements ParamsDigest {
   private static final char[] DIGITS_LOWER = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
   private final String secretKey;
+  private final String secretKeyDigestName;
   private final MessageDigest md;
   private final Comparator<Entry<String, String>> comparator = new Comparator<Map.Entry<String, String>>() {
 
@@ -31,9 +32,11 @@ public class HuobiDigest implements ParamsDigest {
     }
   };
 
-  public HuobiDigest(String secretKey) {
+
+  public HuobiDigest(String secretKey, String secretKeySignatureName) {
 
     this.secretKey = secretKey;
+    this.secretKeyDigestName = secretKeySignatureName;
 
     try {
       md = MessageDigest.getInstance("MD5");
@@ -60,7 +63,7 @@ public class HuobiDigest implements ParamsDigest {
     final Params params = restInvocation.getParamsMap().get(FormParam.class);
     final Map<String, String> nameValueMap = params.asHttpHeaders();
     nameValueMap.remove("sign");
-    nameValueMap.put("secret_key", secretKey);
+    nameValueMap.put(secretKeyDigestName, secretKey);
 
     final List<Map.Entry<String, String>> nameValueList = new ArrayList<Map.Entry<String, String>>(nameValueMap.entrySet());
     Collections.sort(nameValueList, comparator);


### PR DESCRIPTION
Supporting trading futures on BitVc. Placing limit orders, open positions, and account info implemented to start with. 