### PR TITLE
[hitbtc, bittrex, bluetrade] improvements to getTradeHistory and getOpenOrders

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAuthenticated.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexAuthenticated.java
@@ -1,15 +1,5 @@
 package org.knowm.xchange.bittrex.v1;
 
-import java.io.IOException;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-
 import org.knowm.xchange.bittrex.v1.dto.account.BittrexBalancesResponse;
 import org.knowm.xchange.bittrex.v1.dto.account.BittrexDepositAddressResponse;
 import org.knowm.xchange.bittrex.v1.dto.account.BittrexDepositsHistoryResponse;
@@ -19,9 +9,18 @@ import org.knowm.xchange.bittrex.v1.dto.trade.BittrexCancelOrderResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexOpenOrdersResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexTradeHistoryResponse;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexTradeResponse;
-
+import org.knowm.xchange.currency.CurrencyPair;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 @Path("v1.1")
 @Produces(MediaType.APPLICATION_JSON)
@@ -31,65 +30,65 @@ public interface BittrexAuthenticated extends Bittrex {
   @GET
   @Path("account/getdepositaddress")
   BittrexDepositAddressResponse getdepositaddress(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("currency") String currency) throws IOException;
+                                                  @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("currency") String currency) throws IOException;
 
   @GET
   @Path("account/getbalances")
   BittrexBalancesResponse balances(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+                                   @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
 
   @GET
   @Path("market/buylimit")
   BittrexTradeResponse buylimit(@QueryParam("apikey") String apikey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market, @QueryParam("quantity") String quantity,
-      @QueryParam("rate") String rate) throws IOException;
+                                @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market, @QueryParam("quantity") String quantity,
+                                @QueryParam("rate") String rate) throws IOException;
 
   @GET
   @Path("market/selllimit")
   BittrexTradeResponse selllimit(@QueryParam("apikey") String apikey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market, @QueryParam("quantity") String quantity,
-      @QueryParam("rate") String rate) throws IOException;
+                                 @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market, @QueryParam("quantity") String quantity,
+                                 @QueryParam("rate") String rate) throws IOException;
 
   @GET
   @Path("market/buymarket")
   BittrexTradeResponse buymarket(@QueryParam("apikey") String apikey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market,
-      @QueryParam("quantity") String quantity) throws IOException;
+                                 @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market,
+                                 @QueryParam("quantity") String quantity) throws IOException;
 
   @GET
   @Path("market/sellmarket")
   BittrexTradeResponse sellmarket(@QueryParam("apikey") String apikey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market,
-      @QueryParam("quantity") String quantity) throws IOException;
+                                  @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market,
+                                  @QueryParam("quantity") String quantity) throws IOException;
 
   @GET
   @Path("market/cancel")
   BittrexCancelOrderResponse cancel(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("uuid") String uuid) throws IOException;
+                                    @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("uuid") String uuid) throws IOException;
 
   @GET
   @Path("market/getopenorders")
   BittrexOpenOrdersResponse openorders(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-       @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market) throws IOException;
+                                       @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market) throws IOException;
 
   @GET
   @Path("account/getorderhistory")
   BittrexTradeHistoryResponse getorderhistory(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+                                              @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("market") String market) throws IOException;
 
   @GET
   @Path("account/withdraw")
   BittrexWithdrawResponse withdraw(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("currency") String currency, @QueryParam("quantity") String quantity,
-      @QueryParam("address") String address, @QueryParam("paymentid") String paymentId) throws IOException;
+                                   @QueryParam("nonce") SynchronizedValueFactory<Long> nonce, @QueryParam("currency") String currency, @QueryParam("quantity") String quantity,
+                                   @QueryParam("address") String address, @QueryParam("paymentid") String paymentId) throws IOException;
 
   @GET
   @Path("account/getwithdrawalhistory")
   BittrexWithdrawalsHistoryResponse getwithdrawalhistory(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+                                                         @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
 
   @GET
   @Path("account/getdeposithistory")
   BittrexDepositsHistoryResponse getdeposithistory(@QueryParam("apikey") String apiKey, @HeaderParam("apisign") ParamsDigest signature,
-      @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
+                                                   @QueryParam("nonce") SynchronizedValueFactory<Long> nonce) throws IOException;
 }

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexUtils.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexUtils.java
@@ -1,12 +1,13 @@
 package org.knowm.xchange.bittrex.v1;
 
+import org.knowm.xchange.currency.Currency;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.exceptions.ExchangeException;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
-
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.exceptions.ExchangeException;
 
 /**
  * A central place for shared Bittrex properties
@@ -34,6 +35,9 @@ public final class BittrexUtils {
   }
 
   public static String toPairString(CurrencyPair currencyPair) {
+    if(currencyPair.base.getCurrencyCode().equalsIgnoreCase(Currency.BTC.getCurrencyCode()))
+      return currencyPair.base.getCurrencyCode().toUpperCase() + "-" + currencyPair.counter.getCurrencyCode().toUpperCase();
+
     return currencyPair.counter.getCurrencyCode().toUpperCase() + "-" + currencyPair.base.getCurrencyCode().toUpperCase();
   }
 

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeService.java
@@ -1,12 +1,9 @@
 package org.knowm.xchange.bittrex.v1.service;
 
-import static org.knowm.xchange.service.trade.params.TradeHistoryParamsZero.PARAMS_ZERO;
-
-import java.io.IOException;
-import java.util.Collection;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.v1.BittrexAdapters;
+import org.knowm.xchange.bittrex.v1.dto.trade.BittrexUserTrade;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.marketdata.Trades.TradeSortType;
 import org.knowm.xchange.dto.trade.LimitOrder;
@@ -17,8 +14,15 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import static org.knowm.xchange.service.trade.params.TradeHistoryParamsZero.PARAMS_ZERO;
 
 public class BittrexTradeService extends BittrexTradeServiceRaw implements TradeService {
 
@@ -67,7 +71,14 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-    return new UserTrades(BittrexAdapters.adaptUserTrades(getBittrexTradeHistory()), TradeSortType.SortByTimestamp);
+    CurrencyPair currencyPair = null;
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      TradeHistoryParamCurrencyPair tradeHistoryParamCurrencyPair = (TradeHistoryParamCurrencyPair) params;
+      currencyPair = tradeHistoryParamCurrencyPair.getCurrencyPair();
+    }
+
+    List<BittrexUserTrade> bittrexTradeHistory = getBittrexTradeHistory(currencyPair);
+    return new UserTrades(BittrexAdapters.adaptUserTrades(bittrexTradeHistory), TradeSortType.SortByTimestamp);
   }
 
   @Override

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexTradeServiceRaw.java
@@ -1,8 +1,5 @@
 package org.knowm.xchange.bittrex.v1.service;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.v1.BittrexUtils;
 import org.knowm.xchange.bittrex.v1.dto.trade.BittrexCancelOrderResponse;
@@ -18,6 +15,9 @@ import org.knowm.xchange.dto.trade.MarketOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.List;
 
 public class BittrexTradeServiceRaw extends BittrexBaseService {
 
@@ -103,7 +103,7 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
 
     if(params != null && params instanceof OpenOrdersParamCurrencyPair) {
       CurrencyPair currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
-      ccyPair = currencyPair.base.toString() + "-" + currencyPair.counter.toString();
+      ccyPair = BittrexUtils.toPairString(currencyPair);
     }
 
     BittrexOpenOrdersResponse response = bittrexAuthenticated.openorders(apiKey, signatureCreator, exchange.getNonceFactory(), ccyPair);
@@ -116,9 +116,12 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
 
   }
 
-  public List<BittrexUserTrade> getBittrexTradeHistory() throws IOException {
+  public List<BittrexUserTrade> getBittrexTradeHistory(CurrencyPair currencyPair) throws IOException {
+    String ccyPair = null;
+    if(currencyPair != null)
+      ccyPair = BittrexUtils.toPairString(currencyPair);
 
-    BittrexTradeHistoryResponse response = bittrexAuthenticated.getorderhistory(apiKey, signatureCreator, exchange.getNonceFactory());
+    BittrexTradeHistoryResponse response = bittrexAuthenticated.getorderhistory(apiKey, signatureCreator, exchange.getNonceFactory(), ccyPair);
 
     if (response.getSuccess()) {
       return response.getResult();
@@ -126,4 +129,5 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
       throw new ExchangeException(response.getMessage());
     }
   }
+
 }

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcTradeService.java
@@ -1,8 +1,5 @@
 package org.knowm.xchange.hitbtc.service;
 
-import java.io.IOException;
-import java.util.Collection;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
@@ -24,6 +21,9 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+
+import java.io.IOException;
+import java.util.Collection;
 
 public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeService {
 
@@ -77,22 +77,27 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
    */
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
+    int count = 1000;
+    int offset = 0;
 
-    TradeHistoryParamPaging pagingParams = (TradeHistoryParamPaging) params;
-    Integer count = pagingParams.getPageLength();
-    if (count == null) {
-      count = 1000;
+    if (params instanceof TradeHistoryParamPaging) {
+      TradeHistoryParamPaging pagingParams = (TradeHistoryParamPaging) params;
+      if (pagingParams.getPageLength() != null) {
+        count = pagingParams.getPageLength();
+      }
+
+      Integer pageNumber = pagingParams.getPageNumber();
+      offset = count * (pageNumber != null ? pageNumber : 0);
     }
 
-    Integer pageNumber = pagingParams.getPageNumber();
-    int offset = count * (pageNumber != null ? pageNumber : 0);
-
-    CurrencyPair pair = ((TradeHistoryParamCurrencyPair) params).getCurrencyPair();
-    if (pair == null) {
-      pair = CurrencyPair.BTC_USD;
+    String symbols = null;
+    if (params instanceof TradeHistoryParamCurrencyPair) {
+      TradeHistoryParamCurrencyPair tradeHistoryParamCurrencyPair = (TradeHistoryParamCurrencyPair) params;
+      CurrencyPair pair = tradeHistoryParamCurrencyPair.getCurrencyPair();
+      symbols = HitbtcAdapters.adaptCurrencyPair(pair);
     }
 
-    HitbtcOwnTrade[] tradeHistoryRaw = getTradeHistoryRaw(offset, count, HitbtcAdapters.adaptCurrencyPair(pair));
+    HitbtcOwnTrade[] tradeHistoryRaw = getTradeHistoryRaw(offset, count, symbols);
     return HitbtcAdapters.adaptTradeHistory(tradeHistoryRaw, exchange.getExchangeMetaData());
   }
 


### PR DESCRIPTION
[bittrex] made getTradeHistory optionally support TradeHistoryParamCurrencyPair [bittrex] made getBittrexOpenOrders support currency pairs that already have BTC as the base currency (like BTC_XRP) 

[hitbtc] made getTradeHistory optionally support TradeHistoryParamPaging and TradeHistoryParamCurrencyPair

[bluetrade] implemented TradeHistoryParamCurrencyPair and changed the default trade history so it doens't return cancelled trades (as this isn't really supported in the UserTrade class)