### PR TITLE
Removed XRP/GBP and REP/CAD

### DIFF
--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -44,10 +44,6 @@
       "price_scale": 8,
       "min_amount": 30.00000000
     },
-    "XRP/GBP": {
-      "price_scale": 5,
-      "min_amount": 30.00000000
-    },
     "XRP/JPY": {
       "price_scale": 5,
       "min_amount": 30.00000000
@@ -134,10 +130,6 @@
       "min_amount": 0.300000000
     },
     "REP/USD": {
-      "price_scale": 6,
-      "min_amount": 0.300000000
-    },
-    "REP/CAD": {
       "price_scale": 6,
       "min_amount": 0.300000000
     },


### PR DESCRIPTION
These pairs are not supported anymore by Kraken.
https://github.com/timmolter/XChange/issues/1673