### PR TITLE
Bug Fix for Quoine, ticker last price change from LastPrice24h to LastTradedPrice

### DIFF
--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineAdapters.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/QuoineAdapters.java
@@ -36,7 +36,7 @@ public class QuoineAdapters {
     Ticker.Builder builder = new Ticker.Builder();
     builder.ask(quoineTicker.getMarketAsk());
     builder.bid(quoineTicker.getMarketBid());
-    builder.last(quoineTicker.getLastPrice24h());
+    builder.last(quoineTicker.getLastTradedPrice());
     builder.volume(quoineTicker.getVolume24h());
     builder.currencyPair(currencyPair);
     return builder.build();

--- a/xchange-quoine/src/test/java/org/knowm/xchange/quoine/dto/QuoineAdaptersTest.java
+++ b/xchange-quoine/src/test/java/org/knowm/xchange/quoine/dto/QuoineAdaptersTest.java
@@ -42,7 +42,7 @@ public class QuoineAdaptersTest {
     // Verify that the example data was unmarshalled correctly
     assertThat(ticker.getAsk()).isEqualTo(new BigDecimal("227.09383"));
     assertThat(ticker.getBid()).isEqualTo(new BigDecimal("226.78383"));
-    assertThat(ticker.getLast()).isEqualTo(new BigDecimal("227.38976"));
+    assertThat(ticker.getLast()).isEqualTo(new BigDecimal("227.38586"));
     assertThat(ticker.getVolume()).isEqualTo(new BigDecimal("0.16"));
     assertThat(ticker.getCurrencyPair()).isEqualTo(CurrencyPair.BTC_USD);
   }


### PR DESCRIPTION
Bug Fix for Quoine, ticker last price change from LastPrice24h to LastTradedPrice

Before this fix

Ticker [currencyPair=BTC/USD, open=null, **last=5948.35**, bid=6669.81, ask=6730.0, high=null, low=null,avg=null, volume=1207.39716996, timestamp=null]

QuoineProduct{id=1, productType='CurrencyPair', code='CASH', name=' CASH Trading', marketAsk=6730.0, marketBid=6669.81, indicator=1, currencyPairId='null', currency='USD', currencyPairCode='BTCUSD', symbol='$', btcMinimumWithdraw=0.02, fiatMinimumWithdraw=15.0, pusherChannel='product_cash_btcusd_1', takerFee=0.0, makerFee=0.0, lowMarketBid=5886.2, highMarketAsk=6775.60145, volume24h=1207.39716996, **lastPrice24h=5948.35**, cashSpotAsk=null, cashSpotBid=null, **lastTradedPrice=6730.0**, quotedCurrency='USD', baseCurrency='BTC'}
