### PR TITLE
[Jubi] Add getAllTickers interface to fetch all e-coins' tickers by one request

### DIFF
--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/Jubi.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/Jubi.java
@@ -9,6 +9,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Created by Yingzhe on 3/16/2015.
@@ -26,6 +27,10 @@ public interface Jubi {
   @GET
   @Path("ticker/?coin={baseCurrency}")
   JubiTicker getTicker(@PathParam("baseCurrency") String baseCurrency) throws IOException;
+
+  @GET
+  @Path("allticker")
+  Map<String, JubiTicker> getAllTicker() throws IOException;
 
   @GET
   @Path("orders/?coin={baseCurrency}")

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiAdapters.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiAdapters.java
@@ -47,14 +47,4 @@ public class JubiAdapters {
 
     return new Trades(tradeList, Trades.TradeSortType.SortByTimestamp);
   }
-
-  public static Map<String, Ticker> adaptAllTicker(Map<String, JubiTicker> allJubiTicker) {
-    Map<String, Ticker> result = new HashMap<>();
-    if (allJubiTicker != null) {
-      for (Map.Entry<String, JubiTicker> entry : allJubiTicker.entrySet()) {
-        result.put(entry.getKey(), JubiAdapters.adaptTicker(entry.getValue(), new CurrencyPair(entry.getKey(), "cny")));
-      }
-    }
-    return result;
-  }
 }

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiAdapters.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiAdapters.java
@@ -9,23 +9,29 @@ import org.knowm.xchange.jubi.dto.marketdata.JubiTicker;
 import org.knowm.xchange.jubi.dto.marketdata.JubiTrade;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 
 /**
  * Created by Yingzhe on 3/16/2015.
+ * Adapter for market data.
  */
 public class JubiAdapters {
+  /**
+   * private constructor
+   */
+  private JubiAdapters() {
+  }
+
   public static Ticker adaptTicker(JubiTicker ticker, CurrencyPair currencyPair) {
     BigDecimal high = ticker.getHigh();
     BigDecimal low = ticker.getLow();
-    BigDecimal buy = ticker.getBuy();
-    BigDecimal sell = ticker.getSell();
+    BigDecimal bid = ticker.getBuy();
+    BigDecimal ask = ticker.getSell();
     BigDecimal last = ticker.getLast();
     BigDecimal volume = ticker.getVol();
-    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(buy).ask(sell).volume(volume).build();
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(bid).ask(ask).volume(volume).build();
   }
+
   public static Trades adaptTrades(JubiTrade[] jubiTrades, CurrencyPair currencyPair) {
 
     List<Trade> tradeList = new ArrayList<>();
@@ -40,5 +46,15 @@ public class JubiAdapters {
     }
 
     return new Trades(tradeList, Trades.TradeSortType.SortByTimestamp);
+  }
+
+  public static Map<String, Ticker> adaptAllTicker(Map<String, JubiTicker> allJubiTicker) {
+    Map<String, Ticker> result = new HashMap<>();
+    if (allJubiTicker != null) {
+      for (Map.Entry<String, JubiTicker> entry : allJubiTicker.entrySet()) {
+        result.put(entry.getKey(), JubiAdapters.adaptTicker(entry.getValue(), new CurrencyPair(entry.getKey(), "cny")));
+      }
+    }
+    return result;
   }
 }

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiExchange.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiExchange.java
@@ -24,7 +24,7 @@ public class JubiExchange extends BaseExchange {
   public ExchangeSpecification getDefaultExchangeSpecification() {
 
     ExchangeSpecification exchangeSpecification = new ExchangeSpecification(this.getClass().getCanonicalName());
-    exchangeSpecification.setSslUri("http://www.jubi.com/api");
+    exchangeSpecification.setSslUri("https://www.jubi.com/api");
     exchangeSpecification.setHost("www.jubi.com");
     exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("Jubi");

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiExchange.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/JubiExchange.java
@@ -1,22 +1,20 @@
 package org.knowm.xchange.jubi;
 
 import org.knowm.xchange.BaseExchange;
+import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.jubi.service.JubiMarketDataService;
 import org.knowm.xchange.utils.nonce.CurrentTimeNonceFactory;
 
 import si.mazi.rescu.SynchronizedValueFactory;
 
-public class JubiExchange extends BaseExchange {
+public class JubiExchange extends BaseExchange implements Exchange {
 
   private final SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
-  public JubiExchange() {
-
-  }
-
   @Override
   protected void initServices() {
+
     this.marketDataService = new JubiMarketDataService(this);
   }
 

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiBaseService.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiBaseService.java
@@ -1,31 +1,12 @@
 package org.knowm.xchange.jubi.service;
 
-import java.util.HashMap;
-import java.util.List;
-
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.jubi.Jubi;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
-import si.mazi.rescu.RestProxyFactory;
 
-public class JubiBaseService<T extends Jubi> extends BaseExchangeService implements BaseService {
-
-  private static HashMap<String, CurrencyPair> CURRENCY_PAIR_MAP;
-  private static List<CurrencyPair> CURRENCY_PAIR_LIST;
-  protected final T jubi;
-
-  /**
-   * Constructor Initialize common properties from the exchange specification
-   *
-   * @param exchange The {@link org.knowm.xchange.Exchange}
-   */
-  protected JubiBaseService(Class<T> type, Exchange exchange) {
-
+public class JubiBaseService extends BaseExchangeService implements BaseService {
+  public JubiBaseService(Exchange exchange) {
     super(exchange);
-
-    this.jubi = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri());
   }
 }

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataService.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataService.java
@@ -13,7 +13,6 @@ import org.knowm.xchange.jubi.dto.marketdata.JubiTicker;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 import java.io.IOException;
-import java.util.Map;
 
 /**
  * Created by Yingzhe on 3/17/2015.
@@ -32,10 +31,6 @@ public class JubiMarketDataService extends JubiMarketDataServiceRaw implements M
     JubiTicker jubiTicker = getJubiTicker(currencyPair.base.getCurrencyCode(), currencyPair.counter.getCurrencyCode());
     // Adapt to XChange DTOs
     return jubiTicker != null ? JubiAdapters.adaptTicker(jubiTicker, currencyPair) : null;
-  }
-
-  public Map<String, Ticker> getAllTicker(Object... args) throws IOException {
-    return JubiAdapters.adaptAllTicker(getAllJubiTicker());
   }
 
   @Override

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataService.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataService.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.jubi.dto.marketdata.JubiTicker;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Created by Yingzhe on 3/17/2015.
@@ -25,14 +26,16 @@ public class JubiMarketDataService extends JubiMarketDataServiceRaw implements M
   }
 
   @Override
-  public Ticker getTicker(CurrencyPair currencyPair,
-      Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
+  public Ticker getTicker(CurrencyPair currencyPair, Object... args)
+          throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     // Request data
     JubiTicker jubiTicker = getJubiTicker(currencyPair.base.getCurrencyCode(), currencyPair.counter.getCurrencyCode());
-
     // Adapt to XChange DTOs
     return jubiTicker != null ? JubiAdapters.adaptTicker(jubiTicker, currencyPair) : null;
+  }
+
+  public Map<String, Ticker> getAllTicker(Object... args) throws IOException {
+    return JubiAdapters.adaptAllTicker(getAllJubiTicker());
   }
 
   @Override

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
@@ -8,6 +8,7 @@ import org.knowm.xchange.jubi.dto.marketdata.JubiTrade;
 import si.mazi.rescu.RestProxyFactory;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -33,8 +34,15 @@ public class JubiMarketDataServiceRaw extends JubiBaseService {
     return null;
   }
 
-  public Map<String, JubiTicker> getAllJubiTicker() throws IOException {
-    return this.jubi.getAllTicker();
+  public Map<CurrencyPair, JubiTicker> getAllJubiTicker() throws IOException {
+    Map<CurrencyPair, JubiTicker> result = new HashMap<>();
+    Map<String, JubiTicker> rawResult = this.jubi.getAllTicker();
+    if (rawResult != null) {
+      for (Map.Entry<String, JubiTicker> entry : rawResult.entrySet()) {
+        result.put(new CurrencyPair(entry.getKey(), "cny"), entry.getValue());
+      }
+    }
+    return result;
   }
 
   public JubiTrade[] getJubiTrades(CurrencyPair currencyPair, Object[] args) throws IOException {

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
@@ -8,6 +8,7 @@ import org.knowm.xchange.jubi.dto.marketdata.JubiTrade;
 import si.mazi.rescu.RestProxyFactory;
 
 import java.io.IOException;
+import java.util.Map;
 
 /**
  * Created by Yingzhe on 3/17/2015.
@@ -30,6 +31,10 @@ public class JubiMarketDataServiceRaw extends JubiBaseService {
       }
     }
     return null;
+  }
+
+  public Map<String, JubiTicker> getAllJubiTicker() throws IOException {
+    return this.jubi.getAllTicker();
   }
 
   public JubiTrade[] getJubiTrades(CurrencyPair currencyPair, Object[] args) throws IOException {

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
@@ -5,46 +5,34 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.jubi.Jubi;
 import org.knowm.xchange.jubi.dto.marketdata.JubiTicker;
 import org.knowm.xchange.jubi.dto.marketdata.JubiTrade;
+import si.mazi.rescu.RestProxyFactory;
 
 import java.io.IOException;
 
 /**
  * Created by Yingzhe on 3/17/2015.
+ * Market Data Service.
  */
-public class JubiMarketDataServiceRaw extends JubiBaseService<Jubi> {
+public class JubiMarketDataServiceRaw extends JubiBaseService {
 
-  /**
-   * Constructor for JubiMarketDataServiceRaw
-   *
-   * @param exchange The {@link org.knowm.xchange.Exchange}
-   */
+  private final Jubi jubi;
+
   public JubiMarketDataServiceRaw(Exchange exchange) {
-
-    super(Jubi.class, exchange);
+    super(exchange);
+    this.jubi = RestProxyFactory.createProxy(Jubi.class, exchange.getExchangeSpecification().getSslUri());
   }
 
-  /**
-   * Gets ticker from Jubi
-   *
-   * @param baseCurrency Base currency
-   * @param targetCurrency Target currency
-   * @return JubiTicker object
-   * @throws java.io.IOException
-   */
   public JubiTicker getJubiTicker(String baseCurrency, String targetCurrency) throws IOException {
-
     // Base currency needs to be in lower case, otherwise API throws an error
     for (CurrencyPair cp : exchange.getExchangeSymbols()) {
       if (cp.base.getCurrencyCode().equalsIgnoreCase(baseCurrency) && cp.counter.getCurrencyCode().equalsIgnoreCase(targetCurrency)) {
         return this.jubi.getTicker(baseCurrency.toLowerCase());
       }
     }
-
     return null;
   }
 
   public JubiTrade[] getJubiTrades(CurrencyPair currencyPair, Object[] args) throws IOException {
-
     return  (args != null && args.length > 0 && args[0] != null && args[0] instanceof Long)
             ? jubi.getTradesSince(currencyPair.base.getCurrencyCode().toLowerCase(), (Long) args[0])
             : jubi.getTrades(currencyPair.base.getCurrencyCode().toLowerCase());

--- a/xchange-jubi/src/test/java/org/knowm/xchange/jubi/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-jubi/src/test/java/org/knowm/xchange/jubi/service/marketdata/TickerFetchIntegration.java
@@ -6,7 +6,8 @@ import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.jubi.JubiExchange;
-import org.knowm.xchange.jubi.service.JubiMarketDataService;
+import org.knowm.xchange.jubi.dto.marketdata.JubiTicker;
+import org.knowm.xchange.jubi.service.JubiMarketDataServiceRaw;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 import java.util.Map;
@@ -31,7 +32,7 @@ public class TickerFetchIntegration {
   public void allTickerFetchTest() throws Exception {
     Exchange exchange = ExchangeFactory.INSTANCE.createExchange(JubiExchange.class.getName());
     MarketDataService marketDataService = exchange.getMarketDataService();
-    Map<String, Ticker> allTickers = ((JubiMarketDataService) marketDataService).getAllTicker();
+    Map<CurrencyPair, JubiTicker> allTickers = ((JubiMarketDataServiceRaw) marketDataService).getAllJubiTicker();
     System.out.println(allTickers.toString());
     assertThat(allTickers).isNotNull();
   }

--- a/xchange-jubi/src/test/java/org/knowm/xchange/jubi/service/marketdata/TickerFetchIntegration.java
+++ b/xchange-jubi/src/test/java/org/knowm/xchange/jubi/service/marketdata/TickerFetchIntegration.java
@@ -1,14 +1,17 @@
 package org.knowm.xchange.jubi.service.marketdata;
 
-import static org.fest.assertions.api.Assertions.assertThat;
-
 import org.junit.Test;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeFactory;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.jubi.JubiExchange;
+import org.knowm.xchange.jubi.service.JubiMarketDataService;
 import org.knowm.xchange.service.marketdata.MarketDataService;
+
+import java.util.Map;
+
+import static org.fest.assertions.api.Assertions.assertThat;
 
 /**
  * Created by Yingzhe on 3/17/2015.
@@ -17,11 +20,19 @@ public class TickerFetchIntegration {
 
   @Test
   public void tickerFetchTest() throws Exception {
-
     Exchange exchange = ExchangeFactory.INSTANCE.createExchange(JubiExchange.class.getName());
     MarketDataService marketDataService = exchange.getMarketDataService();
     Ticker ticker = marketDataService.getTicker(new CurrencyPair("BTC", "CNY"));
     System.out.println(ticker.toString());
     assertThat(ticker).isNotNull();
+  }
+
+  @Test
+  public void allTickerFetchTest() throws Exception {
+    Exchange exchange = ExchangeFactory.INSTANCE.createExchange(JubiExchange.class.getName());
+    MarketDataService marketDataService = exchange.getMarketDataService();
+    Map<String, Ticker> allTickers = ((JubiMarketDataService) marketDataService).getAllTicker();
+    System.out.println(allTickers.toString());
+    assertThat(allTickers).isNotNull();
   }
 }


### PR DESCRIPTION
1. Move MarketData RestProxy from BaseService down to JubiMarketDataServiceRaw, which allow us to decouple different proxies(market data, account, trade...) in the next development. 
2. Add getAllTickers interface to fetch all e-coins' tickers by one restful request (Path：/api/v1/allticker/).