### PR TITLE
Updated kraken.json

### DIFF
--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -2,49 +2,45 @@
   "currency_pairs": {
     "BTC/EUR": {
       "price_scale": 3,
-      "min_amount": 0.002000000
+      "min_amount": 0.002000000      
     },
     "BTC/USD": {
       "price_scale": 3,
-      "min_amount": 0.002000000
+      "min_amount": 0.002000000      
     },
     "BTC/CAD": {
       "price_scale": 3,
-      "min_amount": 0.002000000
-    },
-    "BTC/GBP": {
-      "price_scale": 3,
-      "min_amount": 0.002000000
+      "min_amount": 0.002000000      
     },
     "BTC/JPY": {
       "price_scale": 1,
-      "min_amount": 0.002000000
+      "min_amount": 0.002000000      
     },
     "LTC/EUR": {
       "price_scale": 5,
-      "min_amount": 0.10000000
+      "min_amount": 0.10000000      
     },
     "LTC/USD": {
       "price_scale": 5,
-      "min_amount": 0.10000000
+      "min_amount": 0.10000000      
     },
     "LTC/BTC": {
       "price_scale": 6,
-      "min_amount": 0.10000000
+      "min_amount": 0.10000000      
     },
     "DOGE/BTC": {
       "price_scale": 8,
-      "min_amount": 3000.00000
+      "min_amount": 3000.00000      
     },
     "XLM/BTC": {
       "price_scale": 8,
-      "min_amount": 300.000000
+      "min_amount": 300.000000      
     },
     "XRP/BTC": {
       "price_scale": 8,
-      "min_amount": 30.00000000
+      "min_amount": 30.00000000      
     },
-    "XRP/JPY": {
+    "XRP/GBP": {
       "price_scale": 5,
       "min_amount": 30.00000000
     },
@@ -58,15 +54,15 @@
     },
     "ETH/BTC": {
       "price_scale": 6,
-      "min_amount": 0.020000000
+      "min_amount": 0.020000000      
     },
     "ETH/EUR": {
       "price_scale": 5,
-      "min_amount": 0.020000000
+      "min_amount": 0.020000000      
     },
     "ETH/USD": {
       "price_scale": 5,
-      "min_amount": 0.020000000
+      "min_amount": 0.020000000      
     },
     "XMR/BTC": {
       "price_scale": 6,
@@ -106,15 +102,11 @@
     },
     "ETH/CAD": {
       "price_scale": 5,
-      "min_amount": 0.020000000
-    },
-    "ETH/GBP": {
-      "price_scale": 5,
-      "min_amount": 0.020000000
+      "min_amount": 0.020000000      
     },
     "ETH/JPY": {
       "price_scale": 1,
-      "min_amount": 0.020000000
+      "min_amount": 0.020000000      
     },
     "REP/BTC": {
       "price_scale": 6,
@@ -128,7 +120,7 @@
       "price_scale": 6,
       "min_amount": 0.300000000
     },
-    "REP/USD": {
+    "REP/CAD": {
       "price_scale": 6,
       "min_amount": 0.300000000
     },
@@ -168,14 +160,6 @@
       "price_scale": 6,
       "min_amount": 0.030000000
     },
-    "GNO/EUR": {
-      "price_scale": 6,
-      "min_amount": 0.030000000
-    },
-    "GNO/USD": {
-      "price_scale": 6,
-      "min_amount": 0.030000000
-    },
     "BCH/BTC": {
       "price_scale": 6,
       "min_amount": 0.020000000
@@ -187,7 +171,15 @@
     "BCH/USD": {
       "price_scale": 4,
       "min_amount": 0.020000000
-    }
+    },
+    "EOS/BTC": {
+      "price_scale": 6,
+      "min_amount": 3.00000000
+    },
+    "EOS/ETH": {
+      "price_scale": 6,
+      "min_amount": 3.00000000
+    },
   },
   "currencies": {},
   "public_rate_limits": [

--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -179,7 +179,7 @@
     "EOS/ETH": {
       "price_scale": 6,
       "min_amount": 3.00000000
-    },
+    }
   },
   "currencies": {},
   "public_rate_limits": [


### PR DESCRIPTION
Kraken removed some pairs: 

In order to help mitigate the strain on our platform caused by recent exponential
growth, we are delisting some of our illiquid trading pairs and temporarily
suspending all advanced order types. *These changes will go into effect on Tuesday,
August 22 around 6 am UTC (Monday August 21 around 11 pm Pacific).*

# The following pairs will be delisted with all outstanding orders being canceled

* XBT/GBP
* ETH/GBP
* XRP/CAD
* XRP/JPY
* EOS/EUR
* EOS/USD
* XLM/EUR
* XLM/USD
* GNO/EUR
* GNO/USD
* REP/USD

# The ability to create new advanced orders will also be temporarily suspended (so
you will only be able to create basic limit and market orders)

Open orders will remain open until cancelled or executed, but you will no longer be
able to create new orders in any of the following advanced types:

* Stop Loss
* Take Profit
* Stop Loss, Take Profit
* Stop Loss, Take Profit Limit
* Stop Loss Limit
* Take Profit Limit
* Trailing Stop
* Trailing Stop Limit
* Stop, Limit

This suspension is temporary only. Advanced orders will return in a month or two as
soon as we are better able to process them. We know that many of our clients like
the advanced orders, but they are used much less frequently than basic limit and
market orders while taking more system resources to process.

*The above changes will go into effect on Tuesday, August 22 around 6 am UTC (Monday
August 21 around 11 pm Pacific).*



Thank you for choosing Kraken,

The Kraken Team