### PR TITLE
Add theOtherType method to OrderType

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -29,7 +29,17 @@ public abstract class Order {
     /**
      * This is to close a long position when trading crypto currency derivatives such as swaps, futures for CFD's.
      */
-    EXIT_BID
+    EXIT_BID;
+
+    public OrderType theOtherType() {
+      switch (this) {
+        case ASK: return BID;
+        case BID: return ASK;
+        case EXIT_ASK: return EXIT_BID;
+        case EXIT_BID: return EXIT_ASK;
+      }
+      throw new RuntimeException("should not reach here");
+    }
   }
 
   public enum OrderStatus {


### PR DESCRIPTION
Sometimes, I want to get the `ASK` for `BID` OrderType and vise versa.  Rather than writing switch statements or ifs on many places, I'd prefer the OrderType enum can calculate the other type of itself.

So, wrote such method.
... Any opinion?