### PR TITLE
Add 'open' field to 'Ticker'

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/marketdata/Ticker.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.utils.DateUtils;
 public final class Ticker {
 
   private final CurrencyPair currencyPair;
+  private final BigDecimal open;
   private final BigDecimal last;
   private final BigDecimal bid;
   private final BigDecimal ask;
@@ -42,9 +43,9 @@ public final class Ticker {
    * @param volume 24h volume
    * @param timestamp - the timestamp of the ticker according to the exchange's server, null if not provided
    */
-  private Ticker(CurrencyPair currencyPair, BigDecimal last, BigDecimal bid, BigDecimal ask, BigDecimal high, BigDecimal low, BigDecimal vwap,
+  private Ticker(CurrencyPair currencyPair, BigDecimal open, BigDecimal last, BigDecimal bid, BigDecimal ask, BigDecimal high, BigDecimal low, BigDecimal vwap,
       BigDecimal volume, Date timestamp) {
-
+    this.open = open;
     this.currencyPair = currencyPair;
     this.last = last;
     this.bid = bid;
@@ -59,6 +60,11 @@ public final class Ticker {
   public CurrencyPair getCurrencyPair() {
 
     return currencyPair;
+  }
+
+  public BigDecimal getOpen() {
+
+    return open;
   }
 
   public BigDecimal getLast() {
@@ -104,7 +110,7 @@ public final class Ticker {
   @Override
   public String toString() {
 
-    return "Ticker [currencyPair=" + currencyPair + ", last=" + last + ", bid=" + bid + ", ask=" + ask + ", high=" + high + ", low=" + low + ",avg="
+    return "Ticker [currencyPair=" + currencyPair + ", open=" + open + ", last=" + last + ", bid=" + bid + ", ask=" + ask + ", high=" + high + ", low=" + low + ",avg="
         + vwap + ", volume=" + volume + ", timestamp=" + DateUtils.toMillisNullSafe(timestamp) + "]";
   }
 
@@ -120,6 +126,7 @@ public final class Ticker {
   public static class Builder {
 
     private CurrencyPair currencyPair;
+    private BigDecimal open;
     private BigDecimal last;
     private BigDecimal bid;
     private BigDecimal ask;
@@ -136,7 +143,7 @@ public final class Ticker {
 
       validateState();
 
-      Ticker ticker = new Ticker(currencyPair, last, bid, ask, high, low, vwap, volume, timestamp);
+      Ticker ticker = new Ticker(currencyPair, open, last, bid, ask, high, low, vwap, volume, timestamp);
 
       isBuilt = true;
 
@@ -153,6 +160,12 @@ public final class Ticker {
     public Builder currencyPair(CurrencyPair currencyPair) {
 
       this.currencyPair = currencyPair;
+      return this;
+    }
+
+    public Builder open(BigDecimal open) {
+
+      this.open = open;
       return this;
     }
 


### PR DESCRIPTION
This PR is a suggestion to add `open` attribute to the `Ticker` class.

A lot of exchanges support it and they either set this value to "the price from 24h ago" or "the price at 00:00 on a given day" for example:

* Bitstamp - https://www.bitstamp.net/api/ticker/ - `open` attribute is the "First price of the day"
* Bittrex - https://bittrex.com/api/v1.1/public/getmarketsummaries - `PrevDay` attribute - "the price at 24h ago"

If this PR is accepted, I can edit few of the `Ticker` implementations to add support for that attribute, but I'm sure that there are many changes which don't support it