### PR TITLE
Issue #1710 resolves [Okcoin] Withdraw crypto not working

### DIFF
--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinDigest.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinDigest.java
@@ -88,7 +88,7 @@ public class OkCoinDigest implements ParamsDigest {
     try {
       md.reset();
 
-      byte[] digest = md.digest(message.getBytes("UTF-8"));
+      byte[] digest = md.digest(message.getBytes("US-ASCII"));
 
       return String.valueOf(encodeHex(digest, DIGITS_UPPER));
     } catch (UnsupportedEncodingException e) {

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinUtils.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/OkCoinUtils.java
@@ -115,7 +115,7 @@ public class OkCoinUtils {
       case (20028):
         return "no such contract";
       default:
-        return "Unknown error";
+        return "Unknown error: " + errorCode;
     }
   }
 }

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountService.java
@@ -43,7 +43,7 @@ public class OkCoinAccountService extends OkCoinAccountServiceRaw implements Acc
     String currencySymbol = OkCoinAdapters.adaptSymbol(new CurrencyPair(currency, useIntl ? Currency.USD : Currency.CNY));
 
     // Defualt withdraw target is external address. Use withdraw function in OkCoinAccountServiceRaw for internal withdraw
-    OKCoinWithdraw result = withdraw(currencySymbol, address, amount, "okex");
+    OKCoinWithdraw result = withdraw(currencySymbol, address, amount, "address");
 
     if (result != null)
       return result.getWithdrawId();

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinAccountServiceRaw.java
@@ -40,12 +40,12 @@ public class OkCoinAccountServiceRaw extends OKCoinBaseTradeService {
 
   public OKCoinWithdraw withdraw(String currencySymbol, String withdrawAddress, BigDecimal amount, String target) throws IOException {
     String fee = null;
-    if (target.equals("okex")) { //External address
-      if (currencySymbol.startsWith("btc")) fee = "0.0001";
+    if (target.equals("address")) { //External address
+      if (currencySymbol.startsWith("btc")) fee = "0.002";
       else if (currencySymbol.startsWith("ltc")) fee = "0.001";
       else if (currencySymbol.startsWith("eth")) fee = "0.01";
       else throw new IllegalArgumentException("Unsupported withdraw currency");
-    } else if (target.equals("okcn") || target.equals("okcom")) { //Internal address
+    } else if (target.equals("okex") || target.equals("okcn") || target.equals("okcom")) { //Internal address
       fee = "0";
     } else {
       throw new IllegalArgumentException("Unsupported withdraw target");


### PR DESCRIPTION
This would fix withdrawal issues arises when 'tradepwd' includes characters that encoded differently in  Unicode and ASCII. tradepwd should be encoded in ASCII.

Default target should be external address, so 'address' is appropriate.