### PR TITLE
Bitfinex errors solved and added new coins

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -48,6 +48,13 @@ public final class BitfinexAdapters {
 
   }
 
+  public static String adaptBitfinexCurrency(String bitfinexSymbol) {
+	  String currency = bitfinexSymbol.toUpperCase();
+	  if (currency.equals("DSH")) {
+		  currency = "DASH";
+	  }
+	  return currency;
+  }
   public static List<CurrencyPair> adaptCurrencyPairs(Collection<String> bitfinexSymbol) {
 
     List<CurrencyPair> currencyPairs = new ArrayList<CurrencyPair>();
@@ -59,8 +66,8 @@ public final class BitfinexAdapters {
 
   public static CurrencyPair adaptCurrencyPair(String bitfinexSymbol) {
 
-    String tradableIdentifier = bitfinexSymbol.substring(0, 3).toUpperCase();
-    String transactionCurrency = bitfinexSymbol.substring(3).toUpperCase();
+    String tradableIdentifier = adaptBitfinexCurrency(bitfinexSymbol.substring(0, 3));
+    String transactionCurrency = adaptBitfinexCurrency(bitfinexSymbol.substring(3));
     return new CurrencyPair(tradableIdentifier, transactionCurrency);
   }
 
@@ -231,7 +238,7 @@ public final class BitfinexAdapters {
     // for each currency we have multiple balances types: exchange, trading, deposit.
     // each of those may be partially frozen/available
     for (BitfinexBalancesResponse balance : response) {
-      String currencyName = balance.getCurrency().toUpperCase();
+      String currencyName = adaptBitfinexCurrency(balance.getCurrency());
       BigDecimal[] balanceDetail = balancesByCurrency.get(currencyName);
       if (balanceDetail == null) {
         balanceDetail = new BigDecimal[] { balance.getAmount(), balance.getAvailable() };

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -15,9 +15,17 @@ public final class BitfinexUtils {
 
   }
 
+  public static String adaptXchangeCurrency(String xchangeSymbol) {
+	  String currency = xchangeSymbol.toLowerCase();
+	  if (currency.equals("dash")) {
+		  currency = "dsh";
+	  }
+	  return currency;
+  }
+  
   public static String toPairString(CurrencyPair currencyPair) {
 
-    return currencyPair.base.toString().toLowerCase() + currencyPair.counter.toString().toLowerCase();
+    return adaptXchangeCurrency(currencyPair.base.toString()) + adaptXchangeCurrency(currencyPair.counter.toString());
   }
   
     /**

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOfferRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOfferRequest.java
@@ -13,9 +13,9 @@ public class BitfinexCancelOfferRequest {
 
   @JsonProperty("offer_id")
   @JsonRawValue
-  private int offerId;
+  private long offerId;
 
-  public BitfinexCancelOfferRequest(String nonce, int offerId) {
+  public BitfinexCancelOfferRequest(String nonce, long offerId) {
 
     this.request = "/v1/offer/cancel";
     this.nonce = nonce;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOrderMultiRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOrderMultiRequest.java
@@ -11,9 +11,9 @@ public class BitfinexCancelOrderMultiRequest {
   protected String nonce;
 
   @JsonProperty("order_ids")
-  protected int[] orderIds;
+  protected long[] orderIds;
 
-  public BitfinexCancelOrderMultiRequest(String nonce, int[] orderIds) {
+  public BitfinexCancelOrderMultiRequest(String nonce, long[] orderIds) {
 
     this.request = "/v1/order/cancel/multi";
     this.nonce = nonce;
@@ -36,11 +36,11 @@ public class BitfinexCancelOrderMultiRequest {
     this.nonce = nonce;
   }
 
-  public int[] getOrderIds() {
+  public long[] getOrderIds() {
     return orderIds;
   }
 
-  public void setOrderIds(int[] orderIds) {
+  public void setOrderIds(long[] orderIds) {
     this.orderIds = orderIds;
   }
 

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOrderRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexCancelOrderRequest.java
@@ -13,7 +13,7 @@ public class BitfinexCancelOrderRequest {
 
   @JsonProperty("order_id")
   @JsonRawValue
-  private int orderId;
+  private long orderId;
 
   /**
    * Constructor
@@ -21,7 +21,7 @@ public class BitfinexCancelOrderRequest {
    * @param nonce
    * @param orderId
    */
-  public BitfinexCancelOrderRequest(String nonce, int orderId) {
+  public BitfinexCancelOrderRequest(String nonce, long orderId) {
 
     this.request = "/v1/order/cancel";
     this.orderId = orderId;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOfferStatusRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOfferStatusRequest.java
@@ -13,9 +13,9 @@ public class BitfinexOfferStatusRequest {
 
   @JsonProperty("order_id")
   @JsonRawValue
-  private int orderId;
+  private long orderId;
 
-  public BitfinexOfferStatusRequest(String nonce, int orderId) {
+  public BitfinexOfferStatusRequest(String nonce, long orderId) {
 
     this.request = "/v1/offer/status";
     this.orderId = orderId;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusRequest.java
@@ -11,9 +11,9 @@ public class BitfinexOrderStatusRequest {
   @JsonProperty("nonce")
   protected String nonce;
 
-  @JsonProperty("order_id")
+  @JsonProperty("order_id") 
   @JsonRawValue
-  private int orderId;
+  private long orderId;
 
   /**
    * Constructor
@@ -21,7 +21,7 @@ public class BitfinexOrderStatusRequest {
    * @param nonce
    * @param orderId
    */
-  public BitfinexOrderStatusRequest(String nonce, int orderId) {
+  public BitfinexOrderStatusRequest(String nonce, long orderId) {
 
     this.request = "/v1/order/status";
     this.orderId = orderId;

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusResponse.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BitfinexOrderStatusResponse {
 
-  private final double id;
+  private final long id;
   private final String symbol;
   private final String exchange;
   private final BigDecimal price;
@@ -39,7 +39,7 @@ public class BitfinexOrderStatusResponse {
    * @param remainingAmount
    * @param executedAmount
    */
-  public BitfinexOrderStatusResponse(@JsonProperty("id") double id, @JsonProperty("symbol") String symbol, @JsonProperty("exchange") String exchange,
+  public BitfinexOrderStatusResponse(@JsonProperty("id") long id, @JsonProperty("symbol") String symbol, @JsonProperty("exchange") String exchange,
       @JsonProperty("price") BigDecimal price, @JsonProperty("avg_execution_price") BigDecimal avgExecutionPrice, @JsonProperty("side") String side,
       @JsonProperty("type") String type, @JsonProperty("timestamp") BigDecimal timestamp, @JsonProperty("is_live") boolean isLive,
       @JsonProperty("is_cancelled") boolean isCancelled, @JsonProperty("was_forced") boolean wasForced,
@@ -117,7 +117,7 @@ public class BitfinexOrderStatusResponse {
     return timestamp;
   }
 
-  public double getId() {
+  public long getId() {
 
     return id;
   }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusResponse.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexOrderStatusResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class BitfinexOrderStatusResponse {
 
-  private final int id;
+  private final double id;
   private final String symbol;
   private final String exchange;
   private final BigDecimal price;
@@ -39,7 +39,7 @@ public class BitfinexOrderStatusResponse {
    * @param remainingAmount
    * @param executedAmount
    */
-  public BitfinexOrderStatusResponse(@JsonProperty("id") int id, @JsonProperty("symbol") String symbol, @JsonProperty("exchange") String exchange,
+  public BitfinexOrderStatusResponse(@JsonProperty("id") double id, @JsonProperty("symbol") String symbol, @JsonProperty("exchange") String exchange,
       @JsonProperty("price") BigDecimal price, @JsonProperty("avg_execution_price") BigDecimal avgExecutionPrice, @JsonProperty("side") String side,
       @JsonProperty("type") String type, @JsonProperty("timestamp") BigDecimal timestamp, @JsonProperty("is_live") boolean isLive,
       @JsonProperty("is_cancelled") boolean isCancelled, @JsonProperty("was_forced") boolean wasForced,
@@ -117,7 +117,7 @@ public class BitfinexOrderStatusResponse {
     return timestamp;
   }
 
-  public int getId() {
+  public double getId() {
 
     return id;
   }

--- a/xchange-bitfinex/src/main/resources/bitfinex.json
+++ b/xchange-bitfinex/src/main/resources/bitfinex.json
@@ -51,7 +51,40 @@
     "XMR/USD": {
       "price_scale": 4,
       "min_amount": 0.100000000
+    },
+    "DASH/BTC": {
+      "price_scale": 6,
+      "min_amount": 0.010000000
+    },
+    "DASH/USD": {
+      "price_scale": 4,
+      "min_amount": 0.010000000
+    },
+    "RRT/BTC": {
+      "price_scale": 6,
+      "min_amount": 0.100000000
+    },
+    "RRT/USD": {
+      "price_scale": 4,
+      "min_amount": 0.100000000
+    },
+    "BCC/BTC": {
+      "price_scale": 6,
+      "min_amount": 0.010000000
+    },
+    "BCC/USD": {
+      "price_scale": 4,
+      "min_amount": 0.010000000
+    },
+    "BCU/BTC": {
+      "price_scale": 6,
+      "min_amount": 0.010000000
+    },
+    "BCU/USD": {
+      "price_scale": 4,
+      "min_amount": 0.010000000
     }
+
   },
   "currencies": {
     "BTC": {


### PR DESCRIPTION
Bitfinex order numbers are now to high to fit in a signed int. (resulting in errors at placing orders and retrieving open orders. Error at place order is a real problem, the order is executed, but result results in an error)
Increased order number to long type.
Added new coins, also conversion of dsh to dash