### PR TITLE
[Core, Kraken, Poloniex] HTTP read timeout configurable by exchange

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -34,6 +34,8 @@ public class ExchangeSpecification {
 
   private int port = 80;
 
+  private int httpReadTimeout = 0; // default rescu configuration will be used if value not changed
+
   private String metaDataJsonFileOverride = null;
 
   private boolean shouldLoadRemoteMetaData = true; // default value
@@ -60,7 +62,7 @@ public class ExchangeSpecification {
    *
    * @param exchangeClass The exchange class
    */
-  public ExchangeSpecification(Class exchangeClass) {
+  public ExchangeSpecification(Class<? extends Exchange> exchangeClass) {
 
     this.exchangeClassName = exchangeClass.getCanonicalName();
   }
@@ -130,6 +132,28 @@ public class ExchangeSpecification {
   public int getPort() {
 
     return port;
+  }
+
+  /**
+   * Set the http read timeout for the connection. If not supplied the default rescu timeout will be used. Check the exchange code to see if this
+   * option has been implemented.
+   *
+   * @param milliseconds the http read timeout in milliseconds
+   */
+  public void setHttpReadTimeout(int milliseconds) {
+
+    this.httpReadTimeout = milliseconds;
+  }
+
+  /**
+   * Get the http read timeout for the connection. If the default value of zero is returned then the default rescu timeout will be applied. Check the
+   * exchange code to see if this option has been implemented.
+   *
+   * @return the http read timeout in milliseconds
+   */
+  public int getHttpReadTimeout() {
+
+    return httpReadTimeout;
   }
 
   /**

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
@@ -2,7 +2,6 @@ package org.knowm.xchange.gdax.service;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
@@ -38,7 +37,9 @@ public class GDAXTradeServiceRaw extends GDAXBaseService<GDAX> {
     } else if (tradeHistoryParams instanceof TradeHistoryParamCurrencyPair) {
       TradeHistoryParamCurrencyPair ccyPairParams = (TradeHistoryParamCurrencyPair) tradeHistoryParams;
       CurrencyPair currencyPair = ccyPairParams.getCurrencyPair();
-      productId = toProductId(currencyPair);
+      if(currencyPair != null) {
+        productId = toProductId(currencyPair);
+      }
     }
 
     return coinbaseEx.getFills(apiKey, digest, getTimestamp(), passphrase, orderId, productId);

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
@@ -216,7 +216,7 @@ public final class GeminiAdapters {
     BigDecimal ask = GeminiTicker.getAsk();
     BigDecimal volume = GeminiTicker.getVolume().getBaseVolume(currencyPair);
 
-    Date timestamp = DateUtils.fromMillisUtc((long) (GeminiTicker.getVolume().getTimestampMS()));
+    Date timestamp = DateUtils.fromMillisUtc(GeminiTicker.getVolume().getTimestampMS());
 
     return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).volume(volume).timestamp(timestamp)
         .build();
@@ -283,10 +283,9 @@ public final class GeminiAdapters {
     return new UserTrades(pastTrades, TradeSortType.SortByTimestamp);
   }
 
-  private static Date convertBigDecimalTimestampToDate(BigDecimal timestamp) {
+  private static Date convertBigDecimalTimestampToDate(BigDecimal timestampInSeconds) {
 
-    BigDecimal timestampInMillis = timestamp.multiply(new BigDecimal("1000"));
-    return new Date(timestampInMillis.longValue());
+    return new Date((long)Math.floor(timestampInSeconds.doubleValue() * 1000));
   }
 
   public static ExchangeMetaData adaptMetaData(List<CurrencyPair> currencyPairs, ExchangeMetaData metaData) {

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.kraken.dto.trade.KrakenOrderFlags;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -39,7 +40,14 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    kraken = RestProxyFactory.createProxy(KrakenAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+    
+    kraken = RestProxyFactory.createProxy(KrakenAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     signatureCreator = KrakenDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 


### PR DESCRIPTION
I've added a HTTP read timeout configuration to the ExchangeSpecification class to allow the read timeout to be configured on a per exchange basis. I've implemented this for Kraken and Poloniex since in the last couple of months or so these exchanges have required longer timeouts. The exchange specific timeout will override the global rescu configuration, e.g. from rescu.properties. 

Also contains minor fix for GDAX trade history and improvement to Gemini timestamp conversion. 