### PR TITLE
[Huobi] Update api url

### DIFF
--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiExchange.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/HuobiExchange.java
@@ -115,14 +115,14 @@ public class HuobiExchange extends BaseExchange implements Exchange {
     spec.setExchangeDescription("Huobi-Family Exchange (Huobi, BitVC, BitVC Futures)");
 
     /* by default we request market data from huobi and execute on bitvc */
-    spec.setPlainTextUri("http://market.huobi.com/staticmarket");
+    spec.setPlainTextUri("http://api.huobi.com/staticmarket");
     spec.setSslUri("https://api.huobi.com/apiv3");
 
     /* set to true if trade and account service should be from BitVc too */
     spec.setExchangeSpecificParametersItem(USE_BITVC, false);
     spec.setExchangeSpecificParametersItem(USE_BITVC_FUTURES_MARKET_DATA, false);
     spec.setExchangeSpecificParametersItem(USE_BITVC_FUTURES_EXECUTION, false);
-    spec.setExchangeSpecificParametersItem(HUOBI_MARKET_DATA, "http://market.huobi.com/staticmarket");
+    spec.setExchangeSpecificParametersItem(HUOBI_MARKET_DATA, "http://api.huobi.com/staticmarket");
     spec.setExchangeSpecificParametersItem("Websocket_SslUri", "http://hq.huobi.com");
 
     return spec;


### PR DESCRIPTION
Use correct api url. "http://market.huobi.com/staticmarket" is obsolete.