### PR TITLE
[#hotfix] Yobit volume should be in the base currency

### DIFF
--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
@@ -107,7 +107,7 @@ public class YoBitAdapters {
     BigDecimal ask = ticker.getSell();
     BigDecimal high = ticker.getHigh();
     BigDecimal low = ticker.getLow();
-    BigDecimal volume = ticker.getVol();
+    BigDecimal volume = ticker.getVolCur();
     Date timestamp = new Date(ticker.getUpdated() * 1000L);
 
     return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low)


### PR DESCRIPTION
To maintain consistency with the rest of the API, the volume in the ticker should be in the BASE currency.

That value can be acquired via `vol_cur` of the API call