### PR TITLE
[Okcoin] Update json and withdraw crypto

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoin.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoin.java
@@ -1,16 +1,5 @@
 package org.knowm.xchange.okcoin;
 
-import java.io.IOException;
-
-import javax.ws.rs.Consumes;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-
 import org.knowm.xchange.okcoin.dto.account.OKCoinWithdraw;
 import org.knowm.xchange.okcoin.dto.account.OkCoinAccountRecords;
 import org.knowm.xchange.okcoin.dto.account.OkCoinFuturesUserInfoCross;
@@ -18,13 +7,12 @@ import org.knowm.xchange.okcoin.dto.account.OkCoinUserInfo;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinDepth;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTickerResponse;
 import org.knowm.xchange.okcoin.dto.marketdata.OkCoinTrade;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesOrderResult;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinFuturesTradeHistoryResult;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinOrderResult;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinPositionResult;
-import org.knowm.xchange.okcoin.dto.trade.OkCoinTradeResult;
-
+import org.knowm.xchange.okcoin.dto.trade.*;
 import si.mazi.rescu.ParamsDigest;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
 
 @Path("/v1")
 @Produces(MediaType.APPLICATION_JSON)
@@ -142,7 +130,7 @@ public interface OkCoin {
   @Path("withdraw.do")
   OKCoinWithdraw withdraw(@FormParam("api_key") String api_key, @FormParam("symbol") String symbol, @FormParam("sign") ParamsDigest sign,
       @FormParam("chargefee") String chargefee, @FormParam("trade_pwd") String trade_pwd, @FormParam("withdraw_address") String withdraw_address,
-      @FormParam("withdraw_amount") String withdraw_amount) throws IOException;
+      @FormParam("withdraw_amount") String withdraw_amount, @FormParam("target") String target) throws IOException;
 
   @POST
   @Path("account_records.do")

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
@@ -1,9 +1,5 @@
 package org.knowm.xchange.okcoin.service;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-import java.util.List;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -16,13 +12,11 @@ import org.knowm.xchange.okcoin.OkCoinAdapters;
 import org.knowm.xchange.okcoin.dto.account.OKCoinWithdraw;
 import org.knowm.xchange.okcoin.dto.account.OkCoinAccountRecords;
 import org.knowm.xchange.service.account.AccountService;
-import org.knowm.xchange.service.trade.params.DefaultTradeHistoryParamPaging;
-import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrency;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
-import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
-import org.knowm.xchange.service.trade.params.TradeHistoryParams;
-import org.knowm.xchange.service.trade.params.WithdrawFundsParams;
+import org.knowm.xchange.service.trade.params.*;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
 
 public class OkCoinAccountService extends OkCoinAccountServiceRaw implements AccountService {
 
@@ -45,9 +39,11 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
 
   @Override
   public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
-    String okcoinCurrency = currency == Currency.BTC ? "btc_usd" : "btc_ltc";
+    boolean useIntl = this.exchange.getExchangeSpecification().getExchangeSpecificParametersItem("Use_Intl").equals(true);
+    String currencySymbol = OkCoinAdapters.adaptSymbol(new CurrencyPair(currency, useIntl ? Currency.USD : Currency.CNY));
 
-    OKCoinWithdraw result = withdraw(null, okcoinCurrency, address, amount);
+    // Defualt withdraw target is external address. Use withdraw function in OkCoinAccountServiceRaw for internal withdraw
+    OKCoinWithdraw result = withdraw(currencySymbol, address, amount, "okex");
 
     if (result != null)
       return result.getWithdrawId();

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
@@ -1,13 +1,13 @@
 package org.knowm.xchange.okcoin.service;
 
-import java.io.IOException;
-import java.math.BigDecimal;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.okcoin.dto.account.OKCoinWithdraw;
 import org.knowm.xchange.okcoin.dto.account.OkCoinAccountRecords;
 import org.knowm.xchange.okcoin.dto.account.OkCoinFuturesUserInfoCross;
 import org.knowm.xchange.okcoin.dto.account.OkCoinUserInfo;
+
+import java.io.IOException;
+import java.math.BigDecimal;
 
 public class OkCoinAccountServiceRaw extends OKCoinBaseTradeService {
   private final String tradepwd;
@@ -38,9 +38,21 @@ public class OkCoinAccountServiceRaw extends OKCoinBaseTradeService {
     return returnOrThrow(futuresUserInfoCross);
   }
 
-  public OKCoinWithdraw withdraw(String assetPairs, String assets, String key, BigDecimal amount) throws IOException {
-    OKCoinWithdraw withdrawResult = okCoin.withdraw(exchange.getExchangeSpecification().getApiKey(), assets, signatureCreator, "0.0001", tradepwd,
-        key, amount.toString());
+  public OKCoinWithdraw withdraw(String currencySymbol, String withdrawAddress, BigDecimal amount, String target) throws IOException {
+    String fee = null;
+    if (target.equals("okex")) { //External address
+      if (currencySymbol.startsWith("btc")) fee = "0.0001";
+      else if (currencySymbol.startsWith("ltc")) fee = "0.001";
+      else if (currencySymbol.startsWith("eth")) fee = "0.01";
+      else throw new IllegalArgumentException("Unsupported withdraw currency");
+    } else if (target.equals("okcn") || target.equals("okcom")) { //Internal address
+      fee = "0";
+    } else {
+      throw new IllegalArgumentException("Unsupported withdraw target");
+    }
+
+    OKCoinWithdraw withdrawResult = okCoin.withdraw(exchange.getExchangeSpecification().getApiKey(), currencySymbol,
+            signatureCreator, fee, tradepwd, withdrawAddress, amount.toString(), target);
 
     return returnOrThrow(withdrawResult);
   }

--- a/xchange-okcoin/src/main/resources/okcoin_china.json
+++ b/xchange-okcoin/src/main/resources/okcoin_china.json
@@ -1,9 +1,15 @@
 {
   "currency_pairs": {
     "BTC/CNY": {
+      "min_amount": 0.01,
       "price_scale": 2
     },
     "LTC/CNY": {
+      "min_amount": 0.1,
+      "price_scale": 2
+    },
+    "ETH/CNY": {
+      "min_amount": 0.01,
       "price_scale": 2
     }
   },

--- a/xchange-okcoin/src/main/resources/okcoin_intl.json
+++ b/xchange-okcoin/src/main/resources/okcoin_intl.json
@@ -1,9 +1,15 @@
 {
   "currency_pairs": {
     "BTC/USD": {
+      "min_amount": 0.01,
       "price_scale": 2
     },
     "LTC/USD": {
+      "min_amount": 0.1,
+      "price_scale": 2
+    },
+    "ETH/USD": {
+      "min_amount": 0.01,
       "price_scale": 2
     }
   },


### PR DESCRIPTION
Update Okcoin json to include min_amount and ETH.

Partially fix withdraw crypto by adding withdraw target, correcting currency symbol and fees.

API reference: 
https://www.okcoin.com/about/rest_api.do
https://www.okcoin.com/api/v1/withdraw.do