### PR TITLE
Add limit_trades param to Gemini getTrades

### DIFF
--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/Gemini.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/Gemini.java
@@ -41,7 +41,8 @@ public interface Gemini {
 
   @GET
   @Path("trades/{symbol}")
-  GeminiTrade[] getTrades(@PathParam("symbol") String symbol, @QueryParam("timestamp") long timestamp) throws IOException, GeminiException;
+  GeminiTrade[] getTrades(@PathParam("symbol") String symbol, @QueryParam("timestamp") long timestamp,
+    @QueryParam("limit_trades") int limit_trades) throws IOException, GeminiException;
 
   @GET
   @Path("lends/{currency}")

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataService.java
@@ -116,7 +116,18 @@ public class GeminiMarketDataService extends GeminiMarketDataServiceRaw implemen
    */
   @Override
   public Trades getTrades(CurrencyPair currencyPair, Object... args) throws IOException {
-
+      
+    // According to API docs, default is 50
+    int limitTrades = 50;
+    if (args.length > 1) {
+        if (args[1] instanceof Integer) {
+            limitTrades = ((Integer)args[1]).intValue();
+        }
+        else {
+            throw new ExchangeException("Argument 1 must be an Integer!");
+        }
+    }
+      
     long lastTradeTime = 0;
     if (args != null && args.length == 1) {
       // parameter 1, if present, is the last trade timestamp
@@ -131,7 +142,7 @@ public class GeminiMarketDataService extends GeminiMarketDataServiceRaw implemen
             "Extra argument #1, the last trade time, must be a Date or Long (millisecond timestamp) (was " + args[0].getClass() + ")");
       }
     }
-    GeminiTrade[] trades = getGeminiTrades(GeminiUtils.toPairString(currencyPair), lastTradeTime);
+    GeminiTrade[] trades = getGeminiTrades(GeminiUtils.toPairString(currencyPair), lastTradeTime, limitTrades);
 
     return GeminiAdapters.adaptTrades(trades, currencyPair);
   }

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataServiceRaw.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiMarketDataServiceRaw.java
@@ -71,10 +71,10 @@ public class GeminiMarketDataServiceRaw extends GeminiBaseService {
     }
   }
 
-  public GeminiTrade[] getGeminiTrades(String pair, long sinceTimestamp) throws IOException {
+  public GeminiTrade[] getGeminiTrades(String pair, long sinceTimestamp, int limitTrades) throws IOException {
 
     try {
-      GeminiTrade[] GeminiTrades = Gemini.getTrades(pair, sinceTimestamp);
+      GeminiTrade[] GeminiTrades = Gemini.getTrades(pair, sinceTimestamp, limitTrades);
       return GeminiTrades;
     } catch (GeminiException e) {
       throw new ExchangeException("Gemini returned an error", e);


### PR DESCRIPTION
Gemini lets you increase the number returned to 1000, the default is 50.