### PR TITLE
[core, Binance, TheRock, LiveCoin, YoBit, all] CancelOrderParams changes

### DIFF
--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXTradeService.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/service/ANXTradeService.java
@@ -90,11 +90,11 @@ public class ANXTradeService extends ANXTradeServiceRaw implements TradeService 
 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
-
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   private UserTrades getTradeHistory(Long from, Long to) throws IOException {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceCancelOrderParams.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceCancelOrderParams.java
@@ -1,15 +1,25 @@
 package org.knowm.xchange.binance.service;
 
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.service.trade.params.CancelOrderParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 
-public class BinanceCancelOrderParams implements CancelOrderParams {
-
-  public final CurrencyPair pair;
-  public final String orderId;
+public class BinanceCancelOrderParams implements CancelOrderByIdParams, CancelOrderByCurrencyPair {
+  private final String orderId;
+  private final CurrencyPair pair;
 
   public BinanceCancelOrderParams(CurrencyPair pair, String orderId) {
     this.pair = pair;
     this.orderId = orderId;
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return pair;
+  }
+
+  @Override
+  public String getOrderId() {
+    return orderId;
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
@@ -24,6 +24,8 @@ import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamLimit;
@@ -79,11 +81,13 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
 
   @Override
   public boolean cancelOrder(CancelOrderParams params) throws IOException {
-    if (!(params instanceof BinanceCancelOrderParams)) {
+    if (!(params instanceof CancelOrderByCurrencyPair) && !(params instanceof CancelOrderByIdParams)) {
       throw new ExchangeException("You need to provide the currency pair and the order id to cancel an order.");
     }
-    BinanceCancelOrderParams p = (BinanceCancelOrderParams) params;
-    super.cancelOrder(BinanceAdapters.toSymbol(p.pair), BinanceAdapters.id(p.orderId), null, null, null, System.currentTimeMillis());
+    CancelOrderByCurrencyPair paramCurrencyPair = (CancelOrderByCurrencyPair) params;
+    CancelOrderByIdParams paramId = (CancelOrderByIdParams) params;
+    super.cancelOrder(BinanceAdapters.toSymbol(paramCurrencyPair.getCurrencyPair()), BinanceAdapters.id(paramId.getOrderId()), null, null,
+        null, System.currentTimeMillis());
     return true;
   }
 

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayTradeService.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayTradeService.java
@@ -74,10 +74,10 @@ public class BitbayTradeService extends BitbayTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
-
   }
 
   @Override

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
@@ -104,9 +104,10 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/BitMarketTradeService.java
+++ b/xchange-bitmarket/src/main/java/org/knowm/xchange/bitmarket/service/BitMarketTradeService.java
@@ -74,9 +74,10 @@ public class BitMarketTradeService extends BitMarketTradeServiceRaw implements T
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeService.java
+++ b/xchange-bitso/src/main/java/org/knowm/xchange/bitso/service/BitsoTradeService.java
@@ -98,9 +98,10 @@ public class BitsoTradeService extends BitsoTradeServiceRaw implements TradeServ
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
+++ b/xchange-bitstamp/src/main/java/org/knowm/xchange/bitstamp/service/BitstampTradeService.java
@@ -93,11 +93,10 @@ public class BitstampTradeService extends BitstampTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
-    } else if (orderParams instanceof CancelAllOrders) {
-      cancelAllBitstampOrders();
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeService.java
@@ -76,9 +76,10 @@ public class BittrexTradeService extends BittrexTradeServiceRaw implements Trade
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeService.java
+++ b/xchange-bleutrade/src/main/java/org/knowm/xchange/bleutrade/service/BleutradeTradeService.java
@@ -73,9 +73,10 @@ public class BleutradeTradeService extends BleutradeTradeServiceRaw implements T
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeService.java
+++ b/xchange-btcmarkets/src/main/java/org/knowm/xchange/btcmarkets/service/BTCMarketsTradeService.java
@@ -80,9 +80,10 @@ public class BTCMarketsTradeService extends BTCMarketsTradeServiceRaw implements
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeTradeService.java
+++ b/xchange-btctrade/src/main/java/org/knowm/xchange/btctrade/service/BTCTradeTradeService.java
@@ -78,9 +78,10 @@ public class BTCTradeTradeService extends BTCTradeTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXTradeService.java
+++ b/xchange-campbx/src/main/java/org/knowm/xchange/campbx/service/CampBXTradeService.java
@@ -131,9 +131,10 @@ public class CampBXTradeService extends CampBXTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   private String composeOrderId(String id, Order.OrderType orderType) {

--- a/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXTradeService.java
+++ b/xchange-ccex/src/main/java/org/knowm/xchange/ccex/service/CCEXTradeService.java
@@ -60,9 +60,10 @@ public class CCEXTradeService extends CCEXTradeServiceRaw implements TradeServic
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeService.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOTradeService.java
@@ -85,9 +85,10 @@ public class CexIOTradeService extends CexIOTradeServiceRaw implements TradeServ
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorTradeService.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorTradeService.java
@@ -51,8 +51,8 @@ public class CoinfloorTradeService extends CoinfloorTradeServiceRaw implements T
   }
 
   @Override
-  public OpenOrders getOpenOrders(
-      OpenOrdersParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public OpenOrders getOpenOrders(OpenOrdersParams params)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     CurrencyPair pair;
     if (params instanceof OpenOrdersParamCurrencyPair) {
       pair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
@@ -169,38 +169,40 @@ public class CoinfloorTradeService extends CoinfloorTradeServiceRaw implements T
   }
 
   @Override
-  public String placeLimitOrder(
-      LimitOrder order) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public String placeLimitOrder(LimitOrder order)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     CoinfloorOrder rawOrder = placeLimitOrder(order.getCurrencyPair(), order.getType(), order.getOriginalAmount(), order.getLimitPrice());
     return Long.toString(rawOrder.getId());
   }
 
   @Override
-  public String placeMarketOrder(
-      MarketOrder order) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public String placeMarketOrder(MarketOrder order)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     placeMarketOrder(order.getCurrencyPair(), order.getType(), order.getOriginalAmount());
     return ""; // coinfloor does not return an id for market orders
   }
 
   @Override
-  public boolean cancelOrder(
-      String orderId) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public boolean cancelOrder(String orderId)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     // API requires currency pair but value seems to be ignored - only the order ID is used for lookup. 
     CurrencyPair currencyPairValueIsIgnored = CurrencyPair.BTC_GBP;
     return cancelOrder(currencyPairValueIsIgnored, Long.parseLong(orderId));
   }
 
   @Override
-  public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public boolean cancelOrder(CancelOrderParams orderParams)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override
-  public Collection<Order> getOrder(
-      String... orderIds) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public Collection<Order> getOrder(String... orderIds)
+      throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     throw new NotYetImplementedForExchangeException();
   }
 

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeService.java
@@ -116,9 +116,10 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelAllOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelAllOrders.java
@@ -1,4 +1,0 @@
-package org.knowm.xchange.service.trade.params;
-
-public class CancelAllOrders implements CancelOrderParams {
-}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByCurrencyPair.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.service.trade.params;
+
+import org.knowm.xchange.currency.CurrencyPair;
+
+public interface CancelOrderByCurrencyPair extends CancelOrderParams {
+
+  public CurrencyPair getCurrencyPair();
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByIdParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/CancelOrderByIdParams.java
@@ -1,13 +1,5 @@
 package org.knowm.xchange.service.trade.params;
 
-public class CancelOrderByIdParams implements CancelOrderParams {
-  public final String orderId;
-
-  public CancelOrderByIdParams(String orderId) {
-    this.orderId = orderId;
-  }
-
-  public String getOrderId() {
-    return orderId;
-  }
+public interface CancelOrderByIdParams extends CancelOrderParams {
+  String getOrderId();
 }

--- a/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesTradeService.java
+++ b/xchange-cryptofacilities/src/main/java/org/knowm/xchange/cryptofacilities/service/CryptoFacilitiesTradeService.java
@@ -68,9 +68,10 @@ public class CryptoFacilitiesTradeService extends CryptoFacilitiesTradeServiceRa
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaTradeService.java
+++ b/xchange-cryptopia/src/main/java/org/knowm/xchange/cryptopia/service/CryptopiaTradeService.java
@@ -62,7 +62,7 @@ public class CryptopiaTradeService extends CryptopiaTradeServiceRaw implements T
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
       CancelOrderByIdParams params = (CancelOrderByIdParams) orderParams;
-      return cancel(params.orderId);
+      return cancel(params.getOrderId());
     } else {
       throw new IllegalStateException("Dont understand " + orderParams);
     }

--- a/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXTradeService.java
+++ b/xchange-dsx/src/main/java/org/knowm/xchange/dsx/service/DSXTradeService.java
@@ -98,9 +98,10 @@ public class DSXTradeService extends DSXTradeServiceRaw implements TradeService 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   public boolean cancelAllOrders() throws IOException {

--- a/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/EmpoExTradeService.java
+++ b/xchange-empoex/src/main/java/org/knowm/xchange/empoex/service/EmpoExTradeService.java
@@ -68,9 +68,10 @@ public class EmpoExTradeService extends EmpoExTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinTradeService.java
+++ b/xchange-gatecoin/src/main/java/org/knowm/xchange/gatecoin/service/GatecoinTradeService.java
@@ -117,9 +117,10 @@ public class GatecoinTradeService extends GatecoinTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeService.java
+++ b/xchange-gateio/src/main/java/org/knowm/xchange/gateio/service/GateioTradeService.java
@@ -82,9 +82,10 @@ public class GateioTradeService extends GateioTradeServiceRaw implements TradeSe
   public boolean cancelOrder(
       CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
@@ -72,9 +72,10 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements TradeServic
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
+++ b/xchange-gemini/src/main/java/org/knowm/xchange/gemini/v1/service/GeminiTradeService.java
@@ -87,9 +87,10 @@ public class GeminiTradeService extends GeminiTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
@@ -61,11 +61,11 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveTradeService.java
@@ -82,9 +82,10 @@ public class IndependentReserveTradeService extends IndependentReserveTradeServi
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitTradeService.java
@@ -87,9 +87,10 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements TradeServ
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeService.java
+++ b/xchange-kraken/src/main/java/org/knowm/xchange/kraken/service/KrakenTradeService.java
@@ -67,9 +67,10 @@ public class KrakenTradeService extends KrakenTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCTradeService.java
+++ b/xchange-lakebtc/src/main/java/org/knowm/xchange/lakebtc/service/LakeBTCTradeService.java
@@ -64,9 +64,10 @@ public class LakeBTCTradeService extends LakeBTCTradeServiceRaw implements Trade
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeService.java
+++ b/xchange-liqui/src/main/java/org/knowm/xchange/liqui/service/LiquiTradeService.java
@@ -74,9 +74,10 @@ public class LiquiTradeService extends LiquiTradeServiceRaw implements TradeServ
   @Override
   public boolean cancelOrder(final CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoTradeService.java
+++ b/xchange-luno/src/main/java/org/knowm/xchange/luno/service/LunoTradeService.java
@@ -112,9 +112,10 @@ public class LunoTradeService extends LunoBaseService implements TradeService {
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeService.java
+++ b/xchange-mercadobitcoin/src/main/java/org/knowm/xchange/mercadobitcoin/service/MercadoBitcoinTradeService.java
@@ -131,9 +131,10 @@ public class MercadoBitcoinTradeService extends MercadoBitcoinTradeServiceRaw im
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinFuturesTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinFuturesTradeService.java
@@ -170,9 +170,10 @@ public class OkCoinFuturesTradeService extends OkCoinTradeServiceRaw implements 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinTradeService.java
+++ b/xchange-okcoin/src/main/java/org/knowm/xchange/okcoin/service/OkCoinTradeService.java
@@ -135,9 +135,10 @@ public class OkCoinTradeService extends OkCoinTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeService.java
+++ b/xchange-poloniex/src/main/java/org/knowm/xchange/poloniex/service/PoloniexTradeService.java
@@ -105,9 +105,10 @@ public class PoloniexTradeService extends PoloniexTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxTradeService.java
+++ b/xchange-quadrigacx/src/main/java/org/knowm/xchange/quadrigacx/service/QuadrigaCxTradeService.java
@@ -122,9 +122,10 @@ public class QuadrigaCxTradeService extends QuadrigaCxTradeServiceRaw implements
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineTradeService.java
+++ b/xchange-quoine/src/main/java/org/knowm/xchange/quoine/service/QuoineTradeService.java
@@ -81,9 +81,10 @@ public class QuoineTradeService extends QuoineTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleTradeService.java
+++ b/xchange-ripple/src/main/java/org/knowm/xchange/ripple/service/RippleTradeService.java
@@ -84,10 +84,10 @@ public class RippleTradeService extends RippleTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      CancelOrderByIdParams params = (CancelOrderByIdParams) orderParams;
-      return cancelOrder(params.orderId, ripple.validateOrderRequests());
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusTradeService.java
+++ b/xchange-taurus/src/main/java/org/knowm/xchange/taurus/service/TaurusTradeService.java
@@ -83,9 +83,10 @@ public class TaurusTradeService extends TaurusTradeServiceRaw implements TradeSe
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/dto/TheRockCancelOrderParams.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/dto/TheRockCancelOrderParams.java
@@ -1,14 +1,25 @@
 package org.knowm.xchange.therock.dto;
 
 import org.knowm.xchange.currency.CurrencyPair;
-import org.knowm.xchange.service.trade.params.CancelOrderParams;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 
-public class TheRockCancelOrderParams implements CancelOrderParams {
+public class TheRockCancelOrderParams implements CancelOrderByIdParams, CancelOrderByCurrencyPair {
   public final CurrencyPair currencyPair;
   public final Long orderId;
 
   public TheRockCancelOrderParams(CurrencyPair currencyPair, Long orderId) {
     this.currencyPair = currencyPair;
     this.orderId = orderId;
+  }
+
+  @Override
+  public CurrencyPair getCurrencyPair() {
+    return currencyPair;
+  }
+
+  @Override
+  public String getOrderId() {
+    return orderId.toString();
   }
 }

--- a/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeService.java
+++ b/xchange-therock/src/main/java/org/knowm/xchange/therock/service/TheRockTradeService.java
@@ -15,6 +15,8 @@ import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
+import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
+import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
@@ -25,7 +27,7 @@ import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 import org.knowm.xchange.therock.TheRockAdapters;
 import org.knowm.xchange.therock.TheRockExchange;
-import org.knowm.xchange.therock.dto.TheRockCancelOrderParams;
+import org.knowm.xchange.therock.dto.TheRockException;
 import org.knowm.xchange.therock.dto.trade.TheRockOrder;
 
 /**
@@ -86,17 +88,31 @@ public class TheRockTradeService extends TheRockTradeServiceRaw implements Trade
       throw new ExchangeException("Provide TheRockCancelOrderParams with orderId and currencyPair");
     }
 
-    return cancelOrder(new TheRockCancelOrderParams(cp, Long.parseLong(orderId)));
+    return cancelOrder(cp, orderId);
   }
 
   @Override
-  public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    if (orderParams instanceof TheRockCancelOrderParams) {
-      TheRockCancelOrderParams params = (TheRockCancelOrderParams) orderParams;
-      TheRockOrder cancelledOrder = cancelTheRockOrder(params.currencyPair, params.orderId);
-      return "deleted".equals(cancelledOrder.getStatus());
+  public boolean cancelOrder(
+      CancelOrderParams params) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+    if (!(params instanceof CancelOrderByIdParams)) {
+      return false;
     }
-    return false;
+    CancelOrderByIdParams paramId = (CancelOrderByIdParams) params;
+
+    CurrencyPair currencyPair;
+    if (params instanceof CancelOrderByCurrencyPair) {
+      CancelOrderByCurrencyPair paramCurrencyPair = (CancelOrderByCurrencyPair) params;
+      currencyPair = paramCurrencyPair.getCurrencyPair();
+    } else {
+      currencyPair = null;
+    }
+
+    return cancelOrder(currencyPair, paramId.getOrderId());
+  }
+
+  private boolean cancelOrder(CurrencyPair currencyPair, String orderId) throws TheRockException, NumberFormatException, IOException {
+    TheRockOrder cancelledOrder = cancelTheRockOrder(currencyPair, Long.parseLong(orderId));
+    return "deleted".equals(cancelledOrder.getStatus());
   }
 
   /**

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroTradeService.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroTradeService.java
@@ -52,9 +52,10 @@ public class VaultoroTradeService extends VaultoroTradeServiceRaw implements Tra
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   @Override

--- a/xchange-wex/src/main/java/org/knowm/xchange/wex/v3/service/WexTradeService.java
+++ b/xchange-wex/src/main/java/org/knowm/xchange/wex/v3/service/WexTradeService.java
@@ -101,9 +101,10 @@ public class WexTradeService extends WexTradeServiceRaw implements TradeService 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      cancelOrder(((CancelOrderByIdParams) orderParams).orderId);
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-    return false;
   }
 
   /**

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitTradeService.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitTradeService.java
@@ -72,20 +72,16 @@ public class YoBitTradeService extends YoBitTradeServiceRaw {
 
   @Override
   public boolean cancelOrder(String orderId) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    return cancelOrder((CancelOrderParams) new CancelOrderByIdParams(orderId));
+    return cancelOrderById(orderId).success;
   }
 
   @Override
   public boolean cancelOrder(CancelOrderParams orderParams) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
     if (orderParams instanceof CancelOrderByIdParams) {
-      CancelOrderByIdParams params = (CancelOrderByIdParams) orderParams;
-
-      BaseYoBitResponse response = cancelOrder(params);
-
-      return response.success;
+      return cancelOrder(((CancelOrderByIdParams) orderParams).getOrderId());
+    } else {
+      return false;
     }
-
-    throw new IllegalStateException("Need to specify order id");
   }
 
   @Override

--- a/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitTradeServiceRaw.java
+++ b/xchange-yobit/src/main/java/org/knowm/xchange/yobit/service/YoBitTradeServiceRaw.java
@@ -77,12 +77,17 @@ public abstract class YoBitTradeServiceRaw extends YoBitBaseService<YoBit> imple
 
   public BaseYoBitResponse cancelOrder(CancelOrderByIdParams params) throws IOException {
 
+    return cancelOrderById(params.getOrderId());
+  }
+
+  protected BaseYoBitResponse cancelOrderById(String orderId) throws IOException {
+
     return service.cancelOrder(
         exchange.getExchangeSpecification().getApiKey(),
         signatureCreator,
         "CancelOrder",
         exchange.getNonceFactory(),
-        Long.valueOf(params.getOrderId())
+        Long.valueOf(orderId)
     );
   }
 


### PR DESCRIPTION
As mentioned in  #1963, I'd like to slightly re-work the CancelOrderParams interface so that it is not so closely tied to exchange specific implementations and can also be re-used between orders. 

This change effects all implementations, in most cases the change is trivial to the TradeService's cancelOrder(CancelOrderParams orderParams) method. For Binance, TheRock, LiveCoin and YoBit I've had to make some small additional changes to fit what was already there in with the new interfaces. 

I've not got connections for TheRock, LiveCoin or YoBit so have not been able to verify these. Binance and my other connections are working fine for me. 

- CancelOrderByIdParams changed from class to interface
- CancelAllOrders deleted - it wasn't being used
- added CancelOrderByCurrencyPair interface
