### PR TITLE
Implement remainingAmount via cumulativeAmount

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexAdapters.java
@@ -291,7 +291,7 @@ public final class BitfinexAdapters {
       CurrencyPair currencyPair = adaptCurrencyPair(order.getSymbol());
       Date timestamp = convertBigDecimalTimestampToDate(order.getTimestamp());
 
-      limitOrders.add(new LimitOrder(orderType, order.getOriginalAmount(), order.getRemainingAmount(), currencyPair, String.valueOf(order.getId()), timestamp, order.getPrice(),
+      limitOrders.add(new LimitOrder(orderType, order.getOriginalAmount(), currencyPair, String.valueOf(order.getId()), timestamp, order.getPrice(),
           order.getAvgExecutionPrice(), order.getExecutedAmount(), status));
     }
 

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -155,6 +155,7 @@ public abstract class Order implements Serializable {
    * @param id An id (usually provided by the exchange)
    * @param timestamp the absolute time for this order according to the exchange's server, null if not provided
    * @param averagePrice the averagePrice of fill belonging to the order
+   * @param cumulativeAmount the amount that has been filled
    * @param status the status of the order at the exchange
    */
   public Order(OrderType type, BigDecimal originalAmount, CurrencyPair currencyPair, String id, Date timestamp, BigDecimal averagePrice,
@@ -202,6 +203,14 @@ public abstract class Order implements Serializable {
     return cumulativeAmount;
   }
 
+  /**
+   * @return The remaining order amount
+   */
+  public BigDecimal getRemainingAmount() {
+
+    return originalAmount.subtract(cumulativeAmount);
+  }
+  
   /**
    * @return The average price of the fills in the order
    */
@@ -321,6 +330,7 @@ public abstract class Order implements Serializable {
     protected String id;
     protected Date timestamp;
     protected BigDecimal averagePrice;
+    protected BigDecimal cumulativeAmount;
     protected OrderStatus status;
 
     protected final Set<IOrderFlags> flags = new HashSet<>();
@@ -353,6 +363,12 @@ public abstract class Order implements Serializable {
 
       this.averagePrice = averagePrice;
       return this;
+    }
+    
+    public Builder cumulativeAmount(BigDecimal cumulativeAmount) {
+
+        this.cumulativeAmount = cumulativeAmount;
+        return this;
     }
 
     public Builder currencyPair(CurrencyPair currencyPair) {

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesAdapters.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/CryptoFacilitiesAdapters.java
@@ -128,7 +128,7 @@ public class CryptoFacilitiesAdapters {
   }
 
   public static LimitOrder adaptLimitOrder(CryptoFacilitiesOpenOrder ord) {
-    return new LimitOrder(adaptOrderType(ord.getDirection()), ord.getQuantity(), ord.getUnfilled(), new CurrencyPair(ord.getSymbol(), ord.getSymbol().substring(6, 9)),
+    return new LimitOrder(adaptOrderType(ord.getDirection()), ord.getQuantity(), new CurrencyPair(ord.getSymbol(), ord.getSymbol().substring(6, 9)),
         ord.getId(), ord.getTimestamp(), ord.getLimitPrice(), BigDecimal.ZERO, ord.getFilled(), adaptOrderStatus(ord.getStatus()));
   }
 

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -156,7 +156,7 @@ public class GDAXAdapters {
       OrderStatus orderStatus = order.getFilledSize().compareTo(BigDecimal.ZERO) == 0 ?
           Order.OrderStatus.NEW : Order.OrderStatus.PARTIALLY_FILLED;
 
-      LimitOrder limitOrder = new LimitOrder(type, order.getSize(), order.getSize().subtract(order.getFilledSize()), currencyPair,
+      LimitOrder limitOrder = new LimitOrder(type, order.getSize(), currencyPair,
               order.getId(), createdAt, order.getPrice(), order.getPrice(), order.getFilledSize(), orderStatus);
 
       orders.add(limitOrder);

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/GeminiAdapters.java
@@ -259,7 +259,7 @@ public final class GeminiAdapters {
         status = OrderStatus.FILLED;
       }
 
-      LimitOrder limitOrder = new LimitOrder(orderType, order.getOriginalAmount(), order.getRemainingAmount(), currencyPair,
+      LimitOrder limitOrder = new LimitOrder(orderType, order.getOriginalAmount(), currencyPair,
               String.valueOf(order.getId()), timestamp, order.getPrice(), order.getAvgExecutionPrice(), order.getExecutedAmount(), status);
 
       limitOrders.add(limitOrder);

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -189,7 +189,7 @@ public class KrakenAdapters {
       status = OrderStatus.PARTIALLY_FILLED;
     }
 
-    return new LimitOrder(type, originalAmount, remainingAmount, pair, id, timestamp, orderDescription.getPrice(),
+    return new LimitOrder(type, originalAmount, pair, id, timestamp, orderDescription.getPrice(),
             orderDescription.getPrice(), filledAmount, status);
   }
 


### PR DESCRIPTION
Order class already holds cumulativeAmount, so remainingAmount can be directly retrieved via originalAmount.subtract(cumulativeAmount). 
- Order.getRemainingAmount() method for that purpose. LimitOrder.remainingAmount was removed.
- C'tors and Builders were updated accordingly
- All relevant exchanges adapters were updated accordingly.

NOTE: Consider removing LimitOrder.getFilledAmount() which is the same as Order.getCumulativeAmount and causes confusion.