### PR TITLE
Kraken - Get funding history for all currencies

### DIFF
--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenAccountService.java
@@ -65,7 +65,7 @@ public class KrakenAccountService extends KrakenAccountServiceRaw implements Acc
 
   @Override
   public TradeHistoryParams createFundingHistoryParams() {
-    return new KrakenFundingHistoryParams(null, null, null, new Currency[]{Currency.BTC, Currency.USD});
+    return new KrakenFundingHistoryParams(null, null, null, (Currency[]) null);
   }
 
   @Override


### PR DESCRIPTION
On Kraken exchange, getFundingHistory(...) only returns BTC or USD
funding events with the default TradeHistoryParams. Modify default
TradeHistoryParams instantiation so that the funding events for all
currencies are returned. Fixes #1829.