### PR TITLE
Minor: Add withdrawals fees on exchanges meta data

### DIFF
--- a/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/bootstrap/ANXGenerator.java
+++ b/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/bootstrap/ANXGenerator.java
@@ -88,21 +88,21 @@ public class ANXGenerator {
     maxAmount.put(EGD, null);
 
     for (Currency crypto : cryptos) {
-      currencyMap.put(crypto, new CurrencyMetaData(8));
+      currencyMap.put(crypto, new CurrencyMetaData(8, null));
     }
 
-    currencyMap.put(CNY, new CurrencyMetaData(8));
+    currencyMap.put(CNY, new CurrencyMetaData(8, null));
     for (Currency fiat : fiats) {
       if (!currencyMap.containsKey(fiat)) {
-        currencyMap.put(fiat, new CurrencyMetaData(2));
+        currencyMap.put(fiat, new CurrencyMetaData(2, null));
       }
     }
 
     // extra currencies available, but not traded
-    currencyMap.put(CHF, new CurrencyMetaData(2));
-    currencyMap.put(NMC, new CurrencyMetaData(8));
-    currencyMap.put(BGC, new CurrencyMetaData(8));
-    currencyMap.put(PPC, new CurrencyMetaData(8));
+    currencyMap.put(CHF, new CurrencyMetaData(2, null));
+    currencyMap.put(NMC, new CurrencyMetaData(8, null));
+    currencyMap.put(BGC, new CurrencyMetaData(8, null));
+    currencyMap.put(PPC, new CurrencyMetaData(8, null));
 
     Collections.addAll(pairs, pairsOther);
 

--- a/xchange-bitfinex/src/main/resources/bitfinex.json
+++ b/xchange-bitfinex/src/main/resources/bitfinex.json
@@ -99,25 +99,52 @@
   },
   "currencies": {
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.0005
     },
     "BCH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.0005
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "ETC": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
     },
     "LTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "XRP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.02
     },
     "USD": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 0
     },
     "XMR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.04
+    },
+    "ZEC": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "DASH": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "EOS": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "USDT": {
+      "scale": 8,
+      "withdrawal_fee": 5.0
     }
   }
 }

--- a/xchange-bitstamp/src/main/resources/bitstamp.json
+++ b/xchange-bitstamp/src/main/resources/bitstamp.json
@@ -63,22 +63,28 @@
   },
   "currencies": {
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
     },
     "USD": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 0
     },
     "EUR": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 0
     },
     "XRP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
     },
     "LTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
     }
   },
   "private_rate_limits": [

--- a/xchange-bittrex/src/main/resources/bittrex.json
+++ b/xchange-bittrex/src/main/resources/bittrex.json
@@ -23,22 +23,100 @@
   },
   "currencies": {
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.005
+    },
+    "ETC": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "USDT": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
     },
     "LTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01
     },
     "XRP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 5.0
     },
     "PPC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "VTC": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "BLK": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "GAME": {
+      "scale": 8,
+      "withdrawal_fee": 0.2
+    },
+    "SYS": {
+      "scale": 8,
+      "withdrawal_fee": 0.0002
+    },
+    "AMP": {
+      "scale": 8,
+      "withdrawal_fee": 5.0
+    },
+    "PPC": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "LSK": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "BTCD": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
+    },
+    "DASH": {
+      "scale": 8,
+      "withdrawal_fee": 0.002
+    },
+    "XMR": {
+      "scale": 8,
+      "withdrawal_fee": 0.04
+    },
+    "BCH": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "STEEM": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "FCT": {
+      "scale": 8,
+      "withdrawal_fee": 0.01
+    },
+    "DGB": {
+      "scale": 8,
+      "withdrawal_fee": 0.02
     },
     "DOGE": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
+    },
+    "SC": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "ZEC": {
+      "scale": 8,
+      "withdrawal_fee": 0.005
     }
   }
 }

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/BleutradeAdapters.java
@@ -154,7 +154,7 @@ public class BleutradeAdapters {
 
     for (BleutradeCurrency bleutradeCurrency : bleutradeCurrencies) {
       // the getTxFee parameter is the withdrawal charge in the currency in question
-      currencyMetaDataMap.put(Currency.getInstance(bleutradeCurrency.getCurrency()), new CurrencyMetaData(8));
+      currencyMetaDataMap.put(Currency.getInstance(bleutradeCurrency.getCurrency()), new CurrencyMetaData(8, null));
     }
 
     // https://bleutrade.com/help/fees_and_deadlines 11/25/2015 all == 0.25%

--- a/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/BTCEAdapters.java
+++ b/xchange-btce/src/main/java/org/knowm/xchange/btce/v3/BTCEAdapters.java
@@ -280,7 +280,8 @@ public final class BTCEAdapters {
 
   private static void addCurrencyMetaData(Currency symbol, Map<Currency, CurrencyMetaData> currencies, BTCEMetaData btceMetaData) {
     if (!currencies.containsKey(symbol)) {
-      currencies.put(symbol, new CurrencyMetaData(btceMetaData.amountScale));
+      BigDecimal withdrawalFee = btceMetaData.getCurrencies().get(symbol) == null ? null : btceMetaData.getCurrencies().get(symbol).getWithdrawalFee();	
+      currencies.put(symbol, new CurrencyMetaData(btceMetaData.amountScale, withdrawalFee));
     }
   }
 

--- a/xchange-btce/src/main/resources/btce.json
+++ b/xchange-btce/src/main/resources/btce.json
@@ -24,22 +24,52 @@
   },
   "currencies": {
     "EUR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0
+    },
+    "RUR": {
+      "scale": 8,
+      "withdrawal_fee": 0
+    },
+    "USD": {
+      "scale": 8,
+      "withdrawal_fee": 0
     },
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "LTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "PPC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.1
     },
     "NMC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "ZEC": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "NVC": {
+      "scale": 8,
+      "withdrawal_fee": 0.1
+    },
+    "BCH": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
+    },
+    "DASH": {
+      "scale": 8,
+      "withdrawal_fee": 0.001
     }
   },
   "publicInfoCacheSeconds": 2,

--- a/xchange-cexio/src/main/resources/cexio.json
+++ b/xchange-cexio/src/main/resources/cexio.json
@@ -68,22 +68,28 @@
   },
   "currencies": {
     "BCH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.001
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01
     },
     "GBP": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 3.80
     },
     "EUR": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 3.80
     },
     "USD": {
-      "scale": 2
+      "scale": 2,
+      "withdrawal_fee": 3.80
     }
   },
   "private_rate_limits": [

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyMetaData.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/meta/CurrencyMetaData.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.dto.meta;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -8,22 +9,33 @@ public class CurrencyMetaData implements Serializable {
 
   @JsonProperty("scale")
   private final int scale;
+  
+  /**
+   * Withdrawal fee 
+   */
+  @JsonProperty("withdrawal_fee")
+  private BigDecimal withdrawalFee;
 
   /**
    * Constructor
    *
    * @param scale
    */
-  public CurrencyMetaData(@JsonProperty("scale") int scale) {
-    this.scale = scale;
+  public CurrencyMetaData(@JsonProperty("scale") int scale, @JsonProperty("withdrawal_fee") BigDecimal withdrawalFee) {
+	this.scale = scale;
+    this.withdrawalFee = withdrawalFee;
   }
 
   public int getScale() {
     return scale;
   }
 
+  public BigDecimal getWithdrawalFee() {
+    return withdrawalFee;
+  }
+  
   @Override
   public String toString() {
-    return "CurrencyMetaData{" + "scale=" + scale + '}';
+    return "CurrencyMetaData [" + "scale=" + scale +  ", withdrawalFee=" + withdrawalFee + "]";
   }
 }

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/CryptopiaAdapters.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/CryptopiaAdapters.java
@@ -124,7 +124,7 @@ public final class CryptopiaAdapters {
     Map<Currency, CurrencyMetaData> currencyMetaDataMap = new HashMap<>();
 
     for (CryptopiaCurrency cryptopiaCurrency : cryptopiaCurrencies) {
-      currencyMetaDataMap.put(Currency.getInstance(cryptopiaCurrency.getSymbol()), new CurrencyMetaData(8));
+      currencyMetaDataMap.put(Currency.getInstance(cryptopiaCurrency.getSymbol()), new CurrencyMetaData(8, null));
     }
 
     for (CryptopiaTradePair cryptopiaTradePair : tradePairs) {

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/DSXAdapters.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/DSXAdapters.java
@@ -210,7 +210,8 @@ public class DSXAdapters {
   private static void addCurrencyMetaData(Currency symbol, Map<Currency, CurrencyMetaData> currencies, DSXMetaData dsxMetaData) {
 
     if (!currencies.containsKey(symbol)) {
-      currencies.put(symbol, new CurrencyMetaData(dsxMetaData.amountScale));
+      BigDecimal withdrawalFee = dsxMetaData.getCurrencies().get(symbol) == null ? null : dsxMetaData.getCurrencies().get(symbol).getWithdrawalFee();
+      currencies.put(symbol, new CurrencyMetaData(dsxMetaData.amountScale, withdrawalFee));
     }
   }
 

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/KrakenAdapters.java
@@ -275,7 +275,8 @@ public class KrakenAdapters {
     for (String krakenAssetCode : krakenAssets.keySet()) {
       KrakenAsset krakenAsset = krakenAssets.get(krakenAssetCode);
       Currency currencyCode = KrakenAdapters.adaptCurrency(krakenAssetCode);
-      currencies.put(currencyCode, new CurrencyMetaData(krakenAsset.getScale()));
+      BigDecimal withdrawalFee = originalMetaData.getCurrencies().get(currencyCode) == null ? null : originalMetaData.getCurrencies().get(currencyCode).getWithdrawalFee();	
+      currencies.put(currencyCode, new CurrencyMetaData(krakenAsset.getScale(), withdrawalFee));
     }
 
     return new ExchangeMetaData(pairs, currencies, originalMetaData == null ? null : originalMetaData.getPublicRateLimits(),

--- a/xchange-kraken/src/main/resources/kraken.json
+++ b/xchange-kraken/src/main/resources/kraken.json
@@ -179,7 +179,100 @@
       "price_scale": 6
     }
   },
-  "currencies": {},
+  "currencies": {
+    "EUR": {
+      "scale": 5,
+      "withdrawal_fee": 60.0
+    },
+    "USD": {
+      "scale": 5,
+      "withdrawal_fee": 60.0
+    },
+    "GBP": {
+      "scale": 5,
+      "withdrawal_fee": 60.0
+    },
+    "CAD": {
+      "scale": 5,
+      "withdrawal_fee": 60.0
+    },
+    "JPY": {
+      "scale": 5,
+      "withdrawal_fee": 300.0
+    },
+    "BTC": {
+      "scale": 5,
+      "withdrawal_fee": 0.001
+    },
+    "USDT": {
+      "scale": 5,
+      "withdrawal_fee": 5.0000
+    },
+    "XRP": {
+      "scale": 5,
+      "withdrawal_fee": 0.02000
+    },
+    "XLM": {
+      "scale": 5,
+      "withdrawal_fee": 0.00002
+    },
+    "LTC": {
+      "scale": 5,
+      "withdrawal_fee": 0.00100
+    },
+    "XVN": {
+      "scale": 5,
+      "withdrawal_fee": 0.00010
+    },
+    "DOGE": {
+      "scale": 5,
+      "withdrawal_fee": 2.00
+    },
+    "DASH": {
+      "scale": 5,
+      "withdrawal_fee": 0.00500
+    },
+    "ETH": {
+      "scale": 5,
+      "withdrawal_fee": 0.00500
+    },
+    "ETC": {
+      "scale": 5,
+      "withdrawal_fee": 0.00500
+    },
+    "REP": {
+      "scale": 5,
+      "withdrawal_fee": 0.01000
+    },
+    "ZEC": {
+      "scale": 5,
+      "withdrawal_fee": 0.00010
+    },
+    "ICN": {
+      "scale": 5,
+      "withdrawal_fee": 0.20000
+    },
+    "MLN": {
+      "scale": 5,
+      "withdrawal_fee": 0.00300
+    },
+    "XMR": {
+      "scale": 5,
+      "withdrawal_fee": 0.05000
+    },
+    "GNO": {
+      "scale": 5,
+      "withdrawal_fee": 0.00500
+    },
+    "EOS": {
+      "scale": 5,
+      "withdrawal_fee": 0.50000
+    },
+    "BCH": {
+      "scale": 5,
+      "withdrawal_fee": 0.00100
+    }
+  },
   "public_rate_limits": [
     {
       "calls": 1,

--- a/xchange-poloniex/src/main/resources/poloniex.json
+++ b/xchange-poloniex/src/main/resources/poloniex.json
@@ -363,181 +363,240 @@
   },
   "currencies": {
     "STR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00001000
     },
     "DGB": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.10000000
     },
     "BTCD": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "BTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00010000
     },
     "POT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "BCY": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 4.00000000
     },
     "OMNI": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.10000000
     },
     "BTS": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 5.00000000
     },
     "PPC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "FLO": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "GNO": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00500000
     },
     "CLAM": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00100000
     },
     "GNT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.10000000
     },
     "SC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 10.00000000
     },
     "XPM": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "ARDR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 1.00000000
     },
     "NMC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "ZEC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00100000
     },
     "REP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "DOGE": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 5.00000000
     },
     "XBC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00010000
     },
     "SYS": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "GRC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "STRAT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "XCP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.20000000
     },
     "BURST": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 1.00000000
     },
     "EMC2": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 1.00000000
     },
     "HUC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "RADS": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "BELA": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "XEM": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 15.00000000
     },
     "NAV": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "VRC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "STEEM": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "FCT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "BLK": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "VTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00100000
     },
     "PINK": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "ETC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "ETH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00500000
     },
     "USDT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 2.00000000
     },
     "LBC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "MAID": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 10.00000000
     },
     "DASH": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "AMP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 5.00000000
     },
     "LSK": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.10000000
     },
     "DCR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.10000000
     },
     "NAUT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00000001
     },
     "NXC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "LTC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00100000
     },
     "NXT": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 1.00000000
     },
     "GAME": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "SBD": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "NOTE": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "FLDC": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 150.00000000
     },
     "VIA": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "EXP": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.01000000
     },
     "XMR": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.05000000
     },
     "NEOS": {
-      "scale": 8
+      "scale": 8,
+      "withdrawal_fee": 0.00010000
     }
   },
   "public_rate_limits": [

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/YoBitAdapters.java
@@ -68,11 +68,12 @@ public class YoBitAdapters {
       Integer priceScale = value.getDecimal_places();
       currencyPairs.put(pair, new CurrencyPairMetaData(value.getFee(), minSize, null, priceScale));
 
-      if (!currencies.containsKey(pair.base))
-        currencies.put(pair.base, new CurrencyMetaData(8));
-
+      if (!currencies.containsKey(pair.base)) {
+    	BigDecimal withdrawalFee = exchangeMetaData.getCurrencies().get(pair.base) == null ? null : exchangeMetaData.getCurrencies().get(pair.base).getWithdrawalFee();
+    	currencies.put(pair.base, new CurrencyMetaData(8, withdrawalFee));
+      }
       if (!currencies.containsKey(pair.counter))
-        currencies.put(pair.counter, new CurrencyMetaData(8));
+        currencies.put(pair.counter, new CurrencyMetaData(8, exchangeMetaData.getCurrencies().get(pair.counter).getWithdrawalFee()));
     }
 
     return exchangeMetaData;


### PR DESCRIPTION
Withdrawals fees are usually fixed and I think they can be part of the currency metadata class.

JSON resource file is currently updated only to 7 exchanges.