### PR TITLE
xchange-quoine: AccountInfo fixes

### DIFF
--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineAccountService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineAccountService.java
@@ -37,14 +37,23 @@ public class QuoineAccountService extends QuoineAccountServiceRaw implements Acc
 
   @Override
   public AccountInfo getAccountInfo() throws IOException {
-    if (useMargin) {
+    /**
+     * Account information in Quoine is complicated. If using margin it's probably best
+     * to separately call `getQuoineTradingAccountInfo` in order to get position exposures and pnl.
+     *
+     * However for account valuation purposes it is probably better to always use getQuoineFiatAccountInfo
+     * which gives a total balance, including the margin activity.
+     */
+
+
+/*    if (useMargin) {
       QuoineTradingAccountInfo[] quoineTradingAccountInfo = getQuoineTradingAccountInfo();
       return new AccountInfo(QuoineAdapters.adaptTradingWallet(quoineTradingAccountInfo));
 
-    } else {
+    } else { */
       final FiatAccount[] quoineFiatAccountInfo = getQuoineFiatAccountInfo();
       return new AccountInfo(QuoineAdapters.adaptFiatAccountWallet(quoineFiatAccountInfo));
-    }
+    /* } */
   }
 
   @Override


### PR DESCRIPTION
The various account API calls together with how BTC is accounted for between spot and margin is quite confusing. This fix adjusts getting the "fiat" accounts (which include BTC) for spot and margin. This is probably more sane and in line with other margin exchange implementations.