### PR TITLE
[okcoin] add averagePrice and status for limit order

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
@@ -1,17 +1,5 @@
 package org.knowm.xchange.okcoin;
 
-import static org.knowm.xchange.currency.Currency.BTC;
-import static org.knowm.xchange.currency.Currency.LTC;
-import static org.knowm.xchange.currency.Currency.USD;
-
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order.OrderStatus;
@@ -29,23 +17,18 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
-import org.knowm.xchange.okcoin.dto.account.OkCoinAccountRecords;
-import org.knowm.xchange.okcoin.dto.account.OkCoinFunds;
-import org.knowm.xchange.okcoin.dto.account.OkCoinFuturesInfoCross;
-import org.knowm.xchange.okcoin.dto.account.OkCoinFuturesUserInfoCross;
-import org.knowm.xchange.okcoin.dto.account.OkCoinRecords;
-import org.knowm.xchange.okcoin.dto.account.OkCoinUserInfo;
-import org.knowm.xchange.okcoin.dto.account.OkcoinFuturesFundsCross;
+import org.knowm.xchange.okcoin.dto.account.*;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinDepth;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTickerResponse;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTrade;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesOrder;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesOrderResult;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesTradeHistoryResult;
+import org.knowm.xchange.okcoin.dto.trade.*;
 import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesTradeHistoryResult.TransactionType;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinOrder;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinOrderResult;
 import org.knowm.xchange.utils.DateUtils;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import static org.knowm.xchange.currency.Currency.*;
 
 public final class OkCoinAdapters {
 
@@ -234,8 +217,9 @@ public final class OkCoinAdapters {
 
   private static LimitOrder adaptOpenOrder(OkCoinOrder order) {
 
-    return new LimitOrder(adaptOrderType(order.getType()), order.getAmount(), adaptSymbol(order.getSymbol()), String.valueOf(order.getOrderId()),
-        order.getCreateDate(), order.getPrice());
+    return new LimitOrder(adaptOrderType(order.getType()), order.getAmount(), adaptSymbol(order.getSymbol()),
+            String.valueOf(order.getOrderId()), order.getCreateDate(), order.getPrice(), order.getAveragePrice(),
+            order.getDealAmount(), adaptOrderStatus(order.getStatus()));
   }
 
   public static LimitOrder adaptOpenOrderFutures(OkCoinFuturesOrder order) {

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/dto/trade/OkCoinOrder.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/dto/trade/OkCoinOrder.java
@@ -1,9 +1,9 @@
 package org.knowm.xchange.okcoin.dto.trade;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.math.BigDecimal;
 import java.util.Date;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class OkCoinOrder {
 
@@ -23,10 +23,13 @@ public class OkCoinOrder {
 
   private final BigDecimal price;
 
+  private final BigDecimal averagePrice;
+
   public OkCoinOrder(@JsonProperty("order_id") final long orderId, @JsonProperty("status") final int status,
-      @JsonProperty("symbol") final String symbol, @JsonProperty("type") final String type, @JsonProperty("price") final BigDecimal price,
-      @JsonProperty("amount") final BigDecimal amount, @JsonProperty("deal_amount") final BigDecimal dealAmount,
-      @JsonProperty("create_date") final Date createDate) {
+                     @JsonProperty("symbol") final String symbol, @JsonProperty("type") final String type,
+                     @JsonProperty("price") final BigDecimal price, @JsonProperty("avg_price") final BigDecimal averagePrice,
+                     @JsonProperty("amount") final BigDecimal amount, @JsonProperty("deal_amount") final BigDecimal dealAmount,
+                     @JsonProperty("create_date") final Date createDate) {
 
     this.orderId = orderId;
     this.status = status;
@@ -35,6 +38,7 @@ public class OkCoinOrder {
     this.amount = amount;
     this.dealAmount = dealAmount;
     this.price = price;
+    this.averagePrice = averagePrice;
     this.createDate = createDate;
   }
 
@@ -76,5 +80,10 @@ public class OkCoinOrder {
   public BigDecimal getPrice() {
 
     return price;
+  }
+
+  public BigDecimal getAveragePrice() {
+
+    return averagePrice;
   }
 }


### PR DESCRIPTION
`OkCoinOrder` didn't reflect the actual filled price. `price` is from the order client placed and `avg_price` is the actual filled price. 

`adaptOpenOrder()` didn't include the order status and filled size. `adaptOrderStatus` and `dealAmount`should be added. 