### PR TITLE
Removing Logic added in Bittrex Utils at 916f3b32647f4d3255b5907a4d266d56d5fd05fa. 

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexUtils.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/BittrexUtils.java
@@ -35,9 +35,6 @@ public final class BittrexUtils {
   }
 
   public static String toPairString(CurrencyPair currencyPair) {
-    if(currencyPair.base.getCurrencyCode().equalsIgnoreCase(Currency.BTC.getCurrencyCode()))
-      return currencyPair.base.getCurrencyCode().toUpperCase() + "-" + currencyPair.counter.getCurrencyCode().toUpperCase();
-
     return currencyPair.counter.getCurrencyCode().toUpperCase() + "-" + currencyPair.base.getCurrencyCode().toUpperCase();
   }
 


### PR DESCRIPTION
 This logic broke the ticker ability for Bittrex.