### PR TITLE
Bitfinex Lending history implemented

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAuthenticated.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAuthenticated.java
@@ -28,6 +28,7 @@ import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexFundingTradeResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOfferRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrderMultiResponse;
@@ -37,6 +38,7 @@ import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastFundingTradesRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastTradesRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexReplaceOrderRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
@@ -127,7 +129,12 @@ public interface BitfinexAuthenticated extends Bitfinex {
   @POST
   @Path("mytrades")
   BitfinexTradeResponse[] pastTrades(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
-      @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexPastTradesRequest pastTradesRequest) throws IOException, BitfinexException;
+      @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexPastTradesRequest pastTradesRequest) throws IOException, BitfinexException;  
+
+  @POST
+  @Path("mytrades_funding")
+  BitfinexFundingTradeResponse[] pastFundingTrades(@HeaderParam("X-BFX-APIKEY") String apiKey, @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload,
+      @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature, BitfinexPastFundingTradesRequest bitfinexPastFundingTradesRequest) throws IOException, BitfinexException;  
 
   @POST
   @Path("credits")
@@ -155,5 +162,4 @@ public interface BitfinexAuthenticated extends Bitfinex {
   BitfinexDepositWithdrawalHistoryResponse[] depositWithdrawalHistory(@HeaderParam("X-BFX-APIKEY") String apiKey,
       @HeaderParam("X-BFX-PAYLOAD") ParamsDigest payload, @HeaderParam("X-BFX-SIGNATURE") ParamsDigest signature,
       BitfinexDepositWithdrawalHistoryRequest request) throws IOException, BitfinexException;
-
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexFundingTradeResponse.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexFundingTradeResponse.java
@@ -1,0 +1,79 @@
+package org.knowm.xchange.bitfinex.v1.dto.trade;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitfinexFundingTradeResponse {
+
+  private final BigDecimal rate;
+  private final BigDecimal period;
+  private final BigDecimal amount;
+  private final BigDecimal timestamp;
+  private final String type;
+  private final String tradeId;
+  private final String offerId;
+
+  /**
+   * Constructor
+   *
+   * @param rate
+   * @param amount
+   * @param timestamp
+   * @param period
+   * @param type
+   * @param tradeId
+   * @param offerId
+   */
+  public BitfinexFundingTradeResponse(
+		  @JsonProperty("rate") final BigDecimal rate, 
+  		  @JsonProperty("period") final BigDecimal period, 
+  		  @JsonProperty("amount") final BigDecimal amount,
+	      @JsonProperty("timestamp") final BigDecimal timestamp, 
+	      @JsonProperty("type") final String type,
+	      @JsonProperty("tid") final String tradeId, 
+	      @JsonProperty("offer_id") final String offerId) {
+
+    this.rate = rate;
+    this.amount = amount;
+    this.period = period;
+    this.timestamp = timestamp;
+    this.type = type;
+    this.tradeId = tradeId;
+    this.offerId = offerId;
+  }
+
+	public BigDecimal getRate() {
+		return rate;
+	}
+	
+	public BigDecimal getPeriod() {
+		return period;
+	}
+	
+	public BigDecimal getAmount() {
+		return amount;
+	}
+	
+	public BigDecimal getTimestamp() {
+		return timestamp;
+	}
+	
+	public String getType() {
+		return type;
+	}
+	
+	public String getTradeId() {
+		return tradeId;
+	}
+	
+	public String getOfferId() {
+		return offerId;
+	}
+	
+	@Override
+	public String toString() {
+		return "BitfinexFundingTradeResponse [rate=" + rate + ", period=" + period + ", amount=" + amount + ", timestamp="
+				+ timestamp + ", type=" + type + ", tradeId=" + tradeId + ", offerId=" + offerId + "]";
+	}
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexPastFundingTradesRequest.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/trade/BitfinexPastFundingTradesRequest.java
@@ -1,0 +1,38 @@
+package org.knowm.xchange.bitfinex.v1.dto.trade;
+
+import java.util.Date;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BitfinexPastFundingTradesRequest {
+
+  @JsonProperty("request")
+  protected String request;
+
+  @JsonProperty("nonce")
+  protected String nonce;
+
+  @JsonProperty("symbol")
+  protected String symbol;
+
+  /**
+   * Trades made after this timestamp won’t be returned.
+   */
+  @JsonProperty("until")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  protected Date until;
+
+  @JsonProperty("limit_trades")
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  protected Integer limitTrades;
+
+  public BitfinexPastFundingTradesRequest(String nonce, String symbol, Date until, Integer limitTrades) {
+
+    this.request = "/v1/mytrades_funding";
+    this.nonce = nonce;
+    this.symbol = symbol;
+    this.until = until;
+    this.limitTrades = limitTrades;
+  }
+}

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeServiceRaw.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.bitfinex.v1.service;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.Date;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
@@ -17,6 +18,7 @@ import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOfferRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderMultiRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCancelOrderRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexCreditResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexFundingTradeResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexLimitOrder;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOfferRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexNewOrder;
@@ -29,6 +31,7 @@ import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOfferStatusResponse;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderFlags;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexOrderStatusResponse;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastFundingTradesRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexPastTradesRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexReplaceOrderRequest;
 import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexTradeResponse;
@@ -291,6 +294,17 @@ public class BitfinexTradeServiceRaw extends BitfinexBaseService {
       throw new ExchangeException(e);
     }
   }
+  
+  public BitfinexFundingTradeResponse[] getBitfinexFundingHistory(String symbol, Date until, int limit_trades) throws IOException {
+
+	    try {
+	      BitfinexFundingTradeResponse[] fundingTrades = bitfinex.pastFundingTrades(apiKey, payloadCreator, signatureCreator,
+	          new BitfinexPastFundingTradesRequest(String.valueOf(exchange.getNonceFactory().createValue()), symbol, until, limit_trades));
+	      return fundingTrades;
+	    } catch (BitfinexException e) {
+	      throw new ExchangeException(e);
+	    }
+	  }
 
   public BitfinexTradeResponse[] getBitfinexTradeHistory(String symbol, long startTime, Long endTime, int limit) throws IOException {
 

--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/trade/BitfinexTradeDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/bitfinex/trade/BitfinexTradeDemo.java
@@ -1,14 +1,13 @@
 package org.knowm.xchange.examples.bitfinex.trade;
 
 import java.io.IOException;
-import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 
 import org.knowm.xchange.Exchange;
-import org.knowm.xchange.bitfinex.v1.BitfinexOrderType;
+import org.knowm.xchange.bitfinex.v1.dto.trade.BitfinexFundingTradeResponse;
 import org.knowm.xchange.bitfinex.v1.service.BitfinexTradeServiceRaw;
-import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.dto.Order.OrderType;
-import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.examples.bitfinex.BitfinexDemoUtils;
 
 public class BitfinexTradeDemo {
@@ -22,9 +21,16 @@ public class BitfinexTradeDemo {
 
   private static void raw(Exchange bfx) throws IOException {
 
+	  /*
     BitfinexTradeServiceRaw tradeService = (BitfinexTradeServiceRaw) bfx.getTradeService();
     LimitOrder limitOrder = new LimitOrder.Builder(OrderType.BID, CurrencyPair.BTC_USD).limitPrice(new BigDecimal("481.69"))
         .originalAmount(new BigDecimal("0.001")).build();
     tradeService.placeBitfinexLimitOrder(limitOrder, BitfinexOrderType.LIMIT);
+    */
+	  
+	  BitfinexTradeServiceRaw tradeService = (BitfinexTradeServiceRaw) bfx.getTradeService();
+	  
+	  Date tenDaysAgo = Date.from(LocalDate.now().minusDays(10).atStartOfDay(ZoneId.systemDefault()).toInstant());	  
+	  BitfinexFundingTradeResponse[] fundingTradeResponses = tradeService.getBitfinexFundingHistory("USD", tenDaysAgo, 2000);
   }
 }


### PR DESCRIPTION
I implemented to fetch the lending history for Bitfinex. 
I also tested it (and left a test in the bitfinex-examples) and it works.

The only thing I'm not sure: The Bitfinex docs state that there's a RateLimit of 45reqs/min. Does that have to be considered somewhere? 
And, just out of curiousity: Is the Ratelimit per Api Key or per Server?

Please, since it's my first commit to this project, doublecheck it. If approved, please merge it into develop :)

Kind regards,
David