### PR TITLE
Update GDAXProductTicker obj name from bitstampTicker to gdaxTicker

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/gdax/GDAXTickerDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/gdax/GDAXTickerDemo.java
@@ -31,9 +31,9 @@ public class GDAXTickerDemo {
 
   private static void raw(GDAXMarketDataServiceRaw marketDataService) throws IOException {
 
-    GDAXProductTicker bitstampTicker = marketDataService.getCoinbaseExProductTicker(CurrencyPair.BTC_USD);
+    GDAXProductTicker gdaxTicker = marketDataService.getCoinbaseExProductTicker(CurrencyPair.BTC_USD);
 
-    System.out.println(bitstampTicker.toString());
+    System.out.println(gdaxTicker.toString());
   }
 
 }


### PR DESCRIPTION
Looks to be a copy paste mistake. Updated the name to reference gdax as opposed to bitstamp in this gdax example.