### PR TITLE
[poloniex] dropped the usdt mapping

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexUtils.java
@@ -20,15 +20,13 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 public class PoloniexUtils {
 
   public static String toPairString(CurrencyPair currencyPair) {
-
-    return currencyPair.counter.getCurrencyCode().replace("USD","USDT").toUpperCase() + "_" + currencyPair.base.getCurrencyCode().toUpperCase();
-//    return currencyPair.counter.getCurrencyCode().toUpperCase() + "_" + currencyPair.base.getCurrencyCode().toUpperCase();
+    return currencyPair.counter.getCurrencyCode().toUpperCase() + "_" + currencyPair.base.getCurrencyCode().toUpperCase();
   }
 
   public static CurrencyPair toCurrencyPair(String pair) {
 
     String[] currencies = pair.split("_");
-    return new CurrencyPair(currencies[1], currencies[0].replace("USDT","USD"));
+    return new CurrencyPair(currencies[1], currencies[0]);
   }
 
   public static Date stringToDate(String dateString) {


### PR DESCRIPTION
> replace("USD","USDT")

this is not a very clean way to handle currencies
in our application we use explizit USDT currency, now after passing it through this, we get "USDTT", which leads to an error of course

i would like to change it back, if you do not mind
thanks