### PR TITLE
add null checks to MarketDataService classes

### DIFF
--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXMarketDataService.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXMarketDataService.java
@@ -55,7 +55,7 @@ public class ANXMarketDataService extends ANXMarketDataServiceRaw implements Mar
 
     // Request data
     ANXDepthWrapper anxDepthWrapper = null;
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       if (args[0] instanceof String) {
         if ("full" == args[0]) {
           anxDepthWrapper = getANXFullOrderBook(currencyPair);

--- a/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataService.java
+++ b/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataService.java
@@ -49,7 +49,7 @@ public class BitcoiniumMarketDataService extends BitcoiniumMarketDataServiceRaw 
 
     String priceWindow = "";
 
-    if (args.length == 1) {
+    if (args != null && args.length == 1) {
       Object arg0 = args[0];
       if (!(arg0 instanceof String)) {
         throw new ExchangeException("priceWindow argument must be a String!");

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexMarketDataService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexMarketDataService.java
@@ -56,7 +56,7 @@ public class BitfinexMarketDataService extends BitfinexMarketDataServiceRaw impl
     Integer limitBids = null;
     Integer limitAsks = null;
 
-    if (args.length == 2) {
+    if (args != null && args.length == 2) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Integer)) {
         throw new ExchangeException("Argument 0 must be an Integer!");
@@ -84,7 +84,7 @@ public class BitfinexMarketDataService extends BitfinexMarketDataServiceRaw impl
     int limitBids = 50;
     int limitAsks = 50;
 
-    if (args.length == 2) {
+    if (args != null && args.length == 2) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Integer)) {
         throw new ExchangeException("Argument 0 must be an Integer!");

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexMarketDataService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/v1/service/BittrexMarketDataService.java
@@ -49,7 +49,7 @@ public class BittrexMarketDataService extends BittrexMarketDataServiceRaw implem
 
     int depth = 50;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       if (args[0] instanceof Integer && (Integer) args[0] > 0 && (Integer) args[0] <= 50) {
         depth = (Integer) args[0];
       }
@@ -73,7 +73,7 @@ public class BittrexMarketDataService extends BittrexMarketDataServiceRaw implem
 
     int count = 50;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       if (args[0] instanceof Integer) {
         count = (Integer) args[0];
       }

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeMarketDataService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeMarketDataService.java
@@ -38,7 +38,7 @@ public class BleutradeMarketDataService extends BleutradeMarketDataServiceRaw im
 
     int depth = 50;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       if (args[0] instanceof Integer) {
         depth = (Integer) args[0];
       }
@@ -53,7 +53,7 @@ public class BleutradeMarketDataService extends BleutradeMarketDataServiceRaw im
 
     int count = 50;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       if (args[0] instanceof Integer) {
         count = (Integer) args[0];
       }

--- a/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/rest/BTCChinaMarketDataService.java
+++ b/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/rest/BTCChinaMarketDataService.java
@@ -51,7 +51,7 @@ public class BTCChinaMarketDataService extends BTCChinaMarketDataServiceRaw impl
     final BTCChinaDepth btcChinaDepth;
     final String market = BTCChinaAdapters.adaptMarket(currencyPair);
 
-    if (args.length == 0) {
+    if (args == null || args.length == 0) {
       btcChinaDepth = getBTCChinaOrderBook(market);
     } else {
       int limit = ((Number) args[0]).intValue();
@@ -76,9 +76,9 @@ public class BTCChinaMarketDataService extends BTCChinaMarketDataServiceRaw impl
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
 
     final String market = BTCChinaAdapters.adaptMarket(currencyPair);
-    final Number since = args.length > 0 ? (Number) args[0] : null;
-    final Number limit = args.length > 1 ? (Number) args[1] : null;
-    final String sinceType = args.length > 2 ? (String) args[2] : null;
+    final Number since = args != null && args.length > 0 ? (Number) args[0] : null;
+    final Number limit = args != null && args.length > 1 ? (Number) args[1] : null;
+    final String sinceType = args != null && args.length > 2 ? (String) args[2] : null;
 
     log.debug("market: {}, since: {}, limit: {}, sinceType: {}", market, since, limit, sinceType);
 

--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/BTCEMarketDataService.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/BTCEMarketDataService.java
@@ -51,7 +51,7 @@ public class BTCEMarketDataService extends BTCEMarketDataServiceRaw implements M
     String pairs = BTCEAdapters.getPair(currencyPair);
     BTCEDepthWrapper btceDepthWrapper = null;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Integer) || ((Integer) arg0 < 1) || ((Integer) arg0 > FULL_SIZE)) {
         throw new ExchangeException("Orderbook size argument must be an Integer in the range: (1, 2000)!");

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeMarketDataService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeMarketDataService.java
@@ -48,7 +48,7 @@ public class BTCTradeMarketDataService extends BTCTradeMarketDataServiceRaw impl
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
 
     final BTCTradeTrade[] trades;
-    if (args.length == 0) {
+    if (args == null || args.length == 0) {
       trades = getBTCTradeTrades();
     } else {
       trades = getBTCTradeTrades(toLong(args[0]));

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataService.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataService.java
@@ -52,7 +52,7 @@ public class CexIOMarketDataService extends CexIOMarketDataServiceRaw implements
 
     CexIOTrade[] trades;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Number)) {
         throw new ExchangeException("arg[0] must be a Number used to represent since trade id.");

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataService.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataService.java
@@ -33,7 +33,7 @@ public class CoinfloorMarketDataService extends CoinfloorMarketDataServiceRaw im
   @Override
   public Trades getTrades(CurrencyPair pair, Object... args) throws IOException {
     CoinfloorInterval interval;
-    if (args.length == 1 && args[0] instanceof CoinfloorInterval) {
+    if (args != null && args.length == 1 && args[0] instanceof CoinfloorInterval) {
       interval = (CoinfloorInterval) args[0];
     } else {
       interval = CoinfloorInterval.HOUR;

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaMarketDataService.java
@@ -21,7 +21,7 @@ public class CryptopiaMarketDataService extends CryptopiaMarketDataServiceRaw im
 
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       long hours = (long) args[0];
 
       return CryptopiaAdapters.adaptTicker(getCryptopiaTicker(currencyPair, hours), currencyPair);
@@ -32,7 +32,7 @@ public class CryptopiaMarketDataService extends CryptopiaMarketDataServiceRaw im
 
   @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       long orderCount = (long) args[0];
 
       return CryptopiaAdapters.adaptOrderBook(getCryptopiaOrderBook(currencyPair, orderCount), currencyPair);
@@ -43,7 +43,7 @@ public class CryptopiaMarketDataService extends CryptopiaMarketDataServiceRaw im
 
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       long hours = (long) args[0];
 
       return CryptopiaAdapters.adaptTrades(getCryptopiaTrades(currencyPair, hours));

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXMarketDataService.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXMarketDataService.java
@@ -45,7 +45,9 @@ public class DSXMarketDataService extends DSXMarketDataServiceRaw implements Mar
     String pairs = DSXAdapters.getPair(currencyPair);
     String accountType = null;
     try {
-      accountType = (String) args[0];
+      if(args != null) {
+    	  accountType = (String) args[0];
+      }
     } catch (ArrayIndexOutOfBoundsException e) {
       // ignore, can happen if no argument given.
     }
@@ -71,7 +73,9 @@ public class DSXMarketDataService extends DSXMarketDataServiceRaw implements Mar
 
     String accountType = null;
     try {
-      accountType = (String) args[0];
+      if(args != null) {
+    	  accountType = (String) args[0];
+      }
     } catch (ArrayIndexOutOfBoundsException e) {
       // ignore, can happen if no argument given.
     }
@@ -101,7 +105,9 @@ public class DSXMarketDataService extends DSXMarketDataServiceRaw implements Mar
     String pairs = DSXAdapters.getPair(currencyPair);
     int numberOfItems = -1;
     try {
-      numberOfItems = (Integer) args[0];
+      if(args != null) {    	  
+    	  numberOfItems = (Integer) args[0]; //can this really be args[0] if we are also using args[0] as a string below??
+      }
     } catch (ArrayIndexOutOfBoundsException e) {
       // ignore, can happen if no argument given.
     }
@@ -109,7 +115,9 @@ public class DSXMarketDataService extends DSXMarketDataServiceRaw implements Mar
 
     String accountType = null;
     try {
-      accountType = (String) args[0];
+      if(args != null) {
+    	  accountType = (String) args[0];
+      }
     } catch (ArrayIndexOutOfBoundsException e) {
       // ignore, can happen if no argument given.
     }

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinMarketDataService.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinMarketDataService.java
@@ -40,7 +40,7 @@ public class GatecoinMarketDataService extends GatecoinMarketDataServiceRaw impl
 
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
-    if (args.length == 0) {
+    if (args == null || args.length == 0) {
       return GatecoinAdapters.adaptTrades(getGatecoinTransactions(currencyPair.toString()).getTransactions(), currencyPair);
     } else if (args.length == 1) {
       return GatecoinAdapters.adaptTrades(getGatecoinTransactions(currencyPair.toString(), (Integer) args[0], 0).getTransactions(), currencyPair);

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataService.java
@@ -56,7 +56,7 @@ public class GeminiMarketDataService extends GeminiMarketDataServiceRaw implemen
     Integer limitBids = null;
     Integer limitAsks = null;
 
-    if (args.length == 2) {
+    if (args != null && args.length == 2) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Integer)) {
         throw new ExchangeException("Argument 0 must be an Integer!");
@@ -84,7 +84,7 @@ public class GeminiMarketDataService extends GeminiMarketDataServiceRaw implemen
     int limitBids = 50;
     int limitAsks = 50;
 
-    if (args.length == 2) {
+    if (args != null && args.length == 2) {
       Object arg0 = args[0];
       if (!(arg0 instanceof Integer)) {
         throw new ExchangeException("Argument 0 must be an Integer!");

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcMarketDataService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcMarketDataService.java
@@ -42,9 +42,9 @@ public class HitbtcMarketDataService extends HitbtcMarketDataServiceRaw implemen
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
 
-    if (args.length == 0)
+    if (args == null || args.length == 0) {
       return HitbtcAdapters.adaptTrades(getHitbtcTradesRecent(currencyPair, 1000), currencyPair);
-
+    }
     long from = (Long) args[0]; // <trade_id> or <timestamp>
     HitbtcTradesSortField sortBy = (HitbtcTradesSortField) args[1]; // "trade_id" or "timestamp"
     HitbtcTradesSortDirection sortDirection = (HitbtcTradesSortDirection) args[2]; // "asc" or "desc"

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenMarketDataService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenMarketDataService.java
@@ -36,7 +36,7 @@ public class KrakenMarketDataService extends KrakenMarketDataServiceRaw implemen
 
     long count = Long.MAX_VALUE;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       Object arg0 = args[0];
       if (arg0 instanceof Long) {
         count = (Long) arg0;
@@ -57,7 +57,7 @@ public class KrakenMarketDataService extends KrakenMarketDataServiceRaw implemen
 
     Long since = null;
 
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       Object arg0 = args[0];
       if (arg0 instanceof Long) {
         since = (Long) arg0;
@@ -67,8 +67,7 @@ public class KrakenMarketDataService extends KrakenMarketDataServiceRaw implemen
     }
 
     KrakenPublicTrades krakenTrades = getKrakenTrades(currencyPair, since);
-    Trades trades = KrakenAdapters.adaptTrades(krakenTrades.getTrades(), currencyPair, krakenTrades.getLast());
-    return trades;
+    return KrakenAdapters.adaptTrades(krakenTrades.getTrades(), currencyPair, krakenTrades.getLast());
   }
 
 }

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoMarketDataService.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoMarketDataService.java
@@ -56,7 +56,7 @@ public class LunoMarketDataService extends LunoBaseService implements MarketData
     @Override
     public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
         Long since = null;
-        if (args.length >= 1) {
+        if (args != null && args.length >= 1) {
             Object arg0 = args[0];
             if (arg0 instanceof Long) {
                 since = (Long) arg0;

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinFuturesMarketDataService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinFuturesMarketDataService.java
@@ -31,7 +31,7 @@ public class OkCoinFuturesMarketDataService extends OkCoinMarketDataServiceRaw i
 
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       return OkCoinAdapters.adaptTicker(getFuturesTicker(currencyPair, (FuturesContract) args[0]), currencyPair);
     } else {
       return OkCoinAdapters.adaptTicker(getFuturesTicker(currencyPair, futuresContract), currencyPair);
@@ -40,7 +40,7 @@ public class OkCoinFuturesMarketDataService extends OkCoinMarketDataServiceRaw i
 
   @Override
   public OrderBook getOrderBook(CurrencyPair currencyPair, Object... args) throws IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       return OkCoinAdapters.adaptOrderBook(getFuturesDepth(currencyPair, (FuturesContract) args[0]), currencyPair);
     } else {
       return OkCoinAdapters.adaptOrderBook(getFuturesDepth(currencyPair, futuresContract), currencyPair);
@@ -49,7 +49,7 @@ public class OkCoinFuturesMarketDataService extends OkCoinMarketDataServiceRaw i
 
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
-    if (args.length > 0) {
+    if (args != null && args.length > 0) {
       return OkCoinAdapters.adaptTrades(getFuturesTrades(currencyPair, (FuturesContract) args[0]), currencyPair);
     } else {
       return OkCoinAdapters.adaptTrades(getFuturesTrades(currencyPair, futuresContract), currencyPair);

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataService.java
@@ -37,7 +37,7 @@ public class OkCoinMarketDataService extends OkCoinMarketDataServiceRaw implemen
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
     final OkCoinTrade[] trades;
 
-    if (args.length == 0) {
+    if (args == null || args.length == 0) {
       trades = getTrades(currencyPair);
     } else {
       trades = getTrades(currencyPair, (Long) args[0]);

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexMarketDataService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexMarketDataService.java
@@ -34,8 +34,7 @@ public class PoloniexMarketDataService extends PoloniexMarketDataServiceRaw impl
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
 
     PoloniexTicker poloniexTicker = getPoloniexTicker(currencyPair);
-    Ticker ticker = PoloniexAdapters.adaptPoloniexTicker(poloniexTicker, currencyPair);
-    return ticker;
+    return PoloniexAdapters.adaptPoloniexTicker(poloniexTicker, currencyPair);
   }
 
   @Override
@@ -56,8 +55,7 @@ public class PoloniexMarketDataService extends PoloniexMarketDataServiceRaw impl
     if (depth == null) {
       depth = getPoloniexDepth(currencyPair);
     }
-    OrderBook orderBook = PoloniexAdapters.adaptPoloniexDepth(depth, currencyPair);
-    return orderBook;
+    return PoloniexAdapters.adaptPoloniexDepth(depth, currencyPair);
   }
 
   @Override
@@ -84,8 +82,7 @@ public class PoloniexMarketDataService extends PoloniexMarketDataServiceRaw impl
     } else {
       poloniexPublicTrades = getPoloniexPublicTrades(currencyPair, startTime, endTime);
     }
-    Trades trades = PoloniexAdapters.adaptPoloniexPublicTrades(poloniexPublicTrades, currencyPair);
-    return trades;
+    return PoloniexAdapters.adaptPoloniexPublicTrades(poloniexPublicTrades, currencyPair);
   }
 
 }

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleMarketDataService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleMarketDataService.java
@@ -31,7 +31,7 @@ public class RippleMarketDataService extends RippleMarketDataServiceRaw implemen
    */
   @Override
   public OrderBook getOrderBook(final CurrencyPair currencyPair, final Object... args) throws IOException {
-    if ((args.length > 0) && (args[0] instanceof RippleMarketDataParams)) {
+    if ((args != null && args.length > 0) && (args[0] instanceof RippleMarketDataParams)) {
       final RippleMarketDataParams params = (RippleMarketDataParams) args[0];
       final RippleOrderBook orderBook = getRippleOrderBook(currencyPair, params);
       return RippleAdapters.adaptOrderBook(orderBook, params, currencyPair);

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusMarketDataService.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusMarketDataService.java
@@ -32,7 +32,7 @@ public class TaurusMarketDataService extends TaurusMarketDataServiceRaw implemen
 
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
-    final Taurus.Time time = args.length == 0 ? null : (Taurus.Time) args[0];
+    final Taurus.Time time = args == null || args.length == 0 ? null : (Taurus.Time) args[0];
     return TaurusAdapters.adaptTrades(getTaurusTransactions(time), currencyPair);
   }
 }


### PR DESCRIPTION
I was testing out cryptopia exchange support and I was getting NullPointerException because the implementation of `CryptopiaMarketDataService.java` assumes `args` is not null when in reality null should be a perfectly valid value.

I did a quick find/grep for every implementation that wasn't doing null checks and added them.