### PR TITLE
Bitstamp added ETH

### DIFF
--- a/xchange-bitstamp/src/main/resources/bitstamp.json
+++ b/xchange-bitstamp/src/main/resources/bitstamp.json
@@ -3,12 +3,12 @@
     "BTC/USD": {
       "price_scale": 2,
       "trading_fee": 0.0025,
-      "min_amount": 0.010000000
+      "min_amount": 0.001500000
     },
     "BTC/EUR": {
       "price_scale": 2,
       "trading_fee": 0.0025,
-      "min_amount": 0.010000000
+      "min_amount": 0.001500000
     },
     "EUR/USD": {
       "price_scale": 2,
@@ -18,17 +18,17 @@
     "XRP/USD": {
       "price_scale": 5,
       "trading_fee": 0.0025,
-      "min_amount": 200.0000000
+      "min_amount": 40.0000000
     },
     "XRP/EUR": {
       "price_scale": 5,
       "trading_fee": 0.0025,
-      "min_amount": 200.0000000
+      "min_amount": 40.0000000
     },
     "XRP/BTC": {
       "price_scale": 8,
       "trading_fee": 0.0025,
-      "min_amount": 200.0000000
+      "min_amount": 40.0000000
     },
     "LTC/USD": {
       "price_scale": 2,
@@ -44,6 +44,21 @@
       "price_scale": 8,
       "trading_fee": 0.0025,
       "min_amount": 0.15
+    },
+    "ETH/EUR": {
+      "price_scale": 2,
+      "trading_fee": 0.0000,
+      "min_amount": 0.0150000
+    },
+    "ETH/USD": {
+      "price_scale": 2,
+      "trading_fee": 0.0000,
+      "min_amount": 0.0150000
+    },
+    "ETH/BTC": {
+      "price_scale": 8,
+      "trading_fee": 0.0000,
+      "min_amount": 0.0150000
     }
   },
   "currencies": {
@@ -61,7 +76,10 @@
     },
     "LTC": {
       "scale": 8
-    }
+    },
+    "ETH": {
+      "scale": 8
+    }    
   },
   "private_rate_limits": [
     {

--- a/xchange-bitstamp/src/main/resources/bitstamp.json
+++ b/xchange-bitstamp/src/main/resources/bitstamp.json
@@ -48,17 +48,17 @@
     "ETH/EUR": {
       "price_scale": 2,
       "trading_fee": 0.0000,
-      "min_amount": 0.0150000
+      "min_amount": 0.02000000
     },
     "ETH/USD": {
       "price_scale": 2,
       "trading_fee": 0.0000,
-      "min_amount": 0.0150000
+      "min_amount": 0.02000000
     },
     "ETH/BTC": {
       "price_scale": 8,
       "trading_fee": 0.0000,
-      "min_amount": 0.0150000
+      "min_amount": 0.02000000
     }
   },
   "currencies": {


### PR DESCRIPTION
ETH added to bitstamp json file. Changed min amount of BTC and XRP to latest market values.
https://www.bitstamp.net/article/free-ether-trading-limited-time-only/