### PR TITLE
[okcoin] Fix adaptDate

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinAdapters.java
@@ -313,7 +313,7 @@ public final class OkCoinAdapters {
   }
 
   private static Date adaptDate(long date) {
-    return DateUtils.fromMillisUtc(date * 1000L);
+    return DateUtils.fromMillisUtc(date);
   }
 
   public static List<FundingRecord> adaptFundingHistory(final OkCoinAccountRecords[] okCoinAccountRecordsList) {


### PR DESCRIPTION
The date returned from server is already in millisecond. Shouldn't multiply by 1000L. 
https://www.okcoin.com/about/rest_api.do
URL https://www.okcoin.com/api/v1/account_records.do