### PR TITLE
add getClientConfig to BaseExchangeService and make use of it

### DIFF
--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXAccountServiceRaw.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXAccountServiceRaw.java
@@ -44,7 +44,7 @@ public class ANXAccountServiceRaw extends ANXBaseService {
     super(exchange);
 
     Assert.notNull(exchange.getExchangeSpecification().getSslUri(), "Exchange specification URI cannot be null");
-    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = ANXV2Digest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXMarketDataServiceRaw.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXMarketDataServiceRaw.java
@@ -36,7 +36,7 @@ public class ANXMarketDataServiceRaw extends ANXBaseService {
     super(exchange);
 
     Assert.notNull(exchange.getExchangeSpecification().getSslUri(), "Exchange specification URI cannot be null");
-    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public ANXTicker getANXTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXTradeServiceRaw.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXTradeServiceRaw.java
@@ -35,7 +35,7 @@ public class ANXTradeServiceRaw extends ANXBaseService {
     super(exchange);
 
     Assert.notNull(exchange.getExchangeSpecification().getSslUri(), "Exchange specification URI cannot be null");
-    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.anxV2 = RestProxyFactory.createProxy(ANXV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = ANXV2Digest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceBaseService.java
@@ -21,7 +21,7 @@ public class BinanceBaseService extends BaseExchangeService implements BaseServi
      */
     protected BinanceBaseService(Exchange exchange) {
         super(exchange);
-        this.binance = RestProxyFactory.createProxy(BinanceAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+        this.binance = RestProxyFactory.createProxy(BinanceAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
         this.apiKey = exchange.getExchangeSpecification().getApiKey();
         this.signatureCreator = BinanceHmacDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayBaseService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayBaseService.java
@@ -26,8 +26,8 @@ public class BitbayBaseService extends BaseExchangeService implements BaseServic
   BitbayBaseService(Exchange exchange) {
     super(exchange);
 
-    bitbay = RestProxyFactory.createProxy(Bitbay.class, exchange.getExchangeSpecification().getSslUri());
-    bitbayAuthenticated = RestProxyFactory.createProxy(BitbayAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    bitbay = RestProxyFactory.createProxy(Bitbay.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+    bitbayAuthenticated = RestProxyFactory.createProxy(BitbayAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     sign = BitbayDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }

--- a/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/service/BitcoinAverageMarketDataServiceRaw.java
+++ b/xchange-bitcoinaverage/src/main/java/org/knowm/xchange/bitcoinaverage/service/BitcoinAverageMarketDataServiceRaw.java
@@ -29,7 +29,7 @@ public class BitcoinAverageMarketDataServiceRaw extends BitcoinAverageBaseServic
   public BitcoinAverageMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.bitcoinAverage = RestProxyFactory.createProxy(BitcoinAverage.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitcoinAverage = RestProxyFactory.createProxy(BitcoinAverage.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public BitcoinAverageTicker getBitcoinAverageTicker(String tradableIdentifier, String currency) throws IOException {

--- a/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/service/BitcoinChartsMarketDataService.java
+++ b/xchange-bitcoincharts/src/main/java/org/knowm/xchange/bitcoincharts/service/BitcoinChartsMarketDataService.java
@@ -30,7 +30,7 @@ public class BitcoinChartsMarketDataService extends BitcoinChartsBaseService imp
   public BitcoinChartsMarketDataService(Exchange exchange) {
 
     super(exchange);
-    this.bitcoinCharts = RestProxyFactory.createProxy(BitcoinCharts.class, exchange.getExchangeSpecification().getPlainTextUri());
+    this.bitcoinCharts = RestProxyFactory.createProxy(BitcoinCharts.class, exchange.getExchangeSpecification().getPlainTextUri(), getClientConfig());
   }
 
   @Override

--- a/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/service/BitcoinCoreAccountServiceRaw.java
+++ b/xchange-bitcoincore/src/main/java/org/knowm/xchange/bitcoincore/service/BitcoinCoreAccountServiceRaw.java
@@ -28,7 +28,7 @@ public class BitcoinCoreAccountServiceRaw extends BaseExchangeService {
 
     ExchangeSpecification specification = exchange.getExchangeSpecification();
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     String user = specification.getUserName();
     ClientConfigUtil.addBasicAuthCredentials(config, user == null ? "" : user, specification.getPassword());
 

--- a/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/service/BitcoindeBaseService.java
+++ b/xchange-bitcoinde/src/main/java/org/knowm/xchange/bitcoinde/service/BitcoindeBaseService.java
@@ -19,7 +19,7 @@ public class BitcoindeBaseService extends BaseExchangeService implements BaseSer
   protected BitcoindeBaseService(Exchange exchange) {
 
     super(exchange);
-    this.bitcoinde = RestProxyFactory.createProxy(Bitcoinde.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitcoinde = RestProxyFactory.createProxy(Bitcoinde.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BitcoindeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);
   }

--- a/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataServiceRaw.java
+++ b/xchange-bitcoinium/src/main/java/org/knowm/xchange/bitcoinium/service/BitcoiniumMarketDataServiceRaw.java
@@ -32,7 +32,7 @@ public class BitcoiniumMarketDataServiceRaw extends BitcoiniumBaseService {
   public BitcoiniumMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.bitcoinium = RestProxyFactory.createProxy(Bitcoinium.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitcoinium = RestProxyFactory.createProxy(Bitcoinium.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   /**

--- a/xchange-bitcurex/src/main/java/org/knowm/xchange/bitcurex/service/BitcurexBaseService.java
+++ b/xchange-bitcurex/src/main/java/org/knowm/xchange/bitcurex/service/BitcurexBaseService.java
@@ -23,10 +23,11 @@ public class BitcurexBaseService extends BaseExchangeService implements BaseServ
   public BitcurexBaseService(Exchange exchange) {
 
     super(exchange);
-    this.bitcurex = RestProxyFactory.createProxy(Bitcurex.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitcurex = RestProxyFactory.createProxy(Bitcurex.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = BitcurexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getApiKey());
-    this.bitcurexAuthenticated = RestProxyFactory.createProxy(BitcurexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitcurexAuthenticated = RestProxyFactory.createProxy(BitcurexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
 
   }
 }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexBaseService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexBaseService.java
@@ -24,7 +24,7 @@ public class BitfinexBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
 
-    this.bitfinex = RestProxyFactory.createProxy(BitfinexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitfinex = RestProxyFactory.createProxy(BitfinexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BitfinexHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.payloadCreator = new BitfinexPayloadDigest();

--- a/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/BitMarketBaseService.java
+++ b/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/BitMarketBaseService.java
@@ -28,8 +28,9 @@ public class BitMarketBaseService extends BaseExchangeService implements BaseSer
   protected BitMarketBaseService(Exchange exchange) {
     super(exchange);
 
-    bitMarket = RestProxyFactory.createProxy(BitMarket.class, exchange.getExchangeSpecification().getSslUri());
-    bitMarketAuthenticated = RestProxyFactory.createProxy(BitMarketAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    bitMarket = RestProxyFactory.createProxy(BitMarket.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
+    bitMarketAuthenticated = RestProxyFactory.createProxy(BitMarketAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     sign = BitMarketDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     apiKey = exchange.getExchangeSpecification().getApiKey();
   }

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoAccountServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoAccountServiceRaw.java
@@ -20,7 +20,8 @@ public class BitsoAccountServiceRaw extends BitsoBaseService {
   protected BitsoAccountServiceRaw(Exchange exchange) {
     super(exchange);
 
-    this.bitsoAuthenticated = RestProxyFactory.createProxy(BitsoAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitsoAuthenticated = RestProxyFactory.createProxy(BitsoAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = BitsoDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoMarketDataServiceRaw.java
@@ -20,7 +20,7 @@ public class BitsoMarketDataServiceRaw extends BitsoBaseService {
 
   public BitsoMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.bitso = RestProxyFactory.createProxy(Bitso.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitso = RestProxyFactory.createProxy(Bitso.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public BitsoOrderBook getBitsoOrderBook() throws IOException {

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeServiceRaw.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeServiceRaw.java
@@ -24,7 +24,8 @@ public class BitsoTradeServiceRaw extends BitsoBaseService {
   public BitsoTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.bitsoAuthenticated = RestProxyFactory.createProxy(BitsoAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitsoAuthenticated = RestProxyFactory.createProxy(BitsoAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = BitsoDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampAccountServiceRaw.java
@@ -44,8 +44,10 @@ public class BitstampAccountServiceRaw extends BitstampBaseService {
 
     super(exchange);
 
-    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
+    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
 
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BitstampDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), exchange.getExchangeSpecification().getUserName(), apiKey);

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampMarketDataServiceRaw.java
@@ -23,7 +23,7 @@ public class BitstampMarketDataServiceRaw extends BitstampBaseService {
   public BitstampMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.bitstampV2 = RestProxyFactory.createProxy(BitstampV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitstampV2 = RestProxyFactory.createProxy(BitstampV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public BitstampTicker getBitstampTicker(CurrencyPair pair) throws IOException {

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeServiceRaw.java
@@ -28,8 +28,10 @@ public class BitstampTradeServiceRaw extends BitstampBaseService {
 
   public BitstampTradeServiceRaw(Exchange exchange) {
     super(exchange);
-    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.bitstampAuthenticated = RestProxyFactory.createProxy(BitstampAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
+    this.bitstampAuthenticatedV2 = RestProxyFactory.createProxy(BitstampAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.nonceFactory = exchange.getNonceFactory();
     this.signatureCreator = BitstampDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexBaseService.java
@@ -25,8 +25,9 @@ public class BittrexBaseService extends BaseExchangeService implements BaseServi
 
     super(exchange);
 
-    this.bittrexAuthenticated = RestProxyFactory.createProxy(BittrexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
-    this.bittrexV2 = RestProxyFactory.createProxy(BittrexV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.bittrexAuthenticated = RestProxyFactory.createProxy(BittrexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
+    this.bittrexV2 = RestProxyFactory.createProxy(BittrexV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BittrexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeBaseService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeBaseService.java
@@ -23,7 +23,7 @@ public class BleutradeBaseService extends BaseExchangeService implements BaseSer
 
     super(exchange);
 
-    this.bleutrade = RestProxyFactory.createProxy(BleutradeAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bleutrade = RestProxyFactory.createProxy(BleutradeAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BleutradeDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-btc38/src/main/java/org/knowm/xchange/btc38/service/Btc38BaseService.java
+++ b/xchange-btc38/src/main/java/org/knowm/xchange/btc38/service/Btc38BaseService.java
@@ -23,7 +23,7 @@ public class Btc38BaseService<T extends Btc38> extends BaseExchangeService imple
 
     super(exchange);
 
-    this.btc38 = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri());
+    this.btc38 = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
 }

--- a/xchange-btcc/src/main/java/org/knowm/xchange/btcc/service/BTCCBaseService.java
+++ b/xchange-btcc/src/main/java/org/knowm/xchange/btcc/service/BTCCBaseService.java
@@ -14,6 +14,7 @@ public class BTCCBaseService<T extends BTCC> extends BaseExchangeService impleme
 
   protected BTCCBaseService(Exchange exchange, Class<T> type) {
     super(exchange);
-    this.btcc = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getExchangeSpecificParametersItem(BTCCExchange.DATA_API_URI_KEY).toString());
+    this.btcc = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getExchangeSpecificParametersItem(BTCCExchange.DATA_API_URI_KEY).toString(),
+        getClientConfig());
   }
 }

--- a/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/rest/BTCChinaBaseService.java
+++ b/xchange-btcchina/src/main/java/org/knowm/xchange/btcchina/service/rest/BTCChinaBaseService.java
@@ -32,7 +32,7 @@ public class BTCChinaBaseService extends BaseExchangeService implements BaseServ
 
     Assert.notNull(exchange.getExchangeSpecification().getSslUri(), "Exchange specification URI cannot be null");
 
-    this.btcChina = RestProxyFactory.createProxy(BTCChina.class, exchange.getExchangeSpecification().getSslUri());
+    this.btcChina = RestProxyFactory.createProxy(BTCChina.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = BTCChinaDigest.createInstance(exchange.getExchangeSpecification().getApiKey(),
         exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/BTCEBaseService.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/service/BTCEBaseService.java
@@ -29,7 +29,7 @@ public class BTCEBaseService extends BaseExchangeService implements BaseService 
 
     super(exchange);
 
-    this.btce = RestProxyFactory.createProxy(BTCEAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.btce = RestProxyFactory.createProxy(BTCEAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BTCEHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceRaw.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsAccountServiceRaw.java
@@ -27,7 +27,7 @@ public class BTCMarketsAccountServiceRaw extends BTCMarketsBaseService {
   protected BTCMarketsAccountServiceRaw(Exchange exchange) {
     super(exchange);
     this.nonceFactory = exchange.getNonceFactory();
-    this.btcm = RestProxyFactory.createProxy(BTCMarketsAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.btcm = RestProxyFactory.createProxy(BTCMarketsAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signer = new BTCMarketsDigest(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceRaw.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsMarketDataServiceRaw.java
@@ -16,7 +16,7 @@ public class BTCMarketsMarketDataServiceRaw extends BTCMarketsBaseService {
 
   public BTCMarketsMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.btcmarkets = RestProxyFactory.createProxy(BTCMarkets.class, exchange.getExchangeSpecification().getSslUri());
+    this.btcmarkets = RestProxyFactory.createProxy(BTCMarkets.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public BTCMarketsTicker getBTCMarketsTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceRaw.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeServiceRaw.java
@@ -28,7 +28,7 @@ public class BTCMarketsTradeServiceRaw extends BTCMarketsBaseService {
   public BTCMarketsTradeServiceRaw(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.btcm = RestProxyFactory.createProxy(BTCMarketsAuthenticated.class, spec.getSslUri());
+    this.btcm = RestProxyFactory.createProxy(BTCMarketsAuthenticated.class, spec.getSslUri(), getClientConfig());
     this.signer = new BTCMarketsDigest(spec.getSecretKey());
     this.nonceFactory = exchange.getNonceFactory();
   }

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeBaseService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeBaseService.java
@@ -25,7 +25,7 @@ public class BTCTradeBaseService extends BaseExchangeService implements BaseServ
 
     ExchangeSpecification exchangeSpecification = exchange.getExchangeSpecification();
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     // btctrade is using an ssl certificate for 33option.com
     config.setHostnameVerifier(CertHelper.createIncorrectHostnameVerifier(exchangeSpecification.getHost(),
         "CN=www.33option.com,OU=IT,O=OPTIONFORTUNE TRADE LIMITED,L=KOWLOON,ST=HONGKONG,C=HK"));

--- a/xchange-bter/src/main/java/org/knowm/xchange/bter/service/BTERBaseService.java
+++ b/xchange-bter/src/main/java/org/knowm/xchange/bter/service/BTERBaseService.java
@@ -25,7 +25,7 @@ public class BTERBaseService extends BaseExchangeService implements BaseService 
 
     super(exchange);
 
-    this.bter = RestProxyFactory.createProxy(BTERAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.bter = RestProxyFactory.createProxy(BTERAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = BTERHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXBaseService.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXBaseService.java
@@ -25,7 +25,7 @@ public class CampBXBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     // campbx server raises "internal error" if connected via these protocol versions
     config.setSslSocketFactory(CertHelper.createRestrictedSSLSocketFactory("TLSv1", "TLSv1.1"));
 

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXBaseService.java
@@ -26,7 +26,8 @@ public class CCEXBaseService extends BaseExchangeService implements BaseService 
 
     super(exchange);
 
-    this.cCEXAuthenticated = RestProxyFactory.createProxy(CCEXAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.cCEXAuthenticated = RestProxyFactory.createProxy(CCEXAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = CCEXDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXMarketDataServiceRaw.java
@@ -24,7 +24,7 @@ public class CCEXMarketDataServiceRaw extends CCEXBaseService {
 
   public CCEXMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.ccex = RestProxyFactory.createProxy(CCEX.class, exchange.getExchangeSpecification().getSslUri());
+    this.ccex = RestProxyFactory.createProxy(CCEX.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public CCEXGetorderbook getCCEXOrderBook(CurrencyPair pair, int depth) throws IOException {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
@@ -29,7 +29,8 @@ public class CexIOAccountServiceRaw extends CexIOBaseService {
   public CexIOAccountServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     signatureCreator = CexIODigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
@@ -27,7 +27,7 @@ public class CexIOMarketDataServiceRaw extends CexIOBaseService {
 
     super(exchange);
 
-    this.cexio = RestProxyFactory.createProxy(CexIO.class, exchange.getExchangeSpecification().getSslUri());
+    this.cexio = RestProxyFactory.createProxy(CexIO.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public CexIOTicker getCexIOTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeServiceRaw.java
@@ -46,7 +46,7 @@ public class CexIOTradeServiceRaw extends CexIOBaseService {
   public CexIOTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
-    cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    cexIOAuthenticated = RestProxyFactory.createProxy(CexIOAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     signatureCreator = CexIODigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-chbtc/src/main/java/org/knowm/xchange/chbtc/service/ChbtcMarketDataServiceRaw.java
+++ b/xchange-chbtc/src/main/java/org/knowm/xchange/chbtc/service/ChbtcMarketDataServiceRaw.java
@@ -21,7 +21,7 @@ public class ChbtcMarketDataServiceRaw extends BaseExchangeService implements Ba
 
   public ChbtcMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.chbtc = RestProxyFactory.createProxy(Chbtc.class, exchange.getExchangeSpecification().getSslUri());
+    this.chbtc = RestProxyFactory.createProxy(Chbtc.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public ChbtcOrderBook getChbtcOrderBook(CurrencyPair pair) throws IOException {

--- a/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
+++ b/xchange-coinbase/src/main/java/org/knowm/xchange/coinbase/service/CoinbaseBaseService.java
@@ -33,7 +33,7 @@ public class CoinbaseBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
 
-    coinbase = RestProxyFactory.createProxy(CoinbaseAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    coinbase = RestProxyFactory.createProxy(CoinbaseAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     signatureCreator = CoinbaseDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorAuthenticatedService.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorAuthenticatedService.java
@@ -26,7 +26,7 @@ public class CoinfloorAuthenticatedService extends CoinfloorService {
       return;
     }
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     ClientConfigUtil.addBasicAuthCredentials(config, specification.getUserName(), specification.getPassword());
 
     coinfloor = RestProxyFactory.createProxy(CoinfloorAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataServiceRaw.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorMarketDataServiceRaw.java
@@ -20,7 +20,7 @@ public class CoinfloorMarketDataServiceRaw extends BaseExchangeService {
   protected CoinfloorMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
 
-    coinfloor = RestProxyFactory.createProxy(CoinfloorPublic.class, exchange.getExchangeSpecification().getSslUri());
+    coinfloor = RestProxyFactory.createProxy(CoinfloorPublic.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public CoinfloorTicker getCoinfloorTicker(CurrencyPair pair) throws IOException {

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
@@ -24,7 +24,7 @@ class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements B
   public CoinMarketCapMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.coinmarketcap = RestProxyFactory.createProxy(CoinMarketCap.class, exchange.getExchangeSpecification().getSslUri());
+    this.coinmarketcap = RestProxyFactory.createProxy(CoinMarketCap.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public CoinMarketCapTicker getCoinMarketCapTicker(CurrencyPair pair) throws IOException {

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateAccountServiceRaw.java
@@ -45,7 +45,8 @@ public class CoinmateAccountServiceRaw extends CoinmateBaseService {
   public CoinmateAccountServiceRaw(Exchange exchange) {
     super(exchange);
 
-    this.coinmateAuthenticated = RestProxyFactory.createProxy(CoinmateAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.coinmateAuthenticated = RestProxyFactory.createProxy(CoinmateAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = CoinmateDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMarketDataServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateMarketDataServiceRaw.java
@@ -42,7 +42,7 @@ public class CoinmateMarketDataServiceRaw extends CoinmateBaseService {
 
   public CoinmateMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.coinmate = RestProxyFactory.createProxy(Coinmate.class, exchange.getExchangeSpecification().getSslUri());
+    this.coinmate = RestProxyFactory.createProxy(Coinmate.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public CoinmateTicker getCoinmateTicker(String currencyPair) throws IOException {

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeServiceRaw.java
@@ -47,7 +47,8 @@ public class CoinmateTradeServiceRaw extends CoinmateBaseService {
   public CoinmateTradeServiceRaw(Exchange exchange) {
     super(exchange);
 
-    this.coinmateAuthenticated = RestProxyFactory.createProxy(CoinmateAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.coinmateAuthenticated = RestProxyFactory.createProxy(CoinmateAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = CoinmateDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/ExchangeSpecification.java
@@ -34,6 +34,8 @@ public class ExchangeSpecification {
 
   private int port = 80;
 
+  private int httpConnTimeout = 0; // default rescu configuration will be used if value not changed
+
   private int httpReadTimeout = 0; // default rescu configuration will be used if value not changed
 
   private String metaDataJsonFileOverride = null;
@@ -135,8 +137,31 @@ public class ExchangeSpecification {
   }
 
   /**
+   * Set the http connection timeout for the connection. If not supplied the default rescu timeout will be used. Check the exchange code to see if
+   * this option has been implemented.  (This value can also be set globally in "rescu.properties" by setting the property
+   * "rescu.http.connTimeoutMillis".)
+   *
+   * @param milliseconds the http read timeout in milliseconds
+   */
+  public void setHttpConnTimeout(int milliseconds) {
+
+    this.httpConnTimeout = milliseconds;
+  }
+
+  /**
+   * Get the http connection timeout for the connection. If the default value of zero is returned then the default rescu timeout will be applied.
+   * Check the exchange code to see if this option has been implemented.
+   *
+   * @return the http read timeout in milliseconds
+   */
+  public int getHttpConnTimeout() {
+
+    return httpConnTimeout;
+  }
+
+  /**
    * Set the http read timeout for the connection. If not supplied the default rescu timeout will be used. Check the exchange code to see if this
-   * option has been implemented.
+   * option has been implemented. (This value can also be set globally in "rescu.properties" by setting the property "rescu.http.readTimeoutMillis".)
    *
    * @param milliseconds the http read timeout in milliseconds
    */

--- a/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/BaseExchangeService.java
@@ -9,6 +9,8 @@ import org.knowm.xchange.dto.meta.ExchangeMetaData;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
 
+import si.mazi.rescu.ClientConfig;
+
 /**
  * Top of the hierarchy abstract class for an "exchange service"
  */
@@ -41,6 +43,27 @@ public abstract class BaseExchangeService {
   public void verifyOrder(MarketOrder marketOrder) {
 
     verifyOrder(marketOrder, exchange.getExchangeMetaData());
+  }
+
+  /**
+   * Get a ClientConfig object which contains exchange-specific timeout values (<i>httpConnTimeout</i> and <i>httpReadTimeout</i>) if they were present in
+   * the ExchangeSpecification of this instance. Subclasses are encouraged to use this config object when creating a RestCU proxy.
+   *
+   * @return a rescu client config object
+   */
+  public ClientConfig getClientConfig() {
+    ClientConfig rescuConfig = new ClientConfig(); // create default rescu config
+
+    // set per exchange connection- and read-timeout (if they have been set in the ExchangeSpecification)
+    int customHttpConnTimeout = exchange.getExchangeSpecification().getHttpConnTimeout();
+    if (customHttpConnTimeout > 0) {
+      rescuConfig.setHttpConnTimeout(customHttpConnTimeout);
+    }
+    int customHttpReadTimeout = exchange.getExchangeSpecification().getHttpReadTimeout();
+    if (customHttpReadTimeout > 0) {
+      rescuConfig.setHttpReadTimeout(customHttpReadTimeout);
+    }
+    return rescuConfig;
   }
 
   final protected void verifyOrder(Order order, ExchangeMetaData exchangeMetaData) {

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesBaseService.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesBaseService.java
@@ -26,7 +26,8 @@ public class CryptoFacilitiesBaseService extends BaseExchangeService implements 
 
     super(exchange);
 
-    cryptoFacilities = RestProxyFactory.createProxy(CryptoFacilitiesAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    cryptoFacilities = RestProxyFactory.createProxy(CryptoFacilitiesAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     signatureCreator = CryptoFacilitiesDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit/v2/service/CryptonitBaseService.java
+++ b/xchange-cryptonit/src/main/java/org/knowm/xchange/cryptonit/v2/service/CryptonitBaseService.java
@@ -22,7 +22,7 @@ public class CryptonitBaseService extends BaseExchangeService implements BaseSer
 
     super(exchange);
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     // cryptonit server disconnects immediately or raises "protocol version" if connected via these protocol versions
     config.setSslSocketFactory(CertHelper.createRestrictedSSLSocketFactory("SSLv2Hello", "TLSv1", "TLSv1.1"));
 

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaBaseService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaBaseService.java
@@ -16,7 +16,7 @@ public class CryptopiaBaseService extends BaseExchangeService implements BaseSer
   public CryptopiaBaseService(Exchange exchange) {
 
     super(exchange);
-    this.cryptopia = RestProxyFactory.createProxy(Cryptopia.class, exchange.getExchangeSpecification().getSslUri());
+    this.cryptopia = RestProxyFactory.createProxy(Cryptopia.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = CryptopiaDigest.createInstance(exchange.getNonceFactory(), exchange.getExchangeSpecification().getSecretKey(), exchange.getExchangeSpecification().getApiKey());
 
   }

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXBaseService.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXBaseService.java
@@ -31,7 +31,7 @@ public class DSXBaseService extends BaseExchangeService implements BaseService {
   protected DSXBaseService(Exchange exchange) {
     super(exchange);
 
-    this.dsx = RestProxyFactory.createProxy(DSXAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri());
+    this.dsx = RestProxyFactory.createProxy(DSXAuthenticatedV2.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = DSXHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/EmpoExBaseService.java
+++ b/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/EmpoExBaseService.java
@@ -27,12 +27,13 @@ public class EmpoExBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    this.empoExAuthenticated = RestProxyFactory.createProxy(EmpoExAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.empoExAuthenticated = RestProxyFactory.createProxy(EmpoExAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = EmpoExHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.payloadCreator = new EmpoExPayloadDigest();
 
-    this.empoEx = RestProxyFactory.createProxy(EmpoEx.class, exchange.getExchangeSpecification().getSslUri());
+    this.empoEx = RestProxyFactory.createProxy(EmpoEx.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
 
   }
 

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinAccountServiceRaw.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinAccountServiceRaw.java
@@ -24,7 +24,8 @@ public class GatecoinAccountServiceRaw extends GatecoinBaseService {
   protected GatecoinAccountServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.gatecoinAuthenticated = RestProxyFactory.createProxy(GatecoinAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.gatecoinAuthenticated = RestProxyFactory.createProxy(GatecoinAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = GatecoinDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinMarketDataServiceRaw.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinMarketDataServiceRaw.java
@@ -25,7 +25,7 @@ public class GatecoinMarketDataServiceRaw extends GatecoinBaseService {
   public GatecoinMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.gatecoin = RestProxyFactory.createProxy(Gatecoin.class, exchange.getExchangeSpecification().getSslUri());
+    this.gatecoin = RestProxyFactory.createProxy(Gatecoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public GatecoinTickerResult getGatecoinTicker() throws IOException {

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinTradeServiceRaw.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinTradeServiceRaw.java
@@ -22,7 +22,8 @@ public class GatecoinTradeServiceRaw extends GatecoinBaseService {
   public GatecoinTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.gatecoinAuthenticated = RestProxyFactory.createProxy(GatecoinAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.gatecoinAuthenticated = RestProxyFactory.createProxy(GatecoinAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = GatecoinDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXBaseService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXBaseService.java
@@ -19,10 +19,10 @@ public class GDAXBaseService extends BaseExchangeService implements BaseService 
   protected final String apiKey;
   protected final String passphrase;
 
-  protected GDAXBaseService( Exchange exchange) {
+  protected GDAXBaseService(Exchange exchange) {
 
     super(exchange);
-    this.coinbaseEx = RestProxyFactory.createProxy(GDAX.class, exchange.getExchangeSpecification().getSslUri());
+    this.coinbaseEx = RestProxyFactory.createProxy(GDAX.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.digest = GDAXDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.passphrase = (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("passphrase");

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiBaseService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiBaseService.java
@@ -24,7 +24,7 @@ public class GeminiBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    this.Gemini = RestProxyFactory.createProxy(GeminiAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.Gemini = RestProxyFactory.createProxy(GeminiAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = GeminiHmacPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.payloadCreator = new GeminiPayloadDigest();

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcBaseService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/service/HitbtcBaseService.java
@@ -28,7 +28,7 @@ public class HitbtcBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    this.hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     String apiKey = exchange.getExchangeSpecification().getSecretKey();
     this.signatureCreator = apiKey != null && !apiKey.isEmpty() ? HitbtcHmacDigest.createInstance(apiKey) : null;

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcBaseService.java
@@ -20,7 +20,7 @@ public class HitbtcBaseService extends BaseExchangeService implements BaseServic
     String apiKey = exchange.getExchangeSpecification().getApiKey();
     String secretKey = exchange.getExchangeSpecification().getSecretKey();
 
-    ClientConfig config = new ClientConfig();
+    ClientConfig config = getClientConfig();
     ClientConfigUtil.addBasicAuthCredentials(config, apiKey, secretKey);
     hitbtc = RestProxyFactory.createProxy(HitbtcAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), config);
   }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseFuturesServiceRaw.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseFuturesServiceRaw.java
@@ -18,7 +18,7 @@ public class BitVcBaseFuturesServiceRaw extends BaseExchangeService implements B
 
     super(exchange);
 
-    this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "https://api.bitvc.com/futures");
+    this.bitvc = RestProxyFactory.createProxy(BitVcFutures.class, "https://api.bitvc.com/futures", getClientConfig());
     this.accessKey = exchange.getExchangeSpecification().getApiKey();
 
     this.digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secretKey");

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseServiceRaw.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/BitVcBaseServiceRaw.java
@@ -23,7 +23,7 @@ public class BitVcBaseServiceRaw extends BaseExchangeService implements BaseServ
     super(exchange);
 
     final String baseUrl = exchange.getExchangeSpecification().getSslUri();
-    bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl);
+    bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl, getClientConfig());
     accessKey = exchange.getExchangeSpecification().getApiKey();
     digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secret_key");
   }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseTradeService.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiBaseTradeService.java
@@ -19,7 +19,7 @@ public class HuobiBaseTradeService extends HuobiBaseService {
 
     super(exchange);
 
-    huobi = RestProxyFactory.createProxy(Huobi.class, exchange.getExchangeSpecification().getSslUri());
+    huobi = RestProxyFactory.createProxy(Huobi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     accessKey = exchange.getExchangeSpecification().getApiKey();
     digest = new HuobiDigest(exchange.getExchangeSpecification().getSecretKey(), "secret_key");
   }

--- a/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiMarketDataServiceRaw.java
+++ b/xchange-huobi/src/main/java/org/knowm/xchange/huobi/service/HuobiMarketDataServiceRaw.java
@@ -25,7 +25,7 @@ public class HuobiMarketDataServiceRaw extends HuobiBaseService {
     super(exchange);
 
     final String baseUrl = (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem(HuobiExchange.HUOBI_MARKET_DATA);
-    bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl);
+    bitvc = RestProxyFactory.createProxy(BitVc.class, baseUrl, getClientConfig());
   }
 
   public HuobiTicker getBitVcTicker(String symbol) throws IOException {

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveAccountServiceRaw.java
@@ -34,7 +34,7 @@ public class IndependentReserveAccountServiceRaw extends IndependentReserveBaseS
     super(exchange);
 
     this.independentReserveAuthenticated = RestProxyFactory.createProxy(IndependentReserveAuthenticated.class,
-        exchange.getExchangeSpecification().getSslUri());
+        exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = IndependentReserveDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getApiKey(), exchange.getExchangeSpecification().getSslUri());
   }

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
@@ -16,7 +16,8 @@ public class IndependentReserveMarketDataServiceRaw extends IndependentReserveBa
 
   public IndependentReserveMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.independentReserve = RestProxyFactory.createProxy(IndependentReserve.class, exchange.getExchangeSpecification().getSslUri());
+    this.independentReserve = RestProxyFactory.createProxy(IndependentReserve.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
   }
 
   public IndependentReserveOrderBook getIndependentReserveOrderBook(String baseSymbol, String counterSymbol) throws IOException {

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeServiceRaw.java
@@ -41,7 +41,7 @@ public class IndependentReserveTradeServiceRaw extends IndependentReserveBaseSer
     super(exchange);
 
     this.independentReserveAuthenticated = RestProxyFactory.createProxy(IndependentReserveAuthenticated.class,
-        exchange.getExchangeSpecification().getSslUri());
+        exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.signatureCreator = IndependentReserveDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getApiKey(), exchange.getExchangeSpecification().getSslUri());
   }

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitBaseService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitBaseService.java
@@ -30,11 +30,11 @@ public class ItBitBaseService extends BaseExchangeService implements BaseService
     super(exchange);
 
     this.itBitAuthenticated = RestProxyFactory.createProxy(ItBitAuthenticated.class,
-        (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("authHost"));
+        (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("authHost"), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = ItBitHmacPostBodyDigest.createInstance(apiKey, exchange.getExchangeSpecification().getSecretKey());
 
-    this.itBitPublic = RestProxyFactory.createProxy(ItBit.class, exchange.getExchangeSpecification().getSslUri());
+    this.itBitPublic = RestProxyFactory.createProxy(ItBit.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
 
     this.userId = (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("userId");
     this.walletId = (String) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("walletId");

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiAccountServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiAccountServiceRaw.java
@@ -19,7 +19,8 @@ public class JubiAccountServiceRaw extends JubiBaseService {
 
   public JubiAccountServiceRaw(Exchange exchange) {
     super(exchange);
-    this.jubiAuthernticated = RestProxyFactory.createProxy(JubiAuthernticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.jubiAuthernticated = RestProxyFactory.createProxy(JubiAuthernticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = JubiPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiMarketDataServiceRaw.java
@@ -22,7 +22,7 @@ public class JubiMarketDataServiceRaw extends JubiBaseService {
 
   public JubiMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.jubi = RestProxyFactory.createProxy(Jubi.class, exchange.getExchangeSpecification().getSslUri());
+    this.jubi = RestProxyFactory.createProxy(Jubi.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public JubiTicker getJubiTicker(String baseCurrency, String targetCurrency) throws IOException {

--- a/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiTradeServiceRaw.java
+++ b/xchange-jubi/src/main/java/org/knowm/xchange/jubi/service/JubiTradeServiceRaw.java
@@ -26,7 +26,8 @@ public class JubiTradeServiceRaw extends JubiBaseService {
 
   public JubiTradeServiceRaw(Exchange exchange) {
     super(exchange);
-    this.jubiAuthernticated = RestProxyFactory.createProxy(JubiAuthernticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.jubiAuthernticated = RestProxyFactory.createProxy(JubiAuthernticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = JubiPostBodyDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenBaseService.java
@@ -39,7 +39,7 @@ public class KrakenBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    kraken = RestProxyFactory.createProxy(KrakenAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    kraken = RestProxyFactory.createProxy(KrakenAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     signatureCreator = KrakenDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }
 

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCBaseService.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCBaseService.java
@@ -33,11 +33,12 @@ public class LakeBTCBaseService extends BaseExchangeService implements BaseServi
 
     Assert.notNull(exchange.getExchangeSpecification().getSslUri(), "Exchange specification URI cannot be null");
 
-    this.lakeBTCAuthenticated = RestProxyFactory.createProxy(LakeBTCAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.lakeBTCAuthenticated = RestProxyFactory.createProxy(LakeBTCAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = LakeBTCDigest.createInstance(exchange.getExchangeSpecification().getUserName(),
         exchange.getExchangeSpecification().getSecretKey());
 
-    this.lakeBTC = RestProxyFactory.createProxy(LakeBTC.class, exchange.getExchangeSpecification().getSslUri());
+    this.lakeBTC = RestProxyFactory.createProxy(LakeBTC.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
 
   }
 

--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/service/LivecoinBaseService.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/service/LivecoinBaseService.java
@@ -16,7 +16,7 @@ public class LivecoinBaseService<T extends Livecoin> extends BaseExchangeService
   public LivecoinBaseService(Class<T> type, Exchange exchange) {
     super(exchange);
 
-    this.service = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri());
+    this.service = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = LivecoinDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), apiKey);
   }

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoAPIImpl.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/LunoAPIImpl.java
@@ -28,6 +28,7 @@ import org.knowm.xchange.luno.dto.trade.OrderType;
 import org.knowm.xchange.luno.dto.trade.State;
 
 import si.mazi.rescu.BasicAuthCredentials;
+import si.mazi.rescu.ClientConfig;
 import si.mazi.rescu.RestProxyFactory;
 
 public class LunoAPIImpl implements LunoAPI {
@@ -35,10 +36,9 @@ public class LunoAPIImpl implements LunoAPI {
   private final LunoAuthenticated luno;
   private final BasicAuthCredentials auth;
 
+  public LunoAPIImpl(String key, String secret, String uri, ClientConfig clientConfig) {
 
-  public LunoAPIImpl(String key, String secret, String uri) {
-
-    luno = RestProxyFactory.createProxy(LunoAuthenticated.class, uri);
+    luno = RestProxyFactory.createProxy(LunoAuthenticated.class, uri, clientConfig);
     auth = new BasicAuthCredentials(key, secret);
   }
 

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoBaseService.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoBaseService.java
@@ -14,6 +14,6 @@ public class LunoBaseService extends BaseExchangeService implements BaseService 
 
     super(exchange);
     lunoAPI = new LunoAPIImpl(exchange.getExchangeSpecification().getApiKey(), exchange.getExchangeSpecification().getSecretKey(),
-        exchange.getExchangeSpecification().getSslUri());
+        exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 }

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinAccountServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinAccountServiceRaw.java
@@ -29,7 +29,7 @@ public class MercadoBitcoinAccountServiceRaw extends MercadoBitcoinBaseService {
     super(exchange);
 
     this.mercadoBitcoinAuthenticated = RestProxyFactory.createProxy(MercadoBitcoinAuthenticated.class,
-        exchange.getExchangeSpecification().getSslUri());
+        exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public MercadoBitcoinBaseTradeApiResult<MercadoBitcoinAccountInfo> getMercadoBitcoinAccountInfo() throws IOException {

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinMarketDataServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinMarketDataServiceRaw.java
@@ -30,7 +30,7 @@ public class MercadoBitcoinMarketDataServiceRaw extends MercadoBitcoinBaseServic
   public MercadoBitcoinMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.mercadoBitcoin = RestProxyFactory.createProxy(MercadoBitcoin.class, exchange.getExchangeSpecification().getSslUri());
+    this.mercadoBitcoin = RestProxyFactory.createProxy(MercadoBitcoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public MercadoBitcoinOrderBook getMercadoBitcoinOrderBook(CurrencyPair currencyPair) throws IOException {

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeServiceRaw.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeServiceRaw.java
@@ -36,7 +36,7 @@ public class MercadoBitcoinTradeServiceRaw extends MercadoBitcoinBaseService {
 
     super(exchange);
     this.mercadoBitcoinAuthenticated = RestProxyFactory.createProxy(MercadoBitcoinAuthenticated.class,
-        exchange.getExchangeSpecification().getSslUri());
+        exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public MercadoBitcoinBaseTradeApiResult<MercadoBitcoinUserOrders> getMercadoBitcoinUserOrders(@Nonnull String pair, @Nullable String type,

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OKCoinBaseTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OKCoinBaseTradeService.java
@@ -25,7 +25,7 @@ public class OKCoinBaseTradeService extends OkCoinBaseService {
 
     super(exchange);
 
-    okCoin = RestProxyFactory.createProxy(OkCoin.class, exchange.getExchangeSpecification().getSslUri());
+    okCoin = RestProxyFactory.createProxy(OkCoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     apikey = exchange.getExchangeSpecification().getApiKey();
     secretKey = exchange.getExchangeSpecification().getSecretKey();
 

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataServiceRaw.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinMarketDataServiceRaw.java
@@ -26,7 +26,7 @@ public class OkCoinMarketDataServiceRaw extends OkCoinBaseService {
 
     super(exchange);
 
-    okCoin = RestProxyFactory.createProxy(OkCoin.class, exchange.getExchangeSpecification().getSslUri());
+    okCoin = RestProxyFactory.createProxy(OkCoin.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public OkCoinTickerResponse getTicker(CurrencyPair currencyPair) throws IOException {

--- a/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataServiceRaw.java
+++ b/xchange-openexchangerates/src/main/java/org/knowm/xchange/oer/service/OERMarketDataServiceRaw.java
@@ -25,7 +25,7 @@ public class OERMarketDataServiceRaw extends OERBaseService {
   public OERMarketDataServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.openExchangeRates = RestProxyFactory.createProxy(OER.class, exchange.getExchangeSpecification().getPlainTextUri());
+    this.openExchangeRates = RestProxyFactory.createProxy(OER.class, exchange.getExchangeSpecification().getPlainTextUri(), getClientConfig());
   }
 
   public OERRates getOERTicker() throws IOException {

--- a/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumBaseService.java
+++ b/xchange-paymium/src/main/java/org/knowm/xchange/paymium/service/PaymiumBaseService.java
@@ -20,6 +20,6 @@ public class PaymiumBaseService extends BaseExchangeService implements BaseServi
 
     super(exchange);
 
-    this.Paymium = RestProxyFactory.createProxy(Paymium.class, exchange.getExchangeSpecification().getSslUri());
+    this.Paymium = RestProxyFactory.createProxy(Paymium.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexBaseService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexBaseService.java
@@ -37,7 +37,7 @@ public class PoloniexBaseService extends BaseExchangeService implements BaseServ
 
     // TODO should this be fixed/added in rescu itself?
     // Fix for empty string array mapping exception
-    ClientConfig rescuConfig = new ClientConfig();
+    ClientConfig rescuConfig = getClientConfig();
     rescuConfig.setJacksonObjectMapperFactory(new DefaultJacksonObjectMapperFactory() {
       @Override
       public void configureObjectMapper(ObjectMapper objectMapper) {
@@ -46,7 +46,8 @@ public class PoloniexBaseService extends BaseExchangeService implements BaseServ
       }
     });
 
-    this.poloniexAuthenticated = RestProxyFactory.createProxy(PoloniexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.poloniexAuthenticated = RestProxyFactory.createProxy(PoloniexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        rescuConfig);
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = PoloniexDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
     this.poloniex = RestProxyFactory.createProxy(Poloniex.class, exchange.getExchangeSpecification().getSslUri(), rescuConfig);

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxAccountServiceRaw.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxAccountServiceRaw.java
@@ -19,7 +19,8 @@ public class QuadrigaCxAccountServiceRaw extends QuadrigaCxBaseService {
   protected QuadrigaCxAccountServiceRaw(Exchange exchange) {
     super(exchange);
 
-    this.quadrigacxAuthenticated = RestProxyFactory.createProxy(QuadrigaCxAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.quadrigacxAuthenticated = RestProxyFactory.createProxy(QuadrigaCxAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = QuadrigaCxDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxMarketDataServiceRaw.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxMarketDataServiceRaw.java
@@ -18,7 +18,7 @@ public class QuadrigaCxMarketDataServiceRaw extends QuadrigaCxBaseService {
 
   public QuadrigaCxMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.quadrigacx = RestProxyFactory.createProxy(QuadrigaCx.class, exchange.getExchangeSpecification().getSslUri());
+    this.quadrigacx = RestProxyFactory.createProxy(QuadrigaCx.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public QuadrigaCxOrderBook getQuadrigaCxOrderBook(CurrencyPair currencyPair) throws IOException {

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxTradeServiceRaw.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxTradeServiceRaw.java
@@ -23,7 +23,8 @@ public class QuadrigaCxTradeServiceRaw extends QuadrigaCxBaseService {
   public QuadrigaCxTradeServiceRaw(Exchange exchange) {
 
     super(exchange);
-    this.quadrigacxAuthenticated = RestProxyFactory.createProxy(QuadrigaCxAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.quadrigacxAuthenticated = RestProxyFactory.createProxy(QuadrigaCxAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = QuadrigaCxDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineBaseService.java
@@ -33,7 +33,7 @@ public class QuoineBaseService extends BaseExchangeService implements BaseServic
 
     super(exchange);
 
-    quoine = RestProxyFactory.createProxy(QuoineAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    quoine = RestProxyFactory.createProxy(QuoineAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
 
     this.tokenID = exchange.getExchangeSpecification().getApiKey();
     this.secret = exchange.getExchangeSpecification().getSecretKey();

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleBaseService.java
@@ -25,7 +25,7 @@ public class RippleBaseService extends BaseExchangeService implements BaseServic
     } else {
       throw new IllegalStateException("either SSL or plain text URI must be specified");
     }
-    ripplePublic = RestProxyFactory.createProxy(RipplePublic.class, uri);
-    rippleAuthenticated = RestProxyFactory.createProxy(RippleAuthenticated.class, uri);
+    ripplePublic = RestProxyFactory.createProxy(RipplePublic.class, uri, getClientConfig());
+    rippleAuthenticated = RestProxyFactory.createProxy(RippleAuthenticated.class, uri, getClientConfig());
   }
 }

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusAccountServiceRaw.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusAccountServiceRaw.java
@@ -18,7 +18,8 @@ public class TaurusAccountServiceRaw extends TaurusBaseService {
   protected TaurusAccountServiceRaw(Exchange exchange) {
     super(exchange);
 
-    this.taurusAuthenticated = RestProxyFactory.createProxy(TaurusAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.taurusAuthenticated = RestProxyFactory.createProxy(TaurusAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = TaurusDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusMarketDataServiceRaw.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusMarketDataServiceRaw.java
@@ -16,7 +16,7 @@ public class TaurusMarketDataServiceRaw extends TaurusBaseService {
 
   public TaurusMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.taurus = RestProxyFactory.createProxy(Taurus.class, exchange.getExchangeSpecification().getSslUri());
+    this.taurus = RestProxyFactory.createProxy(Taurus.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public TaurusTicker getTaurusTicker() throws IOException {

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusTradeServiceRaw.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusTradeServiceRaw.java
@@ -18,7 +18,8 @@ public class TaurusTradeServiceRaw extends TaurusBaseService {
 
   public TaurusTradeServiceRaw(Exchange exchange) {
     super(exchange);
-    this.taurusAuthenticated = RestProxyFactory.createProxy(TaurusAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.taurusAuthenticated = RestProxyFactory.createProxy(TaurusAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
     this.signatureCreator = TaurusDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(),
         exchange.getExchangeSpecification().getUserName(), exchange.getExchangeSpecification().getApiKey());
   }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockAccountServiceRaw.java
@@ -28,7 +28,7 @@ public class TheRockAccountServiceRaw extends TheRockBaseService {
   protected TheRockAccountServiceRaw(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri());
+    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri(), getClientConfig());
     apiKey = spec.getApiKey();
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockMarketDataServiceRaw.java
@@ -18,7 +18,7 @@ public class TheRockMarketDataServiceRaw extends TheRockBaseService {
 
   public TheRockMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
-    this.theRock = RestProxyFactory.createProxy(TheRock.class, exchange.getExchangeSpecification().getSslUri());
+    this.theRock = RestProxyFactory.createProxy(TheRock.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
   public TheRockTicker getTheRockTicker(TheRock.Pair currencyPair) throws TheRockException, IOException {

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
@@ -26,7 +26,7 @@ public class TheRockTradeServiceRaw extends TheRockBaseService {
   public TheRockTradeServiceRaw(Exchange exchange) {
     super(exchange);
     final ExchangeSpecification spec = exchange.getExchangeSpecification();
-    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri());
+    this.theRockAuthenticated = RestProxyFactory.createProxy(TheRockAuthenticated.class, spec.getSslUri(), getClientConfig());
     this.signatureCreator = new TheRockDigest(spec.getSecretKey());
   }
 

--- a/xchange-truefx/src/main/java/org/knowm/xchange/truefx/service/TrueFxMarketDataServiceRaw.java
+++ b/xchange-truefx/src/main/java/org/knowm/xchange/truefx/service/TrueFxMarketDataServiceRaw.java
@@ -25,7 +25,7 @@ public class TrueFxMarketDataServiceRaw extends BaseExchangeService {
   protected TrueFxMarketDataServiceRaw(Exchange exchange) {
     super(exchange);
 
-    final ClientConfig config = new ClientConfig();
+    final ClientConfig config = getClientConfig();
     config.setJacksonObjectMapperFactory(factory);
 
     trueFx = RestProxyFactory.createProxy(TrueFxPublic.class, exchange.getExchangeSpecification().getPlainTextUri(), config);

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroBaseService.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroBaseService.java
@@ -23,7 +23,7 @@ public class VaultoroBaseService extends BaseExchangeService implements BaseServ
 
     super(exchange);
 
-    this.vaultoro = RestProxyFactory.createProxy(VaultoroAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.vaultoro = RestProxyFactory.createProxy(VaultoroAuthenticated.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
     this.apiKey = exchange.getExchangeSpecification().getApiKey();
     this.signatureCreator = VaultoroDigest.createInstance(exchange.getExchangeSpecification().getSecretKey());
   }

--- a/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/VircurexBaseService.java
+++ b/xchange-vircurex/src/main/java/org/knowm/xchange/vircurex/service/VircurexBaseService.java
@@ -19,6 +19,7 @@ public class VircurexBaseService extends BaseExchangeService implements BaseServ
   public VircurexBaseService(Exchange exchange) {
 
     super(exchange);
-    this.vircurexAuthenticated = RestProxyFactory.createProxy(VircurexAuthenticated.class, exchange.getExchangeSpecification().getSslUri());
+    this.vircurexAuthenticated = RestProxyFactory.createProxy(VircurexAuthenticated.class, exchange.getExchangeSpecification().getSslUri(),
+        getClientConfig());
   }
 }

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitBaseService.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitBaseService.java
@@ -16,6 +16,6 @@ public class YoBitBaseService<T extends YoBit> extends BaseExchangeService imple
     super(exchange);
 
     this.signatureCreator = YoBitDigest.createInstance(exchange.getExchangeSpecification().getSecretKey(), exchange.getExchangeSpecification().getApiKey());
-    this.service = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri());
+    this.service = RestProxyFactory.createProxy(type, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 }


### PR DESCRIPTION
## Overview:
This is a rework of pull-request #1798. Please look over there for full discussion history.

## Details:
1) This PR adds a method `getClientConfig()` to the `BaseExchangeService` which returns a RestCU configuration object, which has already the timeout values from the `ExchangeSpecification` set (uses defaults if they are not set).

2) Also in `ExchangeSpecification` a method for setting the `httpConnTimeout` was added (the `httpReadTimeout` was already included before).

3) Over all sub-projects (exchange implementations) in all subclasses of `BaseExchangeService` every call to `RestProxyFactory.createProxy(..)` was modified, to make use of the newly added `getClientConfig()` method (so that the set timeout values will be used).