### PR TITLE
Builder for LimitOrder and MarketOrder must override all methods from…

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.dto.trade;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.Set;
 
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -157,6 +158,30 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     public Builder timestamp(Date timestamp) {
 
       return (Builder) super.timestamp(timestamp);
+    }
+
+    @Override
+    public Builder orderStatus(Order.OrderStatus status) {
+
+      return (Builder) super.orderStatus(status);
+    }
+
+    @Override
+    public Builder averagePrice(BigDecimal averagePrice) {
+
+      return (Builder) super.averagePrice(averagePrice);
+    }
+
+    @Override
+    public Builder flag(IOrderFlags flag) {
+
+      return (Builder) super.flag(flag);
+    }
+
+    @Override
+    public Builder flags(Set<IOrderFlags> flags) {
+
+      return (Builder) super.flags(flags);
     }
 
     public Builder limitPrice(BigDecimal limitPrice) {

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/MarketOrder.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.dto.trade;
 
 import java.math.BigDecimal;
 import java.util.Date;
+import java.util.Set;
 
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -115,6 +116,18 @@ public class MarketOrder extends Order {
     public Builder timestamp(Date timestamp) {
 
       return (Builder) super.timestamp(timestamp);
+    }
+
+    @Override
+    public Builder flags(Set<IOrderFlags> flags) {
+
+      return (Builder) super.flags(flags);
+    }
+
+    @Override
+    public Builder flag(IOrderFlags flag) {
+
+      return (Builder) super.flag(flag);
     }
 
     public MarketOrder build() {

--- a/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/dto/trade/LimitOrderTest.java
@@ -27,9 +27,8 @@ public class LimitOrderTest {
     final String id = "id";
     final Order.OrderStatus status = Order.OrderStatus.FILLED;
 
-    final LimitOrder.Builder builder = (LimitOrder.Builder) new LimitOrder.Builder(type, currencyPair).tradableAmount(tradableAmount)
-        .limitPrice(limitPrice).timestamp(timestamp).id(id).flag(TestFlags.TEST1).orderStatus(status);
-    final LimitOrder copy = builder.build();
+    final LimitOrder copy = new LimitOrder.Builder(type, currencyPair).tradableAmount(tradableAmount)
+        .limitPrice(limitPrice).orderStatus(status).timestamp(timestamp).id(id).flag(TestFlags.TEST1).build();
 
     assertThat(copy.getType()).isEqualTo(type);
     assertThat(copy.getTradableAmount()).isEqualTo(tradableAmount);


### PR DESCRIPTION
Following #1367, there was bug in setting order status because parent builder was returned:

`LimitOrder order = LimitOrder.Builder(type, currencyPair).orderStatus(status).build()`

Missing overridden methods added.