### PR TITLE
add null check for minimum amount (for poloniex)

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
@@ -57,11 +57,12 @@ public abstract class BaseExchangeService {
 
     BigDecimal amount = tradableAmount.stripTrailingZeros();
     BigDecimal minimumAmount = metaData.getMinimumAmount();
-    if (amount.scale() > minimumAmount.scale()) {
-      throw new IllegalArgumentException("Unsupported amount scale " + amount.scale());
-    } else if (amount.compareTo(minimumAmount) < 0) {
-      throw new IllegalArgumentException("Order amount less than minimum");
+    if (minimumAmount != null) {
+        if (amount.scale() > minimumAmount.scale()) {
+          throw new IllegalArgumentException("Unsupported amount scale " + amount.scale());
+        } else if (amount.compareTo(minimumAmount) < 0) {
+          throw new IllegalArgumentException("Order amount less than minimum");
+        }
     }
   }
-
 }


### PR DESCRIPTION
Poloniex's currency pair meta data doesn't seem to ever have a minimum amount. This means that the verifyOrder method typically fails on Poloniex. I'm happy to make the pull request better, but there doesn't seem to be any other meta data about the currency pair that one could check to stay in line with the spirit of the verifyOrder method. Poloniex does tend to have the price scale int value, making a call to metaData.getPriceScale() valid but that seems like it would return an int value of price scale for the quote currency. I'm not sure we can infer that the tradeable amount's scale must be less than (or equal to?) the quote currency's price scale. If that is a good assumption I'm happy to put it in and throw an IllegalArgumentException.