### PR TITLE
[Core] Fix getFilledAmount [Gemini] [Gdax] Adapt open order

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -109,7 +109,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
 
 	if (remainingAmount != null)
 	{
-		return getOriginalAmount().min(remainingAmount);
+		return getOriginalAmount().subtract(remainingAmount);
 	}
     return null;
   }

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -1,18 +1,9 @@
 package org.knowm.xchange.gdax;
 
-import java.math.BigDecimal;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TimeZone;
-
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.Order.OrderStatus;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.Wallet;
@@ -29,16 +20,16 @@ import org.knowm.xchange.dto.trade.OpenOrders;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.gdax.dto.account.GDAXAccount;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXProduct;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXProductBook;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXProductBookEntry;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXProductStats;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXProductTicker;
-import org.knowm.xchange.gdax.dto.marketdata.GDAXTrade;
+import org.knowm.xchange.gdax.dto.marketdata.*;
 import org.knowm.xchange.gdax.dto.trade.GDAXFill;
 import org.knowm.xchange.gdax.dto.trade.GDAXOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 public class GDAXAdapters {
 
@@ -151,11 +142,11 @@ public class GDAXAdapters {
 
       Date createdAt = parseDate(order.getCreatedAt());
 
-      Order.OrderStatus orderStatus = order.getFilledSize().compareTo(BigDecimal.ZERO) == 0 ?
+      OrderStatus orderStatus = order.getFilledSize().compareTo(BigDecimal.ZERO) == 0 ?
           Order.OrderStatus.NEW : Order.OrderStatus.PARTIALLY_FILLED;
 
-      LimitOrder limitOrder = new LimitOrder(type, order.getSize(), currencyPair, order.getId(), createdAt,
-          order.getPrice(), order.getPrice(), order.getFilledSize(), orderStatus);
+      LimitOrder limitOrder = new LimitOrder(type, order.getSize(), order.getSize().subtract(order.getFilledSize()), currencyPair,
+              order.getId(), createdAt, order.getPrice(), order.getPrice(), order.getFilledSize(), orderStatus);
 
       orders.add(limitOrder);
     }

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
@@ -259,8 +259,8 @@ public final class GeminiAdapters {
         status = OrderStatus.FILLED;
       }
 
-      LimitOrder limitOrder = new LimitOrder(orderType, order.getRemainingAmount(), currencyPair, String.valueOf(order.getId()),
-              timestamp, order.getPrice(), order.getAvgExecutionPrice(), order.getExecutedAmount(), status);
+      LimitOrder limitOrder = new LimitOrder(orderType, order.getOriginalAmount(), order.getRemainingAmount(), currencyPair,
+              String.valueOf(order.getId()), timestamp, order.getPrice(), order.getAvgExecutionPrice(), order.getExecutedAmount(), status);
 
       limitOrders.add(limitOrder);
     }

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiExchange.java
@@ -1,8 +1,5 @@
 package org.knowm.xchange.gemini.v1;
 
-import java.io.IOException;
-import java.util.List;
-
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.ExchangeSpecification;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -11,13 +8,15 @@ import org.knowm.xchange.gemini.v1.service.GeminiAccountService;
 import org.knowm.xchange.gemini.v1.service.GeminiMarketDataService;
 import org.knowm.xchange.gemini.v1.service.GeminiMarketDataServiceRaw;
 import org.knowm.xchange.gemini.v1.service.GeminiTradeService;
-import org.knowm.xchange.utils.nonce.AtomicLongIncrementalTime2013NonceFactory;
-
+import org.knowm.xchange.utils.nonce.AtomicLongCurrentTimeIncrementalNonceFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.io.IOException;
+import java.util.List;
 
 public class GeminiExchange extends BaseExchange {
 
-  private SynchronizedValueFactory<Long> nonceFactory = new AtomicLongIncrementalTime2013NonceFactory();
+  private SynchronizedValueFactory<Long> nonceFactory = new AtomicLongCurrentTimeIncrementalNonceFactory();
 
   @Override
   protected void initServices() {

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
@@ -1,11 +1,6 @@
 package org.knowm.xchange.gemini.v1;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.math.BigDecimal;
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
@@ -22,7 +17,11 @@ import org.knowm.xchange.gemini.v1.dto.marketdata.GeminiLevel;
 import org.knowm.xchange.gemini.v1.dto.trade.GeminiOrderStatusResponse;
 import org.knowm.xchange.gemini.v1.dto.trade.GeminiTradeResponse;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.math.BigDecimal;
+
+import static org.junit.Assert.assertEquals;
 
 public class GeminiAdaptersTest {
 
@@ -101,7 +100,9 @@ public class GeminiAdaptersTest {
       Order.OrderType expectedOrderType = responses[i].getSide().equalsIgnoreCase("buy") ? Order.OrderType.BID : Order.OrderType.ASK;
 
       assertEquals(String.valueOf(responses[i].getId()), order.getId());
-      assertEquals(responses[i].getRemainingAmount(), order.getTradableAmount());
+      assertEquals(responses[i].getOriginalAmount(), order.getOriginalAmount());
+      assertEquals(responses[i].getRemainingAmount(), order.getRemainingAmount());
+      assertEquals(responses[i].getExecutedAmount(), order.getFilledAmount());
       assertEquals(GeminiAdapters.adaptCurrencyPair(SYMBOL), order.getCurrencyPair());
       assertEquals(expectedOrderType, order.getType());
       assertEquals(expectedTimestampMillis, order.getTimestamp().getTime());


### PR DESCRIPTION
- Fix LimitOrder getFilledAmount. 

- Update Gemini and Gdax's open order adapters to include original, remaining and filled amount. 

- Use `AtomicLongCurrentTimeIncrementalNonceFactory` instead of `AtomicLongIncrementalTime2013NonceFactory` because according to Gemini, "e recommend using a timestamp at millisecond or higher precision"
https://docs.gemini.com/rest-api/#private-api-invocation
`AtomicLongIncrementalTime2013NonceFactory` is rounding down the precision. 