### PR TITLE
add httpConnTimeout setting and apply both timeouts in several exchanges

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexBaseService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexBaseService.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.bitfinex.v1.BitfinexAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -24,7 +25,18 @@ public class BitfinexBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
 
-    this.bitfinex = RestProxyFactory.createProxy(BitfinexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.bitfinex = RestProxyFactory.createProxy(BitfinexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BitfinexHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.payloadCreator = new BitfinexPayloadDigest();

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 import si.mazi.rescu.SynchronizedValueFactory;
 
@@ -44,8 +45,21 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
 
     super(exchange);
 
-    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        rescuConfig);
+    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri(),
+        rescuConfig);
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BitstampDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), exchange.getExchangeSpecification().getUserName(), apiKey);

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
@@ -11,6 +11,7 @@ import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTicker;
 import org.knowm.xchange.bitstamp.dto.marketdata.BitstampTransaction;
 import org.knowm.xchange.currency.CurrencyPair;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 /**
@@ -23,7 +24,19 @@ public class BitstampMarketDataServiceRaw extends BitstampBaseService {
   public BitstampMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.bitstampV2 = RestProxyFactory.createProxy(BitstampV2.class, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.bitstampV2 = RestProxyFactory.createProxy(BitstampV2.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
   }
 
   public BitstampTicker getBitstampTicker(CurrencyPair pair) throws IOException {

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -6,6 +6,7 @@ import org.knowm.xchange.bittrex.BittrexV2;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -25,8 +26,20 @@ public class BittrexBaseService extends BaseExchangeService implements BaseServi
 
     super(exchange);
 
-    this.bittrexAuthenticated = RestProxyFactory.createProxy(BittrexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    this.bittrexV2 = RestProxyFactory.createProxy(BittrexV2.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.bittrexAuthenticated = RestProxyFactory.createProxy(BittrexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        rescuConfig);
+    this.bittrexV2 = RestProxyFactory.createProxy(BittrexV2.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BittrexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.ccex.CCEXAuthenticated;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -26,7 +27,18 @@ public class CCEXBaseService extends BaseExchangeService implements BaseService 
 
     super(exchange);
 
-    this.cCEXAuthenticated = RestProxyFactory.createProxy(CCEXAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.cCEXAuthenticated = RestProxyFactory.createProxy(CCEXAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = CCEXDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.ccex.dto.ticker.CCEXPriceResponse;
 import org.knowm.xchange.ccex.dto.ticker.CCEXTickerResponse;
 import org.knowm.xchange.currency.CurrencyPair;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 /**
@@ -24,7 +25,19 @@ public class CCEXMarketDataServiceRaw extends CCEXBaseService {
 
   public CCEXMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.ccex = RestProxyFactory.createProxy(CCEX.class, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.ccex = RestProxyFactory.createProxy(CCEX.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
   }
 
   public CCEXGetorderbook getCCEXOrderBook(CurrencyPair pair, int depth) throws IOException {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.cexio.dto.account.GHashIOHashrate;
 import org.knowm.xchange.cexio.dto.account.GHashIOWorker;
 import org.knowm.xchange.exceptions.ExchangeException;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -29,7 +30,19 @@ public class CexIOAccountServiceRaw extends CexIOBaseService {
   public CexIOAccountServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     signatureCreator = CexIODigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
@@ -9,6 +9,7 @@ import org.knowm.xchange.cexio.dto.marketdata.CexIOTicker;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTrade;
 import org.knowm.xchange.currency.CurrencyPair;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 /**
@@ -27,7 +28,18 @@ public class CexIOMarketDataServiceRaw extends CexIOBaseService {
 
     super(exchange);
 
-    this.cexio = RestProxyFactory.createProxy(CexIO.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.cexio = RestProxyFactory.createProxy(CexIO.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
   }
 
   public CexIOTicker getCexIOTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 import org.knowm.xchange.utils.DateUtils;
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.HttpStatusIOException;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
@@ -46,7 +47,19 @@ public class CexIOTradeServiceRaw extends CexIOBaseService {
   public CexIOTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
-    cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     signatureCreator = CexIODigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
@@ -13,6 +13,7 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -33,7 +34,18 @@ public class CoinbaseBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
 
-    coinbase = RestProxyFactory.createProxy(CoinbaseAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    coinbase = RestProxyFactory.createProxy(CoinbaseAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     signatureCreator = CoinbaseDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -34,6 +34,8 @@ public class ExchangeSpecification {
 
   private int port = 80;
 
+  private int httpConnTimeout = 0; // default rescu configuration will be used if value not changed
+
   private int httpReadTimeout = 0; // default rescu configuration will be used if value not changed
 
   private String metaDataJsonFileOverride = null;
@@ -135,8 +137,31 @@ public class ExchangeSpecification {
   }
 
   /**
+   * Set the http connection timeout for the connection. If not supplied the default rescu timeout will be used. Check the exchange code to see if
+   * this option has been implemented.  (This value can also be set globally in "rescu.properties" by setting the property
+   * "rescu.http.connTimeoutMillis".)
+   *
+   * @param milliseconds the http read timeout in milliseconds
+   */
+  public void setHttpConnTimeout(int milliseconds) {
+
+    this.httpConnTimeout = milliseconds;
+  }
+
+  /**
+   * Get the http connection timeout for the connection. If the default value of zero is returned then the default rescu timeout will be applied.
+   * Check the exchange code to see if this option has been implemented.
+   *
+   * @return the http read timeout in milliseconds
+   */
+  public int getHttpConnTimeout() {
+
+    return httpConnTimeout;
+  }
+
+  /**
    * Set the http read timeout for the connection. If not supplied the default rescu timeout will be used. Check the exchange code to see if this
-   * option has been implemented.
+   * option has been implemented. (This value can also be set globally in "rescu.properties" by setting the property "rescu.http.readTimeoutMillis".)
    *
    * @param milliseconds the http read timeout in milliseconds
    */

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXBaseService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXBaseService.java
@@ -5,6 +5,7 @@ import org.knowm.xchange.gdax.GDAX;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -22,7 +23,19 @@ public class GDAXBaseService<T extends GDAX> extends BaseExchangeService impleme
   protected GDAXBaseService(Class<T> type, Exchange exchange) {
 
     super(exchange);
-    this.coinbaseEx = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.coinbaseEx = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     this.digest = GDAXDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.passphrase = (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("passphrase");

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcBaseService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcBaseService.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.hitbtc.dto.trade.HitbtcExecutionReport;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.ParamsDigest;
 import si.mazi.rescu.RestProxyFactory;
 
@@ -28,7 +29,18 @@ public class HitbtcBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    this.hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     String apiKey = exchange.getExchangeSpecification().getSecretKey();
     this.signatureCreator = apiKey != null && !apiKey.isEmpty() ? HitbtcHmacDigest.createInstance(apiKey) : null;

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
@@ -21,6 +21,17 @@ public class HitbtcBaseService extends BaseExchangeService implements BaseServic
     String secretKey = exchange.getExchangeSpecification().getSecretKey();
 
     ClientConfig config = new ClientConfig();
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      config.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      config.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
     ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
     hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
   }

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -42,6 +42,11 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
 
     ClientConfig rescuConfig = new ClientConfig(); // default rescu config
 
+    // allow HTTP connect- and read-timeout to be set per exchange
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
     int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
     if (customHttpReadTimeout > 0) {
       rescuConfig.setHttpReadTimeout(customHttpReadTimeout);

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoExchange.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoExchange.java
@@ -19,11 +19,18 @@ public class LunoExchange extends BaseExchange implements Exchange {
 
   @Override
   protected void initServices() {
+
+    // allow HTTP connect- and read-timeout to be set per exchange
     ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
     int customHttpReadTimeout = getExchangeSpecification().getHttpReadTimeout();
     if (customHttpReadTimeout > 0) {
       rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
     }
+
     final LunoAPI luno = new LunoAPIImpl(getExchangeSpecification().getApiKey(), getExchangeSpecification().getSecretKey(),
         getExchangeSpecification().getSslUri(), rescuConfig);
     this.marketDataService = new LunoMarketDataService(this, luno);

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexBaseService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexBaseService.java
@@ -44,6 +44,11 @@ public class PoloniexBaseService extends BaseExchangeService implements BaseServ
       }
     });
 
+    // allow HTTP connection timeout to be altered per exchange
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
     // allow HTTP read timeout to be altered per exchange
     int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
     if (customHttpReadTimeout > 0) {

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
@@ -6,6 +6,7 @@ import org.knowm.xchange.ripple.RipplePublic;
 import org.knowm.xchange.service.BaseExchangeService;
 import org.knowm.xchange.service.BaseService;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 public class RippleBaseService extends BaseExchangeService implements BaseService {
@@ -16,6 +17,18 @@ public class RippleBaseService extends BaseExchangeService implements BaseServic
   public RippleBaseService(final Exchange exchange) {
     super(exchange);
     final String uri;
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
     if (exchange.getExchangeSpecification().getSslUri() != null && exchange.getExchangeSpecification().getSslUri().length() > 0) {
       // by default use an SSL encrypted connection if it is configured 
       uri = exchange.getExchangeSpecification().getSslUri();
@@ -25,7 +38,7 @@ public class RippleBaseService extends BaseExchangeService implements BaseServic
     } else {
       throw new IllegalStateException("either SSL or plain text URI must be specified");
     }
-    ripplePublic = RestProxyFactory.createProxy(RipplePublic.class, uri);
-    rippleAuthenticated = RestProxyFactory.createProxy(RippleAuthenticated.class, uri);
+    ripplePublic = RestProxyFactory.createProxy(RipplePublic.class, uri, rescuConfig);
+    rippleAuthenticated = RestProxyFactory.createProxy(RippleAuthenticated.class, uri, rescuConfig);
   }
 }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.therock.dto.account.TheRockWithdrawal;
 import org.knowm.xchange.therock.dto.account.TheRockWithdrawalResponse;
 import org.knowm.xchange.therock.dto.trade.TheRockTransactions;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockAccountServiceRaw extends TheRockBaseService {
@@ -28,7 +29,19 @@ public class TheRockAccountServiceRaw extends TheRockBaseService {
   protected TheRockAccountServiceRaw(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = spec.getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = spec.getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri(), rescuConfig);
     apiKey = spec.getApiKey();
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.therock.dto.marketdata.TheRockOrderBook;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTicker;
 import org.knowm.xchange.therock.dto.marketdata.TheRockTrades;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockMarketDataServiceRaw extends TheRockBaseService {
@@ -18,7 +19,19 @@ public class TheRockMarketDataServiceRaw extends TheRockBaseService {
 
   public TheRockMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.theRock = RestProxyFactory.createProxy(TheRock.class, exchange.getExchangeSpecification().getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.theRock = RestProxyFactory.createProxy(TheRock.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);
   }
 
   public TheRockTicker getTheRockTicker(TheRock.Pair currencyPair) throws TheRockException, IOException {

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
@@ -16,6 +16,7 @@ import org.knowm.xchange.therock.dto.trade.TheRockOrders;
 import org.knowm.xchange.therock.dto.trade.TheRockTransaction;
 import org.knowm.xchange.therock.dto.trade.TheRockUserTrades;
 
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 public class TheRockTradeServiceRaw extends TheRockBaseService {
@@ -26,7 +27,19 @@ public class TheRockTradeServiceRaw extends TheRockBaseService {
   public TheRockTradeServiceRaw(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri());
+
+    // allow HTTP connect- and read-timeout to be set per exchange
+    ClientConfig rescuConfig = new ClientConfig(); // default rescu config
+    int customHttpConnTimeout = spec.getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = spec.getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+
+    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri(), rescuConfig);
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }
 


### PR DESCRIPTION
## Overview:
This pull request adds the support to set HTTP connection timeout and the read timeout separately per exchange (via ExchangeSpecification). As we experience different behavior of different exchanges during times of high traffic, it might be useful to set different values at runtime (per exchange).


## Details:
The first commit adds `setHttpConnTimeout()` and `getHttpConnTimeout()` to `ExchangeSpecification` (similar to methods for httpReadTimeout which were already present.

The second commit adds the application of **both** timeouts (`httpConnTimeout` and `httpReadTimeout`) to several exchange subprojects:

In detail:
- Bitfinex
- Bitstamp
- Bittrex
- C-Cex
- CEX.io
- Coinbase
- GDAX
- HitBTC
- Kraken
- Luno
- Poloniex
- Ripple
- TheRock

I searched for all occurrences of `RestProxyFactory.createProxy(..)` in these projects and made sure, that both timeouts will be applied if they are set in `ExchangeSpecification`.