### PR TITLE
[Gemini] changed order ID to a long since it now exceeds Integer.MAX_VALUE

### DIFF
--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiCancelOrderRequest.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiCancelOrderRequest.java
@@ -13,7 +13,7 @@ public class GeminiCancelOrderRequest {
 
   @JsonProperty("order_id")
   @JsonRawValue
-  private int orderId;
+  private long orderId;
 
   /**
    * Constructor
@@ -21,7 +21,7 @@ public class GeminiCancelOrderRequest {
    * @param nonce
    * @param orderId
    */
-  public GeminiCancelOrderRequest(String nonce, int orderId) {
+  public GeminiCancelOrderRequest(String nonce, long orderId) {
 
     this.request = "/v1/order/cancel";
     this.orderId = orderId;

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiLimitOrder.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiLimitOrder.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.dto.trade.LimitOrder;
  * Poloniex order response contains details of any trades that have just executed in the order entry return value. If a LimitOrder of this type is
  * supplied to the trade service orderEntry method it will be populated with this information.
  */
+@SuppressWarnings("serial")
 public class GeminiLimitOrder extends LimitOrder {
 
   private GeminiOrderStatusResponse response = null;

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiOrderStatusRequest.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiOrderStatusRequest.java
@@ -13,7 +13,7 @@ public class GeminiOrderStatusRequest {
 
   @JsonProperty("order_id")
   @JsonRawValue
-  private int orderId;
+  private long orderId;
 
   /**
    * Constructor
@@ -21,7 +21,7 @@ public class GeminiOrderStatusRequest {
    * @param nonce
    * @param orderId
    */
-  public GeminiOrderStatusRequest(String nonce, int orderId) {
+  public GeminiOrderStatusRequest(String nonce, long orderId) {
 
     this.request = "/v1/order/status";
     this.orderId = orderId;

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiOrderStatusResponse.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/dto/trade/GeminiOrderStatusResponse.java
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class GeminiOrderStatusResponse {
 
-  private final int id;
+  private final long id;
   private final String symbol;
   private final BigDecimal price;
   private final BigDecimal avgExecutionPrice;
@@ -37,7 +37,7 @@ public class GeminiOrderStatusResponse {
    * @param remainingAmount
    * @param executedAmount
    */
-  public GeminiOrderStatusResponse(@JsonProperty("order_id") int id, @JsonProperty("symbol") String symbol,
+  public GeminiOrderStatusResponse(@JsonProperty("order_id") long id, @JsonProperty("symbol") String symbol,
       @JsonProperty("price") BigDecimal price, @JsonProperty("avg_execution_price") BigDecimal avgExecutionPrice, @JsonProperty("side") String side,
       @JsonProperty("type") String type, @JsonProperty("timestamp") BigDecimal timestamp, @JsonProperty("is_live") boolean isLive,
       @JsonProperty("is_cancelled") boolean isCancelled, @JsonProperty("was_forced") boolean wasForced,
@@ -109,7 +109,7 @@ public class GeminiOrderStatusResponse {
     return timestamp;
   }
 
-  public int getId() {
+  public long getId() {
 
     return id;
   }

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
@@ -151,7 +151,7 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements TradeSe
     throw new NotYetImplementedForExchangeException();
   }
 
-  public static class GeminiTradeHistoryParams implements TradeHistoryParams, TradeHistoryParamCurrencyPair, TradeHistoryParamLimit, TradeHistoryParamsTimeSpan {
+  public static class GeminiTradeHistoryParams implements TradeHistoryParamCurrencyPair, TradeHistoryParamLimit, TradeHistoryParamsTimeSpan {
     private CurrencyPair currencyPair;
     private Integer limit;
     private Date startTime;

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeServiceRaw.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeServiceRaw.java
@@ -80,7 +80,7 @@ public class GeminiTradeServiceRaw extends GeminiBaseService {
 
     try {
       Gemini.cancelOrders(apiKey, payloadCreator, signatureCreator,
-          new GeminiCancelOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
+          new GeminiCancelOrderRequest(String.valueOf(exchange.getNonceFactory().createValue()), Long.valueOf(orderId)));
       return true;
     } catch (GeminiException e) {
       if (e.getMessage().equals("Order could not be cancelled.")) {
@@ -95,7 +95,7 @@ public class GeminiTradeServiceRaw extends GeminiBaseService {
 
     try {
       GeminiOrderStatusResponse orderStatus = Gemini.orderStatus(apiKey, payloadCreator, signatureCreator,
-          new GeminiOrderStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Integer.valueOf(orderId)));
+          new GeminiOrderStatusRequest(String.valueOf(exchange.getNonceFactory().createValue()), Long.valueOf(orderId)));
       return orderStatus;
     } catch (GeminiException e) {
       throw new ExchangeException(e);

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertEquals;
 public class GeminiAdaptersTest {
 
   private final static String MARKET = "Gemini";
-  private final static String EXCHANGE = "exchange";
   private final static String SYMBOL = "BTCUSD";
 
   @Test
@@ -169,8 +168,8 @@ public class GeminiAdaptersTest {
   private GeminiTradeResponse[] initTradeResponses() {
 
     GeminiTradeResponse[] responses = new GeminiTradeResponse[60];
-    int tradeId = 2000;
-    int orderId = 1000;
+    long tradeId = 2000;
+    long orderId = 1000;
 
     for (int i = 0; i < responses.length; i++) {
       BigDecimal price = new BigDecimal(350L + i);

--- a/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
+++ b/xchange-kraken/src/test/java/org/knowm/xchange/kraken/KrakenAdaptersTest.java
@@ -98,7 +98,7 @@ public class KrakenAdaptersTest {
     KrakenAssetPairsResult krakenAssetPairs = mapper.readValue(is, KrakenAssetPairsResult.class);
 
     Set<CurrencyPair> pairs = KrakenAdapters.adaptCurrencyPairs(krakenAssetPairs.getResult().keySet());
-    assertThat(pairs).hasSize(57);
+    assertThat(pairs).hasSize(52);
     assertThat(pairs.contains(CurrencyPair.BTC_USD)).isTrue();
     System.out.println("pairs = " + pairs);
   }


### PR DESCRIPTION
This was causing deserialization exceptions. e.g. 
```
si.mazi.rescu.HttpStatusIOException: Can not deserialize value of type int from String "2147483855": Overflow: numeric value (2147483855) out of range of Integer (-2147483648 - 2147483647)
at org.knowm.xchange.gemini.v1.service.GeminiTradeServiceRaw.getGeminiOpenOrders(GeminiTradeServiceRaw.java:39)
at org.knowm.xchange.gemini.v1.service.GeminiTradeService.getOpenOrders(GeminiTradeService.java:51)
```
I've also removed a couple of compiler warnings, and fixed a Kraken unit test (example-assetpairs-data.json had changed 3 months ago) for for #1866. 