### PR TITLE
[bitstamp] support status value 10

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalRequest.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalRequest.java
@@ -78,6 +78,7 @@ public class WithdrawalRequest {
         case "2": return finished;
         case "3": return canceled;
         case "4": return failed;
+        case "10": return in_process;
         default:throw new IllegalArgumentException(string + " has no corresponding value");
       }
     }


### PR DESCRIPTION
bitstamp reports the status "10" for some withdrawals, this status is not documented
to avoid the IllegalArgumentException lets assume the status is "in_process"