### PR TITLE
Poloniex: Support getting open orders only for selected currency pair.

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/poloniex/trade/PoloniexTradeDemo.java
@@ -5,17 +5,20 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
+import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.examples.poloniex.PoloniexExamplesUtils;
 import org.knowm.xchange.poloniex.PoloniexAdapters;
 import org.knowm.xchange.poloniex.service.PoloniexTradeService;
 import org.knowm.xchange.poloniex.service.PoloniexTradeServiceRaw;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.utils.CertHelper;
 
 /**
@@ -24,11 +27,12 @@ import org.knowm.xchange.utils.CertHelper;
 
 public class PoloniexTradeDemo {
 
+  private static final CurrencyPair REP_ETH = new CurrencyPair("REP", "ETH");
+
   private static CurrencyPair currencyPair;
   private static BigDecimal xmrBuyRate;
 
   public static void main(String[] args) throws Exception {
-
     CertHelper.trustAllCerts();
 
     Exchange poloniex = PoloniexExamplesUtils.getExchange();
@@ -44,8 +48,7 @@ public class PoloniexTradeDemo {
     raw((PoloniexTradeServiceRaw) tradeService);
   }
 
-  private static void generic(TradeService tradeService) throws IOException, InterruptedException {
-
+  private static void generic(TradeService tradeService) throws Exception {
     System.out.println("----------GENERIC----------");
 
     PoloniexTradeService.PoloniexTradeHistoryParams params = new PoloniexTradeService.PoloniexTradeHistoryParams();
@@ -60,13 +63,11 @@ public class PoloniexTradeDemo {
     params.setEndTime(endTime.getTime());
     System.out.println(tradeService.getTradeHistory(params));
 
-    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).tradableAmount(new BigDecimal(".01")).limitPrice(xmrBuyRate).build();
+    LimitOrder order = new LimitOrder.Builder(OrderType.BID, currencyPair).tradableAmount(new BigDecimal(".1")).limitPrice(xmrBuyRate).build();
     String orderId = tradeService.placeLimitOrder(order);
     System.out.println("Placed order #" + orderId);
 
-    Thread.sleep(3000); // wait for order to propagate
-
-    System.out.println(tradeService.getOpenOrders());
+    printOpenOrders(tradeService);
 
     boolean canceled = tradeService.cancelOrder(orderId);
     if (canceled) {
@@ -75,13 +76,10 @@ public class PoloniexTradeDemo {
       System.out.println("Did not successfully cancel order #" + orderId);
     }
 
-    Thread.sleep(3000); // wait for cancellation to propagate
-
-    System.out.println(tradeService.getOpenOrders());
+    printOpenOrders(tradeService);
   }
 
   private static void raw(PoloniexTradeServiceRaw tradeService) throws IOException, InterruptedException {
-
     System.out.println("------------RAW------------");
     System.out.println(Arrays.asList(tradeService.returnTradeHistory(currencyPair, null, null)));
     long startTime = (new Date().getTime() / 1000) - 8 * 60 * 60;
@@ -107,5 +105,21 @@ public class PoloniexTradeDemo {
     Thread.sleep(3000); // wait for cancellation to propagate
 
     System.out.println(PoloniexAdapters.adaptPoloniexOpenOrders(tradeService.returnOpenOrders()));
+  }
+
+  private static void printOpenOrders(TradeService tradeService) throws Exception {
+    TimeUnit.SECONDS.sleep(2);
+
+    final OpenOrdersParamCurrencyPair params = (OpenOrdersParamCurrencyPair) tradeService.createOpenOrdersParams();
+    OpenOrders openOrders = tradeService.getOpenOrders(params);
+    System.out.printf("All open Orders: %s%n", openOrders);
+
+    params.setCurrencyPair(currencyPair);
+    openOrders = tradeService.getOpenOrders(params);
+    System.out.printf("Open Orders for %s: %s%n: ", params, openOrders);
+
+    params.setCurrencyPair(REP_ETH);
+    openOrders = tradeService.getOpenOrders(params);
+    System.out.printf("Open Orders for %s: %s%n: ", params, openOrders);
   }
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -141,7 +141,7 @@ public class PoloniexAdapters {
     return new LoanInfo(loans.get("provided"), loans.get("used"));
   }
 
-  public static OpenOrders adaptPoloniexOpenOrders(HashMap<String, PoloniexOpenOrder[]> poloniexOpenOrders) {
+  public static OpenOrders adaptPoloniexOpenOrders(Map<String, PoloniexOpenOrder[]> poloniexOpenOrders) {
 
     List<LimitOrder> openOrders = new ArrayList<LimitOrder>();
     for (String pairString : poloniexOpenOrders.keySet()) {

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.poloniex;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.Consumes;
@@ -48,28 +49,17 @@ public interface PoloniexAuthenticated {
   HashMap<String, String> returnDepositAddresses(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
 
-  /**
-   * This only works with "all" as currencyPair (for explicit currency pairs, just PoloniexOpenOrder[] is returned and not a Map).
-   */
   @POST
   @FormParam("command")
-  HashMap<String, PoloniexOpenOrder[]> returnOpenOrders(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("currencyPair") String currencyPair) throws PoloniexException, IOException;
-
-  /* TODO: replace the above method with the two methods (plus the enum) below to support currency pairs. This change is not backwards compatible. */
-/*
-  enum AllPairs { all }
-
-  @POST
-  @FormParam("command")
-  HashMap<String, PoloniexOpenOrder[]> returnOpenOrders(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("currencyPair") AllPairs all) throws PoloniexException, IOException;
+  Map<String, PoloniexOpenOrder[]> returnOpenOrders(
+      @HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
+      @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("currencyPair") AllPairs all
+  ) throws PoloniexException, IOException;
 
   @POST
   @FormParam("command")
   PoloniexOpenOrder[] returnOpenOrders(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
       @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("currencyPair") String currencyPair) throws PoloniexException, IOException;
-*/
 
   @POST
   @FormParam("command")
@@ -125,4 +115,6 @@ public interface PoloniexAuthenticated {
   PoloniexDepositsWithdrawalsResponse returnDepositsWithdrawals(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
           @FormParam("nonce") SynchronizedValueFactory<Long> nonce, @FormParam("start") Long startTime, @FormParam("end") Long endTime)
           throws PoloniexException, IOException;
+
+  enum AllPairs { all }
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeServiceRaw.java
@@ -5,10 +5,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.HashMap;
-
-/**
- * @author Zach Holmes
- */
+import java.util.Map;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -26,6 +23,10 @@ import org.knowm.xchange.poloniex.dto.trade.PoloniexUserTrade;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
 
+/**
+ * @author Zach Holmes
+ */
+
 public class PoloniexTradeServiceRaw extends PoloniexBaseService {
 
   public PoloniexTradeServiceRaw(Exchange exchange) {
@@ -33,9 +34,12 @@ public class PoloniexTradeServiceRaw extends PoloniexBaseService {
     super(exchange);
   }
 
-  public HashMap<String, PoloniexOpenOrder[]> returnOpenOrders() throws IOException {
+  public Map<String, PoloniexOpenOrder[]> returnOpenOrders() throws IOException {
+    return poloniexAuthenticated.returnOpenOrders(apiKey, signatureCreator, exchange.getNonceFactory(), PoloniexAuthenticated.AllPairs.all);
+  }
 
-    return poloniexAuthenticated.returnOpenOrders(apiKey, signatureCreator, exchange.getNonceFactory(), "all");
+  public PoloniexOpenOrder[] returnOpenOrders(CurrencyPair currencyPair) throws IOException {
+    return poloniexAuthenticated.returnOpenOrders(apiKey, signatureCreator, exchange.getNonceFactory(), PoloniexUtils.toPairString(currencyPair));
   }
 
   public PoloniexUserTrade[] returnTradeHistory(CurrencyPair currencyPair, Long startTime, Long endTime) throws IOException {


### PR DESCRIPTION
Note that this is breaks compile-time compatibility with old client code using the raw interface (the generic interface is fine). If anyone is using this, this can be fixed with minor code changes (detected by the compiler):

Clients calling `PoloniexAuthenticated::returnOpenOrders` should change the last parameter from `"all"` to `PoloniexAuthenticated.AllPairs.all`.

`PoloniexTradeServiceRaw::returnOpenOrders()` now returns a `Map` instead of a `HashMap`.

@timmolter I'd like to see this merged asap, but I'm leaving the decision whether to wait for a version bump or not to you.