### PR TITLE
[core] fix Currency equals/hashCode for deserialized objects

### DIFF
--- a/xchange-core/pom.xml
+++ b/xchange-core/pom.xml
@@ -34,6 +34,12 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        
+         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
+        </dependency>
 
     </dependencies>
 </project>

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -437,13 +437,13 @@ public class Currency implements Comparable<Currency>, Serializable {
     }
     Currency other = (Currency) obj;
 
-    return attributes == other.attributes;
+    return attributes.equals(other.attributes);
   }
 
   @Override
   public int compareTo(Currency o) {
 
-    if (attributes == o.attributes)
+    if (attributes.equals(o.attributes))
       return 0;
 
     int comparison = code.compareTo(o.code);
@@ -510,5 +510,28 @@ public class Currency implements Comparable<Currency>, Serializable {
         this.unicode = commonCode;
       }
     }
+
+    @Override
+    public int hashCode() {
+        return commonCode.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        CurrencyAttributes other = (CurrencyAttributes) obj;
+        if (commonCode == null) {
+            if (other.commonCode != null)
+                return false;
+        } else if (!commonCode.equals(other.commonCode))
+            return false;
+        return true;
+    }
+
   }
 }

--- a/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
@@ -1,7 +1,9 @@
 package org.knowm.xchange;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
 
@@ -25,5 +27,16 @@ public class CurrencyTest {
     assertEquals(Currency.CNY, Currency.getInstanceNoCreate("CNY"));
     assertEquals(Currency.CNY, Currency.getInstanceNoCreate("cny"));
     assertEquals(new Currency("cny"), Currency.getInstanceNoCreate("CNY"));
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(Currency.BTC, Currency.XBT);
+    assertNotEquals(Currency.LTC, Currency.XBT);
+    
+    Currency btc = SerializationUtils.deserialize(SerializationUtils.serialize(Currency.BTC));
+    assertEquals(Currency.BTC, btc);
+    assertEquals(Currency.XBT, btc);
+    assertNotEquals(Currency.LTC, btc);
   }
 }


### PR DESCRIPTION
The current equal() implementation doesn't work when using deserialized objects, this change fixes it.   (also fixes #1782)