### PR TITLE
some fixes

### DIFF
--- a/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/BitMarketUtils.java
+++ b/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/BitMarketUtils.java
@@ -9,9 +9,9 @@ import org.knowm.xchange.dto.Order;
 public class BitMarketUtils {
   public static String CurrencyPairToBitMarketCurrencyPair(CurrencyPair currencyPair) {
 
-    if (currencyPair == CurrencyPair.BTC_PLN) {
+    if (currencyPair.equals(CurrencyPair.BTC_PLN)) {
       return "BTCPLN";
-    } else if (currencyPair == CurrencyPair.BTC_EUR) {
+    } else if (currencyPair.equals(CurrencyPair.BTC_EUR)) {
       return "BTCEUR";
     } else if (currencyPair.base.getCurrencyCode().equals("LTC") && currencyPair.counter.getCurrencyCode().equals("PLN")) {
       return "LTCPLN";

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAuthenticated.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAuthenticated.java
@@ -70,7 +70,7 @@ public interface BittrexAuthenticated extends Bittrex {
   @GET
   @Path("market/getopenorders")
   BittrexOpenOrdersResponse openorders(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+       @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market) throws IOException;
 
   @GET
   @Path("account/getorderhistory")

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeService.java
@@ -56,7 +56,7 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
   @Override
   public OpenOrders getOpenOrders(
       OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders()));
+    return new OpenOrders(BittrexAdapters.adaptOpenOrders(getBittrexOpenOrders(params)));
   }
 
   @Override

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeServiceRaw.java
@@ -11,10 +11,13 @@ import org.knowm.xchange.bittrex.v1.dto.trade.BittrexOpenOrdersResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexTradeHistoryResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexTradeResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexUserTrade;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
+import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 
 public class BittrexTradeServiceRaw extends BittrexBaseService {
 
@@ -95,9 +98,15 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
 
   }
 
-  public List<BittrexOpenOrder> getBittrexOpenOrders() throws IOException {
+  public List<BittrexOpenOrder> getBittrexOpenOrders(OpenOrdersParams params) throws IOException {
+    String ccyPair = null;
 
-    BittrexOpenOrdersResponse response = bittrexAuthenticated.openorders(apiKey, signatureCreator, exchange.getNonceFactory());
+    if(params != null && params instanceof OpenOrdersParamCurrencyPair) {
+      CurrencyPair currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
+      ccyPair = currencyPair.base.toString() + "-" + currencyPair.counter.toString();
+    }
+
+    BittrexOpenOrdersResponse response = bittrexAuthenticated.openorders(apiKey, signatureCreator, exchange.getNonceFactory(), ccyPair);
 
     if (response.getSuccess()) {
       return response.getBittrexOpenOrders();

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
@@ -1,13 +1,5 @@
 package org.knowm.xchange.bleutrade;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.knowm.xchange.bleutrade.dto.account.BleutradeBalance;
 import org.knowm.xchange.bleutrade.dto.marketdata.BleutradeCurrency;
 import org.knowm.xchange.bleutrade.dto.marketdata.BleutradeLevel;
@@ -32,7 +24,16 @@ import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
 import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.utils.jackson.CurrencyPairDeserializer;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class BleutradeAdapters {
 
@@ -163,4 +164,19 @@ public class BleutradeAdapters {
     return new ExchangeMetaData(marketMetaDataMap, currencyMetaDataMap, null, null, null);
   }
 
+  public static UserTrade adaptUserTrade(BleutradeOpenOrder trade) {
+    OrderType orderType = trade.getType().equalsIgnoreCase("sell") ? OrderType.ASK : OrderType.BID;
+    CurrencyPair currencyPair = BleutradeUtils.toCurrencyPair(trade.getExchange());
+    return new UserTrade(
+        orderType,
+        trade.getQuantity(),
+        currencyPair,
+        trade.getPrice(),
+        BleutradeUtils.toDate(trade.getCreated()),
+        trade.getOrderId(),
+        trade.getOrderId(),
+        null,
+        null
+    );
+  }
 }

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAuthenticated.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAuthenticated.java
@@ -1,6 +1,13 @@
 package org.knowm.xchange.bleutrade;
 
-import java.io.IOException;
+import org.knowm.xchange.bleutrade.dto.account.BleutradeBalanceReturn;
+import org.knowm.xchange.bleutrade.dto.account.BleutradeBalancesReturn;
+import org.knowm.xchange.bleutrade.dto.account.BleutradeDepositAddressReturn;
+import org.knowm.xchange.bleutrade.dto.trade.BleutradeCancelOrderReturn;
+import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrdersReturn;
+import org.knowm.xchange.bleutrade.dto.trade.BleutradePlaceOrderReturn;
+import si.mazi.rescu.ParamsDigest;
+import si.mazi.rescu.SynchronizedValueFactory;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -8,16 +15,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
-
-import org.knowm.xchange.bleutrade.dto.account.BleutradeBalanceReturn;
-import org.knowm.xchange.bleutrade.dto.account.BleutradeBalancesReturn;
-import org.knowm.xchange.bleutrade.dto.account.BleutradeDepositAddressReturn;
-import org.knowm.xchange.bleutrade.dto.trade.BleutradeCancelOrderReturn;
-import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrdersReturn;
-import org.knowm.xchange.bleutrade.dto.trade.BleutradePlaceOrderReturn;
-
-import si.mazi.rescu.ParamsDigest;
-import si.mazi.rescu.SynchronizedValueFactory;
+import java.io.IOException;
 
 @Path("v2")
 @Produces(MediaType.APPLICATION_JSON)
@@ -60,4 +58,9 @@ public interface BleutradeAuthenticated extends Bleutrade {
   BleutradeOpenOrdersReturn getOrders(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
       @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException, BleutradeException;
 
+  @GET
+  @Path("account/getorders")
+  BleutradeOpenOrdersReturn getTrades(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
+      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce,
+      @QueryParam("market") String market, @QueryParam("orderstatus") String orderStatus, @QueryParam("ordertype") String orderType) throws IOException, BleutradeException;
 }

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeService.java
@@ -1,15 +1,15 @@
 package org.knowm.xchange.bleutrade.service;
 
-import java.io.IOException;
-import java.util.Collection;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bleutrade.BleutradeAdapters;
+import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
+import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
@@ -17,6 +17,11 @@ import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 public class BleutradeTradeService extends BleutradeTradeServiceRaw implements TradeService {
 
@@ -65,8 +70,11 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements T
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-
-    throw new NotAvailableFromExchangeException();
+    List<UserTrade> trades = new ArrayList<>();
+    for (BleutradeOpenOrder trade : getTrades(params)) {
+      trades.add(BleutradeAdapters.adaptUserTrade(trade));
+    }
+    return new UserTrades(trades, Trades.TradeSortType.SortByTimestamp);
   }
 
   @Override

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceRaw.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceRaw.java
@@ -1,8 +1,5 @@
 package org.knowm.xchange.bleutrade.service;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bleutrade.BleutradeException;
 import org.knowm.xchange.bleutrade.BleutradeUtils;
@@ -12,6 +9,10 @@ import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrdersReturn;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradePlaceOrderReturn;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+
+import java.io.IOException;
+import java.util.List;
 
 public class BleutradeTradeServiceRaw extends BleutradeBaseService {
 
@@ -84,6 +85,55 @@ public class BleutradeTradeServiceRaw extends BleutradeBaseService {
       return response.getResult();
     } catch (BleutradeException e) {
       throw new ExchangeException(e);
+    }
+  }
+
+  public List<BleutradeOpenOrder> getTrades(TradeHistoryParams params) throws IOException {
+    BleutradeTradeHistoryParams bleutradeTradeHistoryParams;
+    if (params instanceof BleutradeTradeHistoryParams) {
+      bleutradeTradeHistoryParams = (BleutradeTradeHistoryParams) params;
+    } else {
+      bleutradeTradeHistoryParams = BleutradeTradeHistoryParams.ALL;
+    }
+
+    try {
+      BleutradeOpenOrdersReturn response = bleutrade.getTrades(apiKey, signatureCreator, exchange.getNonceFactory(),
+          bleutradeTradeHistoryParams.market,
+          bleutradeTradeHistoryParams.orderStatus,
+          bleutradeTradeHistoryParams.orderType
+      );
+
+      if (!response.getSuccess()) {
+        throw new ExchangeException(response.getMessage());
+      }
+
+      return response.getResult();
+    } catch (BleutradeException e) {
+      throw new ExchangeException(e);
+    }
+  }
+
+  public static class BleutradeTradeHistoryParams implements TradeHistoryParams {
+    public static final BleutradeTradeHistoryParams ALL = new BleutradeTradeHistoryParams("ALL", "ALL", "ALL");
+    /**
+     * DIVIDEND_DIVISOR or ALL
+     */
+    public final String market;
+
+    /**
+     * ALL, OK, OPEN, CANCELED
+     */
+    public final String orderStatus;
+
+    /**
+     * ALL, BUY, SELL
+     */
+    public final String orderType;
+
+    public BleutradeTradeHistoryParams(String market, String orderStatus, String orderType) {
+      this.market = market;
+      this.orderStatus = orderStatus;
+      this.orderType = orderType;
     }
   }
 

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceRaw.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceRaw.java
@@ -7,6 +7,7 @@ import org.knowm.xchange.bleutrade.dto.trade.BleutradeCancelOrderReturn;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrder;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrdersReturn;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradePlaceOrderReturn;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
@@ -129,6 +130,10 @@ public class BleutradeTradeServiceRaw extends BleutradeBaseService {
      * ALL, BUY, SELL
      */
     public final String orderType;
+
+    public BleutradeTradeHistoryParams(CurrencyPair currencyPair, String orderStatus, String orderType) {
+      this(currencyPair.base + "_" + currencyPair.counter, orderStatus, orderType);
+    }
 
     public BleutradeTradeHistoryParams(String market, String orderStatus, String orderType) {
       this.market = market;

--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceTest.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceTest.java
@@ -337,7 +337,7 @@ public class BleutradeTradeServiceTest extends BleutradeServiceTestSupport {
         Mockito.eq(SPECIFICATION_API_KEY),
         Mockito.any(ParamsDigest.class),
         Mockito.any(SynchronizedValueFactory.class),
-        Mockito.matches("market"),
+        Mockito.matches("BTC_AUD"),
         Mockito.matches("status"),
         Mockito.matches("type")
     )).thenReturn(response);
@@ -345,7 +345,7 @@ public class BleutradeTradeServiceTest extends BleutradeServiceTestSupport {
     Whitebox.setInternalState(tradeService, "bleutrade", bleutrade);
 
     // when
-    UserTrades tradeHistory = tradeService.getTradeHistory(new BleutradeTradeServiceRaw.BleutradeTradeHistoryParams("market", "status", "type"));
+    UserTrades tradeHistory = tradeService.getTradeHistory(new BleutradeTradeServiceRaw.BleutradeTradeHistoryParams(CurrencyPair.BTC_AUD, "status", "type"));
     assertThat(tradeHistory.getUserTrades()).hasSize(1);
   }
 

--- a/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceTest.java
+++ b/xchange-bleutrade/src/test/java/org/knowm/xchange/bleutrade/service/BleutradeTradeServiceTest.java
@@ -2,10 +2,12 @@ package org.knowm.xchange.bleutrade.service;
 
 import static org.fest.assertions.api.Assertions.assertThat;
 import static org.fest.assertions.api.Assertions.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -19,6 +21,7 @@ import org.knowm.xchange.bleutrade.BleutradeAuthenticated;
 import org.knowm.xchange.bleutrade.BleutradeException;
 import org.knowm.xchange.bleutrade.BleutradeExchange;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradeCancelOrderReturn;
+import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrder;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradeOpenOrdersReturn;
 import org.knowm.xchange.bleutrade.dto.trade.BleutradePlaceOrderReturn;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -26,6 +29,7 @@ import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
+import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamCurrencyPair;
@@ -291,13 +295,58 @@ public class BleutradeTradeServiceTest extends BleutradeServiceTestSupport {
     fail("BleutradeAccountService should throw ExchangeException on cancel order request error");
   }
 
-  @Test(expected = NotAvailableFromExchangeException.class)
-  public void shouldFailOnGetTradeHistory() throws IOException {
-    // when
-    tradeService.getTradeHistory(new DefaultTradeHistoryParamCurrencyPair(CurrencyPair.BTC_AUD));
+  @Test
+  public void tradeHistoryShouldRequestAllMarketsIfNoneAreSupplied() throws IOException {
+    List<BleutradeOpenOrder> result = new ArrayList<>();
+    BleutradeOpenOrder order = anOrder();
+    result.add(order);
 
-    // then
-    fail("BleutradeAccountService should throw NotAvailableFromExchangeException when getTradeHistory is called");
+    BleutradeOpenOrdersReturn response = new BleutradeOpenOrdersReturn();
+    response.setResult(result);
+    response.setSuccess(true);
+
+    BleutradeAuthenticated bleutrade = mock(BleutradeAuthenticated.class);
+    PowerMockito.when(bleutrade.getTrades(
+        Mockito.eq(SPECIFICATION_API_KEY),
+        Mockito.any(ParamsDigest.class),
+        Mockito.any(SynchronizedValueFactory.class),
+        Mockito.matches("ALL"),
+        Mockito.any(String.class),
+        Mockito.any(String.class)
+    )).thenReturn(response);
+
+    Whitebox.setInternalState(tradeService, "bleutrade", bleutrade);
+
+    // when
+    UserTrades tradeHistory = tradeService.getTradeHistory(null);
+    assertThat(tradeHistory.getUserTrades()).hasSize(1);
+  }
+
+  @Test
+  public void tradeHistoryShouldUnderstandMarketParams() throws IOException {
+    List<BleutradeOpenOrder> result = new ArrayList<>();
+    BleutradeOpenOrder order = anOrder();
+    result.add(order);
+
+    BleutradeOpenOrdersReturn response = new BleutradeOpenOrdersReturn();
+    response.setResult(result);
+    response.setSuccess(true);
+
+    BleutradeAuthenticated bleutrade = mock(BleutradeAuthenticated.class);
+    PowerMockito.when(bleutrade.getTrades(
+        Mockito.eq(SPECIFICATION_API_KEY),
+        Mockito.any(ParamsDigest.class),
+        Mockito.any(SynchronizedValueFactory.class),
+        Mockito.matches("market"),
+        Mockito.matches("status"),
+        Mockito.matches("type")
+    )).thenReturn(response);
+
+    Whitebox.setInternalState(tradeService, "bleutrade", bleutrade);
+
+    // when
+    UserTrades tradeHistory = tradeService.getTradeHistory(new BleutradeTradeServiceRaw.BleutradeTradeHistoryParams("market", "status", "type"));
+    assertThat(tradeHistory.getUserTrades()).hasSize(1);
   }
 
   @Test(expected = NotAvailableFromExchangeException.class)
@@ -307,5 +356,13 @@ public class BleutradeTradeServiceTest extends BleutradeServiceTestSupport {
 
     // then
     fail("BleutradeAccountService should throw NotAvailableFromExchangeException when createTradeHistoryParams is called");
+  }
+
+  private static BleutradeOpenOrder anOrder() {
+    BleutradeOpenOrder order = new BleutradeOpenOrder();
+    order.setType("buy");
+    order.setExchange("BTC_AUD");
+    order.setCreated("2000-01-02 01:02:03.456");
+    return order;
   }
 }

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/dto/meta/DSXMetaData.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/dto/meta/DSXMetaData.java
@@ -1,16 +1,31 @@
 package org.knowm.xchange.dsx.dto.meta;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.meta.CurrencyMetaData;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.dto.meta.ExchangeMetaData;
+import org.knowm.xchange.dto.meta.RateLimit;
+
+import java.math.BigDecimal;
+import java.util.Map;
 
 /**
  * @author Mikhail Wall
  */
 
-public class DSXMetaData {
+public class DSXMetaData extends ExchangeMetaData {
 
   @JsonProperty
   public int publicInfoCacheSeconds;
 
   @JsonProperty
   public int amountScale;
+
+  public DSXMetaData(@JsonProperty("currency_pairs") Map<CurrencyPair, CurrencyPairMetaData> currencyPairs,
+                     @JsonProperty("currencies") Map<Currency, CurrencyMetaData> currencies, @JsonProperty("public_rate_limits") RateLimit[] publicRateLimits,
+                     @JsonProperty("private_rate_limits") RateLimit[] privateRateLimits, @JsonProperty("share_rate_limits") Boolean shareRateLimits) {
+    super(currencyPairs, currencies, publicRateLimits, privateRateLimits, shareRateLimits);
+  }
 }

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bittrex/v1/trade/BittrexTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bittrex/v1/trade/BittrexTradeDemo.java
@@ -71,7 +71,7 @@ public class BittrexTradeDemo {
       Thread.sleep(7000); // wait for order to propagate
 
       System.out.println();
-      System.out.println(tradeService.getBittrexOpenOrders());
+      System.out.println(tradeService.getBittrexOpenOrders(null));
 
       System.out.println("Attempting to cancel order " + uuid);
       boolean cancelled = tradeService.cancelBittrexLimitOrder(uuid);
@@ -85,7 +85,7 @@ public class BittrexTradeDemo {
       Thread.sleep(7000); // wait for cancellation to propagate
 
       System.out.println();
-      System.out.println(tradeService.getBittrexOpenOrders());
+      System.out.println(tradeService.getBittrexOpenOrders(null));
 
     } catch (Exception e) {
       e.printStackTrace();


### PR DESCRIPTION
* fixed incorrect use of == in BitMarket utils that can prevent ccy pairs from being recognised	
* implemented getTradeHistory for BleutradeTrade	
* made DSK metadata suport the 'standard' fields
* implemented OpenOrdersParamCurrencyPair in BittrexTradeService