### PR TITLE
PoloniexAccountServiceRaw: add a method that returns only exchange ac…

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountService.java
@@ -30,7 +30,7 @@ public class PoloniexAccountService extends PoloniexAccountServiceRaw implements
   @Override
   public AccountInfo getAccountInfo() throws IOException {
 
-    List<Balance> balances = getWallets();
+    List<Balance> balances = getExchangeWallet();
     return new AccountInfo(new Wallet(balances));
   }
 

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
@@ -36,6 +36,16 @@ public class PoloniexAccountServiceRaw extends PoloniexBaseService {
     super(exchange);
   }
 
+  public List<Balance> getExchangeWallet() throws IOException {
+    try {
+      HashMap<String, PoloniexBalance> response = poloniexAuthenticated.returnCompleteBalances(apiKey, signatureCreator, exchange.getNonceFactory(),
+          null);
+      return PoloniexAdapters.adaptPoloniexBalances(response);
+    } catch (PoloniexException e) {
+      throw new ExchangeException(e.getError(), e);
+    }
+  }
+
   public List<Balance> getWallets() throws IOException {
     try {
       // using account="all" for margin + lending balances


### PR DESCRIPTION
…count balance (without lending and margin balance), no change to semantics.

PoloniexAccountService::getAccountInfo: change semantics to only return the exchange account balance (without lending, margin).

Since there is no way to access lending and margin accounts via the general interface (PoloniexAccountService), getAccountInfo should not include margin+lending balances. See also my comments [here](https://github.com/timmolter/XChange/pull/1259#issuecomment-288771122).