### PR TITLE
Add convenience methods to ExchangeFactory

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeFactory.java
@@ -70,6 +70,71 @@ public enum ExchangeFactory {
   }
 
   /**
+   * Create an Exchange object with default ExchangeSpecification with authentication info and API keys provided through parameters
+   * <p>
+   * The factory is parameterised with the name of the exchange implementation class. This must be a class extending
+   * {@link org.knowm.xchange.Exchange}.
+   * </p>
+   *
+   * @param exchangeClassName the fully-qualified class name of the exchange
+   * @param userName the username for authentication
+   * @param password the password for authentication
+   * @param apiKey the public API key
+   * @param secretKey the secret API key
+   * @return a new exchange instance configured with the default {@link org.knowm.xchange.ExchangeSpecification}
+   */
+  public Exchange createExchange(String exchangeClassName, String userName, String password, String apiKey, String secretKey) {
+
+    Assert.notNull(exchangeClassName, "exchangeClassName cannot be null");
+
+    log.debug("Creating default exchange from class name");
+
+    Exchange exchange = createExchangeWithoutSpecification(exchangeClassName);
+
+    ExchangeSpecification specification = exchange.getDefaultExchangeSpecification();
+    if (userName != null)  specification.setUserName(userName);
+    if (password != null)  specification.setPassword(password);
+    if (apiKey != null)    specification.setApiKey(apiKey);
+    if (secretKey != null) specification.setSecretKey(secretKey);
+    exchange.applySpecification(specification);
+
+    return exchange;
+
+  }
+
+  /**
+   * Create an Exchange object with default ExchangeSpecification with authentication info provided through parameters
+   * <p>
+   * The factory is parameterised with the name of the exchange implementation class. This must be a class extending
+   * {@link org.knowm.xchange.Exchange}.
+   * </p>
+   *
+   * @param exchangeClassName the fully-qualified class name of the exchange
+   * @param userName the username for authentication
+   * @param password the password for authentication
+   * @return a new exchange instance configured with the default {@link org.knowm.xchange.ExchangeSpecification}
+   */
+  public Exchange createExchangeWithUserNameAndPassword(String exchangeClassName, String userName, String password) {
+    return createExchange(exchangeClassName, userName, password, null, null);
+  }
+
+  /**
+   * Create an Exchange object with default ExchangeSpecification with API keys provided through parameters
+   * <p>
+   * The factory is parameterised with the name of the exchange implementation class. This must be a class extending
+   * {@link org.knowm.xchange.Exchange}.
+   * </p>
+   *
+   * @param exchangeClassName the fully-qualified class name of the exchange
+   * @param apiKey the public API key
+   * @param secretKey the secret API key
+   * @return a new exchange instance configured with the default {@link org.knowm.xchange.ExchangeSpecification}
+   */
+  public Exchange createExchangeWithApiKeys(String exchangeClassName, String apiKey, String secretKey) {
+    return createExchange(exchangeClassName, null, null, apiKey, secretKey);
+  }
+
+  /**
    * Create an Exchange object with default ExchangeSpecification
    * <p>
    * The factory is parameterised with the name of the exchange implementation class. This must be a class extending
@@ -80,15 +145,7 @@ public enum ExchangeFactory {
    * @return a new exchange instance configured with the default {@link org.knowm.xchange.ExchangeSpecification}
    */
   public Exchange createExchange(String exchangeClassName) {
-
-    Assert.notNull(exchangeClassName, "exchangeClassName cannot be null");
-
-    log.debug("Creating default exchange from class name");
-
-    Exchange exchange = createExchangeWithoutSpecification(exchangeClassName);
-    exchange.applySpecification(exchange.getDefaultExchangeSpecification());
-    return exchange;
-
+    return createExchange(exchangeClassName, null, null, null, null);
   }
 
   public Exchange createExchange(ExchangeSpecification exchangeSpecification) {


### PR DESCRIPTION
Noticed these convenience methods could reduce the initialization boilerplate by a few lines for most users.

But this PR actually stems from a separate issue I ran into. By mistake I set the API keys only after constructing the `Exchange`, which resulted in a signing exception, since (it took me a while to find that) during initialization the secret key was not yet set when it was passed to `KrakenDigest` in the `KrakenBaseService` constructor. Other exchanges likely have the same issue.

A possible solution would be to create a `ExchangeSpecificationBuilder` class that returns an immutable `ExchangeSpecification`. That way I couldn't call a setter after the value had already been used, and it would allow moving the default specification out of the instance method, which may then enable simplification of `Exchange` construction.