### PR TITLE
Introduce ticker information into Independent Reserve market plugin

### DIFF
--- a/xchange-independentreserve/pom.xml
+++ b/xchange-independentreserve/pom.xml
@@ -31,4 +31,5 @@
 
     </dependencies>
 
+    <version>4.3.3-SNAPSHOT</version>
 </project>

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserve.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserve.java
@@ -8,6 +8,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTicker;
 import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveOrderBook;
 
 /**
@@ -21,6 +22,11 @@ public interface IndependentReserve {
   @Path("/GetOrderBook")
   IndependentReserveOrderBook getOrderBook(@QueryParam("primaryCurrencyCode") String primaryCurrencyCode,
       @QueryParam("secondaryCurrencyCode") String secondaryCurrencyCode) throws IOException;
+  
+  @GET
+  @Path("/GetMarketSummary")
+  IndependentReserveTicker getMarketSummary(@QueryParam("primaryCurrencyCode") String primaryCurrencyCode,
+      @QueryParam("secondaryCurrencyCode") String secondaryCurrencyCode) throws IOException;  
 
   //    @GET
   //    @Path("ticker/")

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/IndependentReserveAdapters.java
@@ -3,10 +3,12 @@ package org.knowm.xchange.independentreserve;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.math.BigDecimal;
 
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
+import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.Wallet;
 import org.knowm.xchange.dto.marketdata.OrderBook;
@@ -23,6 +25,8 @@ import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveOpenOrde
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveOpenOrdersResponse;
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTrade;
 import org.knowm.xchange.independentreserve.dto.trade.IndependentReserveTradeHistoryResponse;
+import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveOrderBook;
+import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTicker;
 
 /**
  * Author: Kamil Zbikowski Date: 4/10/15
@@ -49,6 +53,31 @@ public class IndependentReserveAdapters {
 
     return new OrderBook(timestamp, asks, bids);
   }
+  
+  /**
+   * Adapts a IndependentReserveTicker to a Ticker Object
+   *
+   * @param independentReserveTicker The exchange specific ticker
+   * @param currencyPair (e.g. BTC/USD)
+   * @return The ticker
+   */
+  public static Ticker adaptTicker(IndependentReserveTicker independentReserveTicker, CurrencyPair currencyPair) {
+
+    BigDecimal last = independentReserveTicker.getLast();
+    BigDecimal bid = independentReserveTicker.getBid();
+    BigDecimal ask = independentReserveTicker.getAsk();
+    BigDecimal high = independentReserveTicker.getHigh();
+    BigDecimal low = independentReserveTicker.getLow();
+    BigDecimal vwap = independentReserveTicker.getVwap();
+    BigDecimal volume = independentReserveTicker.getVolume();
+    Date timestamp = independentReserveTicker.getTimestamp();
+
+    return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).high(high).low(low).vwap(vwap).volume(volume)
+        .timestamp(timestamp).build();
+
+  }
+
+
 
   private static List<LimitOrder> adaptOrders(List<OrderBookOrder> buyOrders, Order.OrderType type, CurrencyPair currencyPair) {
     final List<LimitOrder> orders = new ArrayList<>();
@@ -58,6 +87,8 @@ public class IndependentReserveAdapters {
     }
     return orders;
   }
+  
+
 
   public static Wallet adaptWallet(IndependentReserveBalance independentReserveBalance) {
     List<Balance> balances = new ArrayList<>();

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveTicker.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveTicker.java
@@ -14,7 +14,7 @@ import java.math.BigDecimal;
 import java.text.ParseException;
 
 /**
- * @author Matija Mazi
+ * @author Stuart Low
  */
 public final class IndependentReserveTicker {
 	private final BigDecimal last;

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveTicker.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/dto/marketdata/IndependentReserveTicker.java
@@ -1,0 +1,113 @@
+package org.knowm.xchange.independentreserve.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.util.Date;
+import java.text.SimpleDateFormat;
+import si.mazi.rescu.serialization.jackson.serializers.TimestampDeserializer;
+
+import java.math.BigDecimal;
+import java.text.ParseException;
+
+/**
+ * @author Matija Mazi
+ */
+public final class IndependentReserveTicker {
+	private final BigDecimal last;
+	private final BigDecimal high;
+	private final BigDecimal low;
+	private final BigDecimal vwap;
+	private final BigDecimal volume;
+	private final BigDecimal bid;
+	private final BigDecimal ask;
+	private Date timestamp;
+
+	/**
+	 * Constructor
+	 *
+	 * @param last
+	 * @param high
+	 * @param low
+	 * @param vwap
+	 * @param volume
+	 * @param bid
+	 * @param ask
+	 */
+	public IndependentReserveTicker(@JsonProperty("LastPrice") BigDecimal last,
+			@JsonProperty("DayHighestPrice") BigDecimal high, @JsonProperty("DayLowestPrice") BigDecimal low,
+			@JsonProperty("DayAvgPrice") BigDecimal vwap, @JsonProperty("DayVolumeXbt") BigDecimal volume,
+			@JsonProperty("CurrentHighestBidPrice") BigDecimal bid,
+			@JsonProperty("CurrentLowestOfferPrice") BigDecimal ask,
+			@JsonProperty("CreatedTimestampUtc") String timestamp) {
+
+		// @JsonFormat(pattern="") @JsonDeserialize(using =
+		// TimestampDeserializer.class)
+		this.last = last;
+		this.high = high;
+		this.low = low;
+		this.vwap = vwap;
+		this.volume = volume;
+		this.bid = bid;
+		this.ask = ask;
+		
+		try {
+			SimpleDateFormat myFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSX");
+			this.timestamp = myFormatter.parse(timestamp);
+		} catch (ParseException e) {
+			System.out.println("Received parsing exception while attempting to process timestamp: " + e.getMessage());
+		}
+				
+
+	}
+
+	public BigDecimal getLast() {
+
+		return last;
+	}
+
+	public BigDecimal getHigh() {
+
+		return high;
+	}
+
+	public BigDecimal getLow() {
+
+		return low;
+	}
+
+	public BigDecimal getVwap() {
+
+		return vwap;
+	}
+
+	public BigDecimal getVolume() {
+
+		return volume;
+	}
+
+	public BigDecimal getBid() {
+
+		return bid;
+	}
+
+	public BigDecimal getAsk() {
+
+		return ask;
+	}
+
+	public Date getTimestamp() {
+		return timestamp;
+	}
+
+	@Override
+	public String toString() {
+
+		return "IndependentReserveTicker [last=" + last + ", high=" + high + ", low=" + low + ", vwap=" + vwap
+				+ ", volume=" + volume + ", bid=" + bid + ", ask=" + ask + ", timestamp=" + timestamp + "]";
+	}
+
+}

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataService.java
@@ -17,6 +17,7 @@ import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTic
 
 /**
  * Author: Kamil Zbikowski Date: 4/9/15
+ * @author Stuart Low <stuart@bizabank.com> 
  */
 public class IndependentReserveMarketDataService extends IndependentReserveMarketDataServiceRaw implements MarketDataService {
   public IndependentReserveMarketDataService(IndependentReserveExchange independentReserveExchange) {

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataService.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataService.java
@@ -12,6 +12,8 @@ import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.independentreserve.IndependentReserveAdapters;
 import org.knowm.xchange.independentreserve.IndependentReserveExchange;
 import org.knowm.xchange.service.marketdata.MarketDataService;
+import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTicker;
+
 
 /**
  * Author: Kamil Zbikowski Date: 4/9/15
@@ -20,11 +22,12 @@ public class IndependentReserveMarketDataService extends IndependentReserveMarke
   public IndependentReserveMarketDataService(IndependentReserveExchange independentReserveExchange) {
     super(independentReserveExchange);
   }
-
+  
   @Override
   public Ticker getTicker(CurrencyPair currencyPair,
       Object... args) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
-    throw new UnsupportedOperationException();
+	    IndependentReserveTicker t = getIndependentReserveTicker(currencyPair.base.toString(), currencyPair.counter.toString());
+	    return IndependentReserveAdapters.adaptTicker(t, currencyPair);
   }
 
   @Override

--- a/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
+++ b/xchange-independentreserve/src/main/java/org/knowm/xchange/independentreserve/service/IndependentReserveMarketDataServiceRaw.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.independentreserve.IndependentReserve;
+import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveTicker;
 import org.knowm.xchange.independentreserve.dto.marketdata.IndependentReserveOrderBook;
 
 import si.mazi.rescu.RestProxyFactory;
@@ -19,6 +20,16 @@ public class IndependentReserveMarketDataServiceRaw extends IndependentReserveBa
     this.independentReserve = RestProxyFactory.createProxy(IndependentReserve.class, exchange.getExchangeSpecification().getSslUri(),
         getClientConfig());
   }
+  
+  public IndependentReserveTicker getIndependentReserveTicker(String baseSymbol, String counterSymbol) throws IOException {
+
+	    // Independent Reserve works with Xbt
+	    if (baseSymbol.equals("BTC")) {
+	      baseSymbol = "Xbt";
+	    }
+
+	    return independentReserve.getMarketSummary(baseSymbol, counterSymbol);
+	  }
 
   public IndependentReserveOrderBook getIndependentReserveOrderBook(String baseSymbol, String counterSymbol) throws IOException {
 


### PR DESCRIPTION
Hi there, this introduces the standardised Ticker information for the Independent Reserve exchange based in Australia. No much changes here probably not perfect but functions. IR provides everything except Open price. Content lifted from Bitstamp and BTCMarkets plugins.