### PR TITLE
[quoine] use getApiKey and getSecretKey

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/QuoineExamplesUtils.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/quoine/QuoineExamplesUtils.java
@@ -15,8 +15,8 @@ public class QuoineExamplesUtils {
     ExchangeSpecification exSpec = new ExchangeSpecification(QuoineExchange.class);
 
     // enter your specific API access info here
-    exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_TOKEN_ID, "");
-    exSpec.getExchangeSpecificParameters().put(QuoineExchange.KEY_USER_SECRET, "");
+    exSpec.setApiKey("KEY_TOKEN_ID");
+    exSpec.setSecretKey("KEY_USER_SECRET");
 
     return ExchangeFactory.INSTANCE.createExchange(exSpec);
   }

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineExchange.java
@@ -12,9 +12,6 @@ import si.mazi.rescu.SynchronizedValueFactory;
 
 public class QuoineExchange extends BaseExchange implements Exchange {
 
-  public static final String KEY_TOKEN_ID = "KEY_TOKEN_ID";
-  public static final String KEY_USER_SECRET = "KEY_USER_SECRET";
-
   private SynchronizedValueFactory<Long> nonceFactory = new CurrentTimeNonceFactory();
 
   @Override

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
@@ -34,8 +34,8 @@ public class QuoineBaseService extends BaseExchangeService implements BaseServic
 
     quoine = RestProxyFactory.createProxy(QuoineAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
 
-    this.tokenID = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_TOKEN_ID);
-    this.secret = (String) exchange.getExchangeSpecification().getExchangeSpecificParameters().get(QuoineExchange.KEY_USER_SECRET);
+    this.tokenID = exchange.getExchangeSpecification().getApiKey();
+    this.secret = exchange.getExchangeSpecification().getSecretKey();
 
     if (this.tokenID != null && this.secret != null) {
       this.signatureCreator = new QuoineSignatureDigest(this.tokenID, this.secret, exchange.getNonceFactory());


### PR DESCRIPTION
Currently, xchange-quoine uses it's own specification parameter for setting api(or, token, in the terms of quoine exchange) and secret key.  This does not follow convention, so I thought it would be better to use the ordinal interface of `ExchangeSpecification#getApiKey()` and `ExchangeSpecification#getSecretKey()`.

(Can revent new people stumbling on this peculiarity, e.g. #1398 , IMO.. )