### PR TITLE
xchange-okcoin: Use new URIs for okcoin.com futures

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
@@ -56,9 +56,9 @@ public class OkCoinExchange extends BaseExchange {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null
         && exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true)) {
-      exchangeSpecification.setSslUri("https://www.okcoin.com/api");
-      exchangeSpecification.setHost("www.okcoin.com");
-      exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okcoin.com:10440/websocket/okcoinapi");
+      exchangeSpecification.setSslUri("https://www.okex.com/api");
+      exchangeSpecification.setHost("www.okex.com");
+      exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okex.com:10440/websocket/okcoinapi");
     }
   }
 


### PR DESCRIPTION
Support for okex.com, the futures exchange endpoint of okcoin.com.

Let's see if this is enough, or if okex.com requires its own module at some point.

https://github.com/timmolter/XChange/issues/1484