### PR TITLE
TheRock: add all query parameters for /orders request

### DIFF
--- a/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/trade/TheRockTradeRawDemo.java
+++ b/xchange-examples/src/main/java/org/knowm/xchange/examples/therock/trade/TheRockTradeRawDemo.java
@@ -39,9 +39,19 @@ public class TheRockTradeRawDemo {
     print(orderResult);
     Thread.sleep(3000);
 
-    //get-orders
+    //get-orders (without any parameters besides pair, only open orders will be returned)
     TheRockOrders orders = tradeService.getTheRockOrders(BTC_EUR);
     print(orders);
+    Thread.sleep(3000);
+
+    //get execute orders, only page 1
+    TheRockOrders executedOrders = tradeService.getTheRockOrders(BTC_EUR,null,null,"executed",null,null,1);
+    print(executedOrders);
+    Thread.sleep(3000);
+
+    //get only executed sell order, starting on page 3
+    TheRockOrders execSellOrders = tradeService.getTheRockOrders(BTC_EUR,null,null,"executed",Side.sell,null,1);
+    print(execSellOrders);
     Thread.sleep(3000);
 
     //cancel

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAuthenticated.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/TheRockAuthenticated.java
@@ -76,6 +76,15 @@ public interface TheRockAuthenticated {
       @HeaderParam(X_TRT_NONCE) SynchronizedValueFactory<Long> nonceFactory) throws TheRockException, IOException;
 
   @GET
+  @Path("funds/{fund_id}/orders")
+  TheRockOrders orders(@PathParam("fund_id") TheRock.Pair currencyPair, @HeaderParam(X_TRT_KEY) String publicKey,
+      @HeaderParam(X_TRT_SIGN) TheRockDigest signer,
+      @HeaderParam(X_TRT_NONCE) SynchronizedValueFactory<Long> nonceFactory,
+      @QueryParam("after") Date after, @QueryParam("before") Date before, @QueryParam("status") String status,
+      @QueryParam("side") TheRockOrder.Side side, @QueryParam("position_id") Long positionId, @QueryParam("page") int page
+  ) throws TheRockException, IOException;
+
+  @GET
   @Path("funds/{fund_id}/orders/{id}")
   TheRockOrder showOrder(@PathParam("fund_id") TheRock.Pair currencyPair, @PathParam("id") Long orderId, @HeaderParam(X_TRT_KEY) String publicKey,
       @HeaderParam(X_TRT_SIGN) TheRockDigest signer,

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeServiceRaw.java
@@ -62,6 +62,19 @@ public class TheRockTradeServiceRaw extends TheRockBaseService {
     }
   }
 
+  public TheRockOrders getTheRockOrders(CurrencyPair currencyPair, Date after, Date before, String status, TheRockOrder.Side side,
+      Long positionId, int page) throws TheRockException, IOException {
+    try {
+      return theRockAuthenticated.orders(new TheRock.Pair(currencyPair),
+          exchange.getExchangeSpecification().getApiKey(), signatureCreator,
+          exchange.getNonceFactory(),
+          after, before, status, side, positionId, page
+      );
+    } catch (TheRockException e) {
+      throw new ExchangeException(e);
+    }
+  }
+
   public TheRockOrder showTheRockOrder(CurrencyPair currencyPair, Long orderId) throws TheRockException, IOException {
     try {
       return theRockAuthenticated.showOrder(new TheRock.Pair(currencyPair), orderId, exchange.getExchangeSpecification().getApiKey(),


### PR DESCRIPTION
Until now the implementation only contains a single "orders" method,
which accepts only a single argument (the fundId/tradingPair).

This commit adds a second "orders" method, which supports all query
parameters supported by the "/v1/funds/:fund_id/orders" API endpoint:

- "after" (filter orders after a certain timestamp)
- "before" (filter orders before a certain timestamp)
- "status" (accepted values are: active, conditional, executed)
- "side" (filter orders by side. Accepted values are: buy, sell)
- "position_id" (filter orders by margin position ID)
- "page" (used for pagination, if results are more than 1 page)

See API-documentation here:
https://api.therocktrading.com/doc/v1/index.html#api-Trading_API-ListOrders