### PR TITLE
Dash pairs don't contain the x or z identification on kraken

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenUtils.java
@@ -48,7 +48,14 @@ public class KrakenUtils {
   }
 
   public static String createKrakenCurrencyPair(CurrencyPair currencyPair) {
-
+    // DASH is a strange exception for X and Z adds.
+  	if ("DASH".equals(currencyPair.base.getCurrencyCode())) {
+		  Currency counter = currencyPair.counter;
+		  if (counter.getIso4217Currency() != null) {
+			  counter = currencyPair.counter.getIso4217Currency();
+	    }		
+	    return currencyPair.base.getCurrencyCode() + counter.getCurrencyCode();	
+	  }
     return createKrakenCurrencyPair(currencyPair.base, currencyPair.counter);
   }
 


### PR DESCRIPTION
Dash pairs don't contain the x or z identification