### PR TITLE
Update HitbtcTradeServiceRaw.java

### DIFF
--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcTradeServiceRaw.java
@@ -248,7 +248,7 @@ public class HitbtcTradeServiceRaw extends HitbtcBaseService {
     CurrencyPair pair = order.getCurrencyPair();
     BigDecimal lotDivisor = LOT_SIZES.get(pair);
 
-    BigDecimal lots = order.getTradableAmount().divide(lotDivisor, BigDecimal.ROUND_UNNECESSARY);
+    BigDecimal lots = order.getTradableAmount().divide(lotDivisor, BigDecimal.ROUND_UNNECESSARY).setScale(0, BigDecimal.ROUND_DOWN);
     if (lots.compareTo(BigDecimal.ONE) < 0) {
       throw new IllegalArgumentException("Tradable amount too low");
     }


### PR DESCRIPTION
toBigIntegerExact() throws an exception whenever the lots number is not an integer. Rounded down because it is more acceptable to place an order smaller in case we base it on the balance, otherwise it can exceed what we have in the balance.