### PR TITLE
Add OmiseGO (OMG) currency and related currency pairs OMG/USD, OMG/BTC and OMG/ETH

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -160,6 +160,7 @@ public class Currency implements Comparable<Currency> {
   public static final Currency NXT = createCurrency("NXT", "Nextcoin", null);
   public static final Currency NZD = createCurrency("NZD", "New Zealand Dollar", null);
   public static final Currency OMR = createCurrency("OMR", "Omani Rial", null);
+  public static final Currency OMG = createCurrency("OMG", "OmiseGO", null);
   public static final Currency PAB = createCurrency("PAB", "Panamanian Balboa", null);
   public static final Currency PEN = createCurrency("PEN", "Peruvian Nuevo Sol", null);
   public static final Currency PGK = createCurrency("PGK", "Papua New Guinean Kina", null);

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -159,8 +159,8 @@ public class Currency implements Comparable<Currency> {
   public static final Currency NVC = createCurrency("NVC", "Novacoin", null);
   public static final Currency NXT = createCurrency("NXT", "Nextcoin", null);
   public static final Currency NZD = createCurrency("NZD", "New Zealand Dollar", null);
-  public static final Currency OMR = createCurrency("OMR", "Omani Rial", null);
   public static final Currency OMG = createCurrency("OMG", "OmiseGO", null);
+  public static final Currency OMR = createCurrency("OMR", "Omani Rial", null);
   public static final Currency PAB = createCurrency("PAB", "Panamanian Balboa", null);
   public static final Currency PEN = createCurrency("PEN", "Peruvian Nuevo Sol", null);
   public static final Currency PGK = createCurrency("PGK", "Papua New Guinean Kina", null);

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/CurrencyPair.java
@@ -181,6 +181,11 @@ public class CurrencyPair implements Comparable<CurrencyPair> {
   public static final CurrencyPair IOTA_ETH = new CurrencyPair(Currency.IOT, Currency.ETH);
   //end
 
+  // OMG
+  public static final CurrencyPair OMG_USD = new CurrencyPair(Currency.OMG, Currency.USD);
+  public static final CurrencyPair OMG_BTC = new CurrencyPair(Currency.OMG, Currency.BTC);
+  public static final CurrencyPair OMG_ETH = new CurrencyPair(Currency.OMG, Currency.ETH);
+
   // not real currencies, but tradable commodities (GH/s)
   public static final CurrencyPair GHs_BTC = new CurrencyPair(Currency.GHs, Currency.BTC);
   public static final CurrencyPair GHs_NMC = new CurrencyPair(Currency.GHs, Currency.NMC);


### PR DESCRIPTION
Homepage - https://omg.omise.co/

Stats / MarketCap - https://coinmarketcap.com/assets/omisego/

Trading Exchanges - https://www.coingecko.com/en/coins/omisego/trading_exchanges

OMG pairs at Bitfinex - https://www.bitfinex.com/stats
