### PR TITLE
Updated kraken non documented minimal usdt order amount

### DIFF
--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -155,7 +155,7 @@
     },
     "USDT/USD": {
       "price_scale": 6,
-      "min_amount": 1.0
+      "min_amount": 5.0
     },
     "DASH/BTC": {
       "price_scale": 6,


### PR DESCRIPTION
Usdt minimal order amount seems to be 5 usdt. (non documented on their support pages, found this amount with trying)