### PR TITLE
Poloniex : Implement API function returnOpenLoanOffers 

### DIFF
--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -86,7 +86,7 @@ public class PoloniexAdapters {
 
     for (PoloniexLevel level : levels) {
 
-      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).originalAmount(level.getAmount()).limitPrice(level.getLimit()).build();
+      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).tradableAmount(level.getAmount()).limitPrice(level.getLimit()).build();
       orders.add(limitOrder);
     }
     return orders;
@@ -145,7 +145,7 @@ public class PoloniexAdapters {
       loans.put(item.getKey(), loanOrders);
     }
 
-    return new LoanInfo(loans.get("provided"), loans.get("used"));
+    return new LoanInfo(loans.get("provided"), loans.get("used"), loans.get("opened"));
   }
 
   public static OpenOrders adaptPoloniexOpenOrders(Map<String, PoloniexOpenOrder[]> poloniexOpenOrders) {
@@ -167,7 +167,7 @@ public class PoloniexAdapters {
 
     OrderType type = openOrder.getType().equals("buy") ? OrderType.BID : OrderType.ASK;
     Date timestamp = PoloniexUtils.stringToDate(openOrder.getDate());
-    LimitOrder limitOrder = new LimitOrder.Builder(type, currencyPair).limitPrice(openOrder.getRate()).originalAmount(openOrder.getAmount())
+    LimitOrder limitOrder = new LimitOrder.Builder(type, currencyPair).limitPrice(openOrder.getRate()).tradableAmount(openOrder.getAmount())
         .id(openOrder.getOrderNumber()).timestamp(timestamp).build();
 
     return limitOrder;
@@ -183,19 +183,10 @@ public class PoloniexAdapters {
     String orderId = String.valueOf(userTrade.getOrderNumber());
 
     // Poloniex returns fee as a multiplier, e.g. a 0.2% fee is 0.002
-    // fee currency/size depends on trade direction (buy/sell). It appears to be rounded down
-    final BigDecimal feeAmount;
-    final String feeCurrencyCode;
-    if (orderType == OrderType.ASK) {
-      feeAmount = amount.multiply(price).multiply(userTrade.getFee()).setScale(8, BigDecimal.ROUND_DOWN);
-      feeCurrencyCode = currencyPair.counter.getCurrencyCode();
-    } else {
-      feeAmount = amount.multiply(userTrade.getFee()).setScale(8, BigDecimal.ROUND_DOWN);
-      feeCurrencyCode = currencyPair.base.getCurrencyCode();
-    }
+    BigDecimal feeAmount = amount.multiply(price).multiply(userTrade.getFee());
 
     return new UserTrade(orderType, amount, currencyPair, price, date, tradeId, orderId, feeAmount,
-        Currency.getInstance(feeCurrencyCode));
+        Currency.getInstance(currencyPair.counter.getCurrencyCode()));
   }
 
   public static ExchangeMetaData adaptToExchangeMetaData(Map<String, PoloniexCurrencyInfo> poloniexCurrencyInfo,
@@ -208,7 +199,7 @@ public class PoloniexAdapters {
 
       Currency ccy = Currency.getInstance(entry.getKey());
 
-      if (!currencyMetaDataMap.containsKey(ccy))
+      if(!currencyMetaDataMap.containsKey(ccy))
         currencyMetaDataMap.put(ccy, currencyArchetype);
     }
 
@@ -218,7 +209,7 @@ public class PoloniexAdapters {
     for (String market : poloniexMarketData.keySet()) {
       CurrencyPair currencyPair = PoloniexUtils.toCurrencyPair(market);
 
-      if (!marketMetaDataMap.containsKey(currencyPair))
+      if(!marketMetaDataMap.containsKey(currencyPair))
         marketMetaDataMap.put(currencyPair, marketArchetype);
     }
 

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAdapters.java
@@ -86,7 +86,7 @@ public class PoloniexAdapters {
 
     for (PoloniexLevel level : levels) {
 
-      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).tradableAmount(level.getAmount()).limitPrice(level.getLimit()).build();
+      LimitOrder limitOrder = new LimitOrder.Builder(orderType, currencyPair).originalAmount(level.getAmount()).limitPrice(level.getLimit()).build();
       orders.add(limitOrder);
     }
     return orders;
@@ -167,7 +167,7 @@ public class PoloniexAdapters {
 
     OrderType type = openOrder.getType().equals("buy") ? OrderType.BID : OrderType.ASK;
     Date timestamp = PoloniexUtils.stringToDate(openOrder.getDate());
-    LimitOrder limitOrder = new LimitOrder.Builder(type, currencyPair).limitPrice(openOrder.getRate()).tradableAmount(openOrder.getAmount())
+    LimitOrder limitOrder = new LimitOrder.Builder(type, currencyPair).limitPrice(openOrder.getRate()).originalAmount(openOrder.getAmount())
         .id(openOrder.getOrderNumber()).timestamp(timestamp).build();
 
     return limitOrder;
@@ -183,10 +183,19 @@ public class PoloniexAdapters {
     String orderId = String.valueOf(userTrade.getOrderNumber());
 
     // Poloniex returns fee as a multiplier, e.g. a 0.2% fee is 0.002
-    BigDecimal feeAmount = amount.multiply(price).multiply(userTrade.getFee());
+    // fee currency/size depends on trade direction (buy/sell). It appears to be rounded down
+    final BigDecimal feeAmount;
+    final String feeCurrencyCode;
+    if (orderType == OrderType.ASK) {
+      feeAmount = amount.multiply(price).multiply(userTrade.getFee()).setScale(8, BigDecimal.ROUND_DOWN);
+      feeCurrencyCode = currencyPair.counter.getCurrencyCode();
+    } else {
+      feeAmount = amount.multiply(userTrade.getFee()).setScale(8, BigDecimal.ROUND_DOWN);
+      feeCurrencyCode = currencyPair.base.getCurrencyCode();
+    }
 
     return new UserTrade(orderType, amount, currencyPair, price, date, tradeId, orderId, feeAmount,
-        Currency.getInstance(currencyPair.counter.getCurrencyCode()));
+        Currency.getInstance(feeCurrencyCode));
   }
 
   public static ExchangeMetaData adaptToExchangeMetaData(Map<String, PoloniexCurrencyInfo> poloniexCurrencyInfo,
@@ -199,7 +208,7 @@ public class PoloniexAdapters {
 
       Currency ccy = Currency.getInstance(entry.getKey());
 
-      if(!currencyMetaDataMap.containsKey(ccy))
+      if (!currencyMetaDataMap.containsKey(ccy))
         currencyMetaDataMap.put(ccy, currencyArchetype);
     }
 
@@ -209,7 +218,7 @@ public class PoloniexAdapters {
     for (String market : poloniexMarketData.keySet()) {
       CurrencyPair currencyPair = PoloniexUtils.toCurrencyPair(market);
 
-      if(!marketMetaDataMap.containsKey(currencyPair))
+      if (!marketMetaDataMap.containsKey(currencyPair))
         marketMetaDataMap.put(currencyPair, marketArchetype);
     }
 

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
@@ -5,7 +5,7 @@ import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
+import android.support.annotation.Nullable;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.FormParam;
 import javax.ws.rs.HeaderParam;
@@ -42,7 +42,11 @@ public interface PoloniexAuthenticated {
   @POST
   @FormParam("command")
   HashMap<String, PoloniexLoan[]> returnActiveLoans(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-      @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+                                                    @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+  @POST
+  @FormParam("command")
+  HashMap<String, PoloniexLoan[]> returnOpenLoanOffers(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
+                                                    @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
 
   @POST
   @FormParam("command")

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/PoloniexAuthenticated.java
@@ -42,11 +42,12 @@ public interface PoloniexAuthenticated {
   @POST
   @FormParam("command")
   HashMap<String, PoloniexLoan[]> returnActiveLoans(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-                                                    @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+      @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+
   @POST
   @FormParam("command")
   HashMap<String, PoloniexLoan[]> returnOpenLoanOffers(@HeaderParam("Key") String apiKey, @HeaderParam("Sign") ParamsDigest signature,
-                                                    @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
+      @FormParam("nonce") SynchronizedValueFactory<Long> nonce) throws PoloniexException, IOException;
 
   @POST
   @FormParam("command")

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/LoanInfo.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/LoanInfo.java
@@ -22,14 +22,21 @@ public final class LoanInfo {
   private final List<LoanOrder> usedLoans;
 
   /**
+   * Opened loans
+   */
+  private final List<LoanOrder> openedLoans;
+
+  /**
    * Constructs an {@link LoanInfo}.
    *
    * @param providedLoans provided loans.
    * @param usedLoans used loans.
+   * @param openedLoans open loans.
    */
-  public LoanInfo(List<LoanOrder> providedLoans, List<LoanOrder> usedLoans) {
+  public LoanInfo(List<LoanOrder> providedLoans, List<LoanOrder> usedLoans, List<LoanOrder> openedLoans) {
     this.providedLoans = providedLoans;
     this.usedLoans = usedLoans;
+    this.openedLoans = openedLoans;
   }
 
   public List<LoanOrder> getProvidedLoans() {
@@ -38,6 +45,10 @@ public final class LoanInfo {
 
   public List<LoanOrder> getUsedLoans() {
     return usedLoans;
+  }
+
+  public List<LoanOrder> getOpenedLoans() {
+    return openedLoans;
   }
 
 }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/LoanInfo.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/LoanInfo.java
@@ -31,7 +31,6 @@ public final class LoanInfo {
    *
    * @param providedLoans provided loans.
    * @param usedLoans used loans.
-   * @param openedLoans open loans.
    */
   public LoanInfo(List<LoanOrder> providedLoans, List<LoanOrder> usedLoans, List<LoanOrder> openedLoans) {
     this.providedLoans = providedLoans;

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/account/PoloniexLoan.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/dto/account/PoloniexLoan.java
@@ -46,6 +46,10 @@ public class PoloniexLoan {
     return currency;
   }
 
+  public void setCurrency(String currency) {
+    this.currency = currency;
+  }
+
   public BigDecimal getRate() {
     return rate;
   }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
@@ -2,11 +2,13 @@ package org.knowm.xchange.poloniex.service;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import javax.annotation.Nullable;
+import android.support.annotation.Nullable;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.currency.Currency;
@@ -60,6 +62,16 @@ public class PoloniexAccountServiceRaw extends PoloniexBaseService {
   public LoanInfo getLoanInfo() throws IOException {
     try {
       HashMap<String, PoloniexLoan[]> response = poloniexAuthenticated.returnActiveLoans(apiKey, signatureCreator, exchange.getNonceFactory());
+      HashMap<String, PoloniexLoan[]> response2 = poloniexAuthenticated.returnOpenLoanOffers(apiKey, signatureCreator, exchange.getNonceFactory());
+      ArrayList<PoloniexLoan> poloniexLoans = new ArrayList<PoloniexLoan>();
+      for(Map.Entry<String, PoloniexLoan[]> entry : response2.entrySet()) {
+        for(PoloniexLoan pl : entry.getValue()) {
+          pl.setCurrency(entry.getKey());
+          poloniexLoans.add(pl);
+        }
+      }
+      PoloniexLoan[] pltmp = new PoloniexLoan[poloniexLoans.size()];
+      response.put("opened",poloniexLoans.toArray(pltmp));
       return PoloniexAdapters.adaptPoloniexLoans(response);
     } catch (PoloniexException e) {
       throw new ExchangeException(e.getError(), e);
@@ -83,7 +95,7 @@ public class PoloniexAccountServiceRaw extends PoloniexBaseService {
   /**
    * @param paymentId For XMR withdrawals, you may optionally specify "paymentId".
    */
-  public String withdraw(Currency currency, BigDecimal amount, String address, @Nullable String paymentId) throws IOException {
+  public String withdrawFunds(Currency currency, BigDecimal amount, String address, @Nullable String paymentId) throws IOException {
     return poloniexAuthenticated
         .withdraw(apiKey, signatureCreator, exchange.getNonceFactory(), currency.getCurrencyCode(), amount, address, paymentId).getResponse();
   }

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexAccountServiceRaw.java
@@ -72,8 +72,7 @@ public class PoloniexAccountServiceRaw extends PoloniexBaseService {
       }
       PoloniexLoan[] pltmp = new PoloniexLoan[poloniexLoans.size()];
       response.put("opened",poloniexLoans.toArray(pltmp));
-      return PoloniexAdapters.adaptPoloniexLoans(response);
-    } catch (PoloniexException e) {
+      return PoloniexAdapters.adaptPoloniexLoans(response);    } catch (PoloniexException e) {
       throw new ExchangeException(e.getError(), e);
     }
   }
@@ -95,7 +94,7 @@ public class PoloniexAccountServiceRaw extends PoloniexBaseService {
   /**
    * @param paymentId For XMR withdrawals, you may optionally specify "paymentId".
    */
-  public String withdrawFunds(Currency currency, BigDecimal amount, String address, @Nullable String paymentId) throws IOException {
+  public String withdraw(Currency currency, BigDecimal amount, String address, @Nullable String paymentId) throws IOException {
     return poloniexAuthenticated
         .withdraw(apiKey, signatureCreator, exchange.getNonceFactory(), currency.getCurrencyCode(), amount, address, paymentId).getResponse();
   }


### PR DESCRIPTION
Hello,

This PR, only to implement Poloniex API function returnOpenLoanOffers.
To make it easy to use, I have formatted structure into the function  getLoanInfo which return also active loans, and used loans.

Now this function returns also pending open loans.

How to use it ? 

-See PR https://github.com/timmolter/XChange/pull/1258 to see how to use getLoanInfo
-To get opened loans, just call ...getLoanInfo().getOpenedLoans()

NOTE : I'm using Xchange on Android, so Nullable import is different from original..