### PR TITLE
Bug-fixes and removing LimitOrder.getFilledAmount

### DIFF
--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
@@ -138,8 +138,8 @@ public class BleutradeAdapters {
       LimitOrder.Builder builder = new LimitOrder.Builder(type, currencyPair);
       builder.id(bleuTradeOpenOrder.getOrderId());
       builder.limitPrice(bleuTradeOpenOrder.getPrice());
-      builder.remainingAmount(bleuTradeOpenOrder.getQuantityRemaining());
       builder.originalAmount(bleuTradeOpenOrder.getQuantity());
+      builder.remainingAmount(bleuTradeOpenOrder.getQuantityRemaining());
       builder.timestamp(BleutradeUtils.toDate(bleuTradeOpenOrder.getCreated()));
       openOrders.add(builder.build());
     }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/Order.java
@@ -208,6 +208,10 @@ public abstract class Order implements Serializable {
    */
   public BigDecimal getRemainingAmount() {
 
+	if (originalAmount == null || cumulativeAmount == null) {
+		return null;
+	}
+	
     return originalAmount.subtract(cumulativeAmount);
   }
 
@@ -331,7 +335,8 @@ public abstract class Order implements Serializable {
     protected CurrencyPair currencyPair;
     protected String id;
     protected Date timestamp;
-    protected BigDecimal averagePrice;
+    protected BigDecimal averagePrice = BigDecimal.ZERO;
+    protected BigDecimal cumulativeAmount = BigDecimal.ZERO;
     protected OrderStatus status;
 
     protected final Set<IOrderFlags> flags = new HashSet<>();
@@ -378,6 +383,15 @@ public abstract class Order implements Serializable {
       return this;
     }
 
+    /**
+     * originalAmount must be initiated beforehand.
+     */
+    public Builder remainingAmount(BigDecimal remainingAmount) {
+
+    	this.cumulativeAmount = originalAmount.subtract(remainingAmount);
+    	return this;
+    }
+    
     public Builder currencyPair(CurrencyPair currencyPair) {
 
       this.currencyPair = currencyPair;

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/LimitOrder.java
@@ -202,6 +202,21 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
     }
 
     @Override
+    public Builder cumulativeAmount(BigDecimal cumulativeAmount) {
+
+        return (Builder) super.cumulativeAmount(cumulativeAmount);
+    }
+    
+    /**
+     * originalAmount must be initiated beforehand.
+     */
+    @Override
+    public Builder remainingAmount(BigDecimal remainingAmount) {
+
+    	return (Builder) super.remainingAmount(remainingAmount);
+    }
+    
+    @Override
     public Builder flag(IOrderFlags flag) {
 
       return (Builder) super.flag(flag);
@@ -218,7 +233,7 @@ public class LimitOrder extends Order implements Comparable<LimitOrder> {
       this.limitPrice = limitPrice;
       return this;
     }
-
+    
     public LimitOrder build() {
 
       LimitOrder order;

--- a/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
+++ b/xchange-gemini/src/test/java/org/knowm/xchange/gemini/v1/GeminiAdaptersTest.java
@@ -103,6 +103,7 @@ public class GeminiAdaptersTest {
       assertEquals(responses[i].getOriginalAmount(), order.getOriginalAmount());
       assertEquals(responses[i].getRemainingAmount(), order.getRemainingAmount());
       assertEquals(responses[i].getExecutedAmount(), order.getOriginalAmount().subtract(order.getRemainingAmount()));
+      assertEquals(responses[i].getExecutedAmount(), order.getCumulativeAmount());
       assertEquals(GeminiAdapters.adaptCurrencyPair(SYMBOL), order.getCurrencyPair());
       assertEquals(expectedOrderType, order.getType());
       assertEquals(expectedTimestampMillis, order.getTimestamp().getTime());


### PR DESCRIPTION
- LimitOrder.getFilledAmount has the same meaning as Order.getCumulativeAmount
- Need to initialize cumulativeAmount and averagePrice
- Adapt Builders