### PR TITLE
fixed filled amount

### DIFF
--- a/xchange-liqui/pom.xml
+++ b/xchange-liqui/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>xchange-liqui_custom</artifactId>
+    <artifactId>xchange-liqui</artifactId>
 
     <name>XChange Liqui</name>
     <description>XChange implementation for the Liqui.io Exchange</description>

--- a/xchange-liqui/pom.xml
+++ b/xchange-liqui/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>xchange-liqui</artifactId>
+    <artifactId>xchange-liqui_custom</artifactId>
 
     <name>XChange Liqui</name>
     <description>XChange implementation for the Liqui.io Exchange</description>

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/LiquiAdapters.java
@@ -117,7 +117,7 @@ public class LiquiAdapters {
         final OrderType type = adaptOrderType(orderInfo.getType());
 
         final BigDecimal originalAmount = orderInfo.getStartAmount();
-        final BigDecimal filledAmount = orderInfo.getAmount();
+        final BigDecimal filledAmount = orderInfo.getStartAmount().subtract(orderInfo.getAmount());
         final CurrencyPair pair = orderInfo.getPair();
         final Date timestamp = new Date(orderInfo.getTimestampCreated() * 1000L);
 


### PR DESCRIPTION
From liqui spec:

start_amount: The initial amount at the time of order creation.
amount: The remaining amount of currency to be bought/sold.