### PR TITLE
Respect Bittrex' usage of BCC for BitcoinCash

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/BittrexUtils.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 
@@ -25,7 +26,17 @@ public final class BittrexUtils {
   }
 
   public static String toPairString(CurrencyPair currencyPair) {
-    return currencyPair.counter.getCurrencyCode().toUpperCase() + "-" + currencyPair.base.getCurrencyCode().toUpperCase();
+    return toBittrexCurrency(currencyPair.counter) + "-" + toBittrexCurrency(currencyPair.base);
+  }
+
+  public static String toBittrexCurrency(Currency currency) {
+    if (currency == null) {
+      return null;
+    }
+    if (currency.equals(Currency.BCH)) {
+      return "BCC";
+    }
+    return currency.getCurrencyCode().toUpperCase();
   }
 
   public static Date toDate(String dateString) {

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bittrex.BittrexAdapters;
+import org.knowm.xchange.bittrex.BittrexUtils;
 import org.knowm.xchange.bittrex.dto.account.BittrexDepositHistory;
 import org.knowm.xchange.bittrex.dto.account.BittrexWithdrawalHistory;
 import org.knowm.xchange.currency.Currency;
@@ -43,14 +44,14 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
   @Override
   public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
 
-    return withdraw(currency.getCurrencyCode(), amount, address, null);
+    return withdraw(BittrexUtils.toBittrexCurrency(currency), amount, address, null);
   }
 
   @Override
   public String withdrawFunds(WithdrawFundsParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (params instanceof RippleWithdrawFundsParams) {
       RippleWithdrawFundsParams defaultParams = (RippleWithdrawFundsParams) params;
-      return withdraw(defaultParams.currency.getCurrencyCode(), defaultParams.amount, defaultParams.address, defaultParams.tag);
+      return withdraw(BittrexUtils.toBittrexCurrency(defaultParams.currency), defaultParams.amount, defaultParams.address, defaultParams.tag);
     }
     if (params instanceof DefaultWithdrawFundsParams) {
       DefaultWithdrawFundsParams defaultParams = (DefaultWithdrawFundsParams) params;
@@ -84,7 +85,7 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
       res.add(new FundingRecord(
           depositHistory.getCryptoAddress(),
           depositHistory.getLastUpdated(),
-          Currency.getInstance(depositHistory.getCurrency()),
+          BittrexAdapters.adaptCurrency(depositHistory.getCurrency()),
           depositHistory.getAmount(),
           String.valueOf(depositHistory.getId()),
           depositHistory.getTxId(),
@@ -114,7 +115,7 @@ public class BittrexAccountService extends BittrexAccountServiceRaw implements A
       res.add(new FundingRecord(
           withdrawalHistory.getAddress(),
           withdrawalHistory.getOpened(),
-          Currency.getInstance(withdrawalHistory.getCurrency()),
+          BittrexAdapters.adaptCurrency(withdrawalHistory.getCurrency()),
           withdrawalHistory.getAmount(),
           withdrawalHistory.getPaymentUuid(),
           withdrawalHistory.getTxId(),

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexAccountServiceRaw.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bittrex.BittrexUtils;
 import org.knowm.xchange.bittrex.dto.account.BittrexBalance;
 import org.knowm.xchange.bittrex.dto.account.BittrexBalanceResponse;
 import org.knowm.xchange.bittrex.dto.account.BittrexBalancesResponse;
@@ -43,9 +44,8 @@ public class BittrexAccountServiceRaw extends BittrexBaseService {
   }
 
   public BittrexBalance getBittrexBalance(Currency currency) throws IOException {
-    BittrexBalanceResponse response = bittrexAuthenticated.getBalance(apiKey, signatureCreator, exchange.getNonceFactory(), currency == null ? null
-        : currency.getCurrencyCode());
-    System.out.println(currency.getCurrencyCode());
+    BittrexBalanceResponse response = bittrexAuthenticated.getBalance(apiKey, signatureCreator, exchange.getNonceFactory(),
+        BittrexUtils.toBittrexCurrency(currency));
     if (response.getSuccess()) {
       return response.getResult();
     } else {
@@ -75,7 +75,8 @@ public class BittrexAccountServiceRaw extends BittrexBaseService {
 
   public List<BittrexWithdrawalHistory> getWithdrawalsHistory(Currency currency) throws IOException {
 
-    BittrexWithdrawalsHistoryResponse response = bittrexAuthenticated.getwithdrawalhistory(apiKey, signatureCreator, exchange.getNonceFactory(), currency == null ? null : currency.getCurrencyCode());
+    BittrexWithdrawalsHistoryResponse response = bittrexAuthenticated.getwithdrawalhistory(apiKey, signatureCreator, exchange.getNonceFactory(),
+        BittrexUtils.toBittrexCurrency(currency));
     if (response.getSuccess()) {
       return response.getResult();
     } else {
@@ -85,7 +86,8 @@ public class BittrexAccountServiceRaw extends BittrexBaseService {
 
   public List<BittrexDepositHistory> getDepositsHistory(Currency currency) throws IOException {
 
-    BittrexDepositsHistoryResponse response = bittrexAuthenticated.getdeposithistory(apiKey, signatureCreator, exchange.getNonceFactory(), currency == null ? null : currency.getCurrencyCode());
+    BittrexDepositsHistoryResponse response = bittrexAuthenticated.getdeposithistory(apiKey, signatureCreator, exchange.getNonceFactory(),
+        BittrexUtils.toBittrexCurrency(currency));
     if (response.getSuccess()) {
       return response.getResult();
     } else {

--- a/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/currency/Currency.java
@@ -39,7 +39,7 @@ public class Currency implements Comparable<Currency>, Serializable {
   public static final Currency BBD = createCurrency("BBD", "Barbadian Dollar", null);
   public static final Currency BC = createCurrency("BC", "BlackCoin", null, "BLK");
   public static final Currency BCC = createCurrency("BCC", "BitConnect", null);
-  public static final Currency BCH = createCurrency("BCH", "BitcoinCash", null);
+  public static final Currency BCH = createCurrency("BCH", "BitcoinCash", null, "BCC");
   public static final Currency BLK = getInstance("BLK");
   public static final Currency BDT = createCurrency("BDT", "Bangladeshi Taka", null);
   public static final Currency BGC = createCurrency("BGC", "Aten 'Black Gold' Coin", null);

--- a/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
+++ b/xchange-core/src/test/java/org/knowm/xchange/CurrencyTest.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.junit.Test;
 import org.knowm.xchange.currency.Currency;
@@ -25,5 +26,11 @@ public class CurrencyTest {
     assertEquals(Currency.CNY, Currency.getInstanceNoCreate("CNY"));
     assertEquals(Currency.CNY, Currency.getInstanceNoCreate("cny"));
     assertEquals(new Currency("cny"), Currency.getInstanceNoCreate("CNY"));
+  }
+
+  @Test
+  public void testBCashVsBitConnect() throws Exception {
+    assertEquals(Currency.getInstance("BCC"), Currency.BCC);
+    assertNotEquals(Currency.BCC, Currency.BCH.getCodeCurrency("BCC"));
   }
 }


### PR DESCRIPTION
XChange detected BitcoinCash as BitConnect for Bittrex. These two commits should fix that.

The `Currency` instance for BitcoinCash will still return the currency code "BCC" when created by a call to the Bittrex Service.

(Sorry about replacing the entire file for `BittrexUtils`. It was originally using CRLF.)