### PR TITLE
[bitstamp] support unknown status values

### DIFF
--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalRequest.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/dto/account/WithdrawalRequest.java
@@ -67,7 +67,7 @@ public class WithdrawalRequest {
   }
 
   public enum Status {
-    open, in_process, finished, canceled, failed;
+    open, in_process, finished, canceled, failed, unknown;
     
     // 0 (open), 1 (in process), 2 (finished), 3 (canceled) or 4 (failed).
     @JsonCreator
@@ -78,8 +78,7 @@ public class WithdrawalRequest {
         case "2": return finished;
         case "3": return canceled;
         case "4": return failed;
-        case "10": return in_process;
-        default:throw new IllegalArgumentException(string + " has no corresponding value");
+        default: return unknown;
       }
     }
   }


### PR DESCRIPTION
very annoying
after adding the status value of "10" (see https://github.com/timmolter/XChange/pull/1709), what ever that means, now i get "8"
the values are still not documented by bitstamp, support request is on the way...

i just changed the method, by adding an "unknown" status, so at least we do not get the IllegalArgumentException