### PR TITLE
xchange-quoine: Default netting strategy and leverage fixes

### DIFF
--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
@@ -34,6 +34,7 @@ public class QuoineExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setSslUri("https://api.quoine.com");
     exchangeSpecification.setExchangeName("Quoine");
     exchangeSpecification.setExchangeSpecificParametersItem("Use_Margin", false);
+    exchangeSpecification.setExchangeSpecificParametersItem("Leverage_Level", "1");
     return exchangeSpecification;
   }
 

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/dto/trade/QuoineNewMarginOrderRequest.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/dto/trade/QuoineNewMarginOrderRequest.java
@@ -11,8 +11,8 @@ public class QuoineNewMarginOrderRequest extends QuoineNewOrderRequest {
   @JsonProperty("funding_currency")
   private final String fundingCurrency;
 
-//  @JsonProperty("order_direction")
-//  private  final String orderDirection; // one_direction, two_direction, netout
+  @JsonProperty("order_direction")
+  private final String orderDirection;
 
   public QuoineNewMarginOrderRequest(String orderType, int productCode, String side, BigDecimal quantity, BigDecimal price,
       int leverageLevel, String fundingCurrency) {
@@ -20,6 +20,8 @@ public class QuoineNewMarginOrderRequest extends QuoineNewOrderRequest {
 
     this.leverageLevel = leverageLevel;
     this.fundingCurrency = fundingCurrency;
+
+    this.orderDirection = "netout";
   }
 
   public int getLeverageLevel() {
@@ -28,6 +30,10 @@ public class QuoineNewMarginOrderRequest extends QuoineNewOrderRequest {
 
   public String getFundingCurrency() {
     return fundingCurrency;
+  }
+
+  public String getOrderDirection() {
+    return orderDirection;
   }
 
   @Override


### PR DESCRIPTION
Quoine allows trading on margin without explicit borrowing, fiat as collateral and "netout" which functions going long and short just like in spot (if you are long 2 and sell 3 you are short 1).