### PR TITLE
Update decimal place precision for Kraken

### DIFF
--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -1,15 +1,15 @@
 {
   "currency_pairs": {
     "BTC/EUR": {
-      "price_scale": 2,
+      "price_scale": 1,
       "min_amount": 0.002000000
     },
     "BTC/USD": {
-      "price_scale": 2,
+      "price_scale": 1,
       "min_amount": 0.002000000
     },
     "BTC/CAD": {
-      "price_scale": 2,
+      "price_scale": 1,
       "min_amount": 0.002000000
     },
     "BTC/JPY": {
@@ -17,11 +17,11 @@
       "min_amount": 0.002000000
     },
     "LTC/EUR": {
-      "price_scale": 4,
+      "price_scale": 2,
       "min_amount": 0.10000000
     },
     "LTC/USD": {
-      "price_scale": 4,
+      "price_scale": 2,
       "min_amount": 0.10000000
     },
     "LTC/BTC": {
@@ -33,11 +33,11 @@
       "min_amount": 3000.00000
     },
     "XLM/BTC": {
-      "price_scale": 7,
+      "price_scale": 8,
       "min_amount": 300.000000
     },
     "XRP/BTC": {
-      "price_scale": 6,
+      "price_scale": 8,
       "min_amount": 30.00000000
     },
     "XRP/GBP": {
@@ -45,23 +45,23 @@
       "min_amount": 30.00000000
     },
     "XRP/EUR": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 30.00000000
     },
     "XRP/USD": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 30.00000000
     },
     "ETH/BTC": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.020000000
     },
     "ETH/EUR": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.020000000
     },
     "ETH/USD": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.020000000
     },
     "XMR/BTC": {
@@ -69,11 +69,11 @@
       "min_amount": 0.100000000
     },
     "XMR/EUR": {
-      "price_scale": 4,
+      "price_scale": 2,
       "min_amount": 0.100000000
     },
     "XMR/USD": {
-      "price_scale": 4,
+      "price_scale": 2,
       "min_amount": 0.100000000
     },
     "ETC/BTC": {
@@ -81,11 +81,11 @@
       "min_amount": 0.300000000
     },
     "ETC/EUR": {
-      "price_scale": 4,
+      "price_scale": 3,
       "min_amount": 0.300000000
     },
     "ETC/USD": {
-      "price_scale": 4,
+      "price_scale": 3,
       "min_amount": 0.300000000
     },
     "ETC/ETH": {
@@ -97,15 +97,15 @@
       "min_amount": 0.100000000
     },
     "MLN/ETH": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.100000000
     },
     "ETH/CAD": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.020000000
     },
     "ETH/JPY": {
-      "price_scale": 1,
+      "price_scale": 0,
       "min_amount": 0.020000000
     },
     "REP/BTC": {
@@ -113,11 +113,11 @@
       "min_amount": 0.300000000
     },
     "REP/ETH": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.300000000
     },
     "REP/EUR": {
-      "price_scale": 4,
+      "price_scale": 3,
       "min_amount": 0.300000000
     },
     "REP/CAD": {
@@ -125,15 +125,15 @@
       "min_amount": 0.300000000
     },
     "ZEC/BTC": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.030000000
     },
     "ZEC/EUR": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.030000000
     },
     "ZEC/USD": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.030000000
     },
     "USDT/USD": {
@@ -141,39 +141,39 @@
       "min_amount": 5.0
     },
     "DASH/BTC": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.030000000
     },
     "DASH/EUR": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.030000000
     },
     "DASH/USD": {
-      "price_scale": 3,
+      "price_scale": 2,
       "min_amount": 0.030000000
     },
     "GNO/ETH": {
-      "price_scale": 6,
+      "price_scale": 4,
       "min_amount": 0.030000000
     },
     "GNO/BTC": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.030000000
     },
     "BCH/BTC": {
-      "price_scale": 6,
+      "price_scale": 5,
       "min_amount": 0.020000000
     },
     "BCH/EUR": {
-      "price_scale": 3,
+      "price_scale": 1,
       "min_amount": 0.020000000
     },
     "BCH/USD": {
-      "price_scale": 3,
+      "price_scale": 1,
       "min_amount": 0.020000000
     },
     "EOS/BTC": {
-      "price_scale": 6,
+      "price_scale": 7,
       "min_amount": 3.00000000
     },
     "EOS/ETH": {
@@ -181,7 +181,7 @@
       "min_amount": 3.00000000
     },
     "ICN/BTC": {
-      "price_scale": 6
+      "price_scale": 7
     },
     "ICN/ETH": {
       "price_scale": 6


### PR DESCRIPTION
Updates `kraken.json` regarding the latest decimal place modification effective September 6 around 6 am UTC. Kraken mail notification:

> 
> Effective Wednesday September 6 around 6 am UTC (Tuesday September 5 around 11 pm PT) we will be changing the allowed decimal place precision for placing orders. We had a lot of feedback from clients after the previous change in precision, with most saying they would like to see the precision reduced even further in some pairs, though we are increasing the precision for a few pairs as well. Reducing price precision can help order books operate more efficiently by reducing the volume of canceled (unfilled) orders as traders continually jump in front of each other by a small fraction in price.
> 
> Below is a list of all trading pairs showing the new allowed number of decimal places for each pair. For example, 1 decimal place will be allowed for bitcoin-USD (XBT/USD), meaning that you can place an order for $4,350.1 but not $4,350.01. Trying to place an order with more decimal places than allowed will result in an error and the order will not be created. If the “%” option is used to specify order price, the result will be truncated (rounded down) to the maximum allowed decimal place. 
> 
> BCH/XBT | 5
> BCH/EUR | 1
> BCH/USD | 1
> XBT/CAD | 1
> XBT/EUR | 1
> XBT/JPY | 0
> XBT/USD | 1
> DASH/XBT | 5
> DASH/EUR | 2
> DASH/USD | 2
> DOGE/XBT | 8
> EOS/XBT | 7
> EOS/ETH | 6
> ETC/XBT | 6
> ETC/ETH | 5
> ETC/EUR | 3
> ETC/USD | 3
> ETH/XBT | 5
> ETH/CAD | 2
> ETH/EUR | 2
> ETH/JPY | 0
> ETH/USD | 2
> GNO/XBT | 5
> GNO/ETH | 4
> ICN/XBT | 7
> ICN/ETH | 6
> LTC/XBT | 6
> LTC/EUR | 2
> LTC/USD | 2
> MLN/XBT | 6
> MLN/ETH | 5
> REP/XBT | 6
> REP/ETH | 5
> REP/EUR | 3
> USDT/USD | 4
> XLM/XBT | 8
> XMR/XBT | 6
> XMR/EUR | 2
> XMR/USD | 2
> XRP/XBT | 8
> XRP/EUR | 5
> XRP/USD | 5
> ZEC/XBT | 5
> ZEC/EUR | 2
> ZEC/USD | 2
> 
> 


