### PR TITLE
xchange-okcoin: Fix wrong configuration

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinExchange.java
@@ -54,11 +54,22 @@ public class OkCoinExchange extends BaseExchange {
    */
   private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
-    if (exchangeSpecification.getExchangeSpecificParameters() != null
-        && exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true)) {
-      exchangeSpecification.setSslUri("https://www.okex.com/api");
-      exchangeSpecification.setHost("www.okex.com");
-      exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okex.com:10440/websocket/okcoinapi");
+    if (exchangeSpecification.getExchangeSpecificParameters() != null) {
+      if(exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true) &&
+              exchangeSpecification.getExchangeSpecificParametersItem("Use_Futures").equals(false)) {
+
+        exchangeSpecification.setSslUri("https://www.okcoin.com/api");
+        exchangeSpecification.setHost("www.okcoin.com");
+        exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okcoin.com:10440/websocket/okcoinapi");
+
+      } else if(exchangeSpecification.getExchangeSpecificParametersItem("Use_Intl").equals(true) &&
+              exchangeSpecification.getExchangeSpecificParametersItem("Use_Futures").equals(true)) {
+
+        exchangeSpecification.setSslUri("https://www.okex.com/api");
+        exchangeSpecification.setHost("www.okex.com");
+        exchangeSpecification.setExchangeSpecificParametersItem("Websocket_SslUri", "wss://real.okex.com:10440/websocket/okcoinapi");
+
+      }
     }
   }
 


### PR DESCRIPTION
Adjust instantiation to allow for:
- okcoin china (okcoin.cn)
- okcoin international spot (okcoin.com)
- okcoin international futures (okex.com)