### PR TITLE
[Bittrex] open order query check for null currency pair

### DIFF
--- a/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
+++ b/xchange-bittrex/src/main/java/org/knowm/xchange/bittrex/service/BittrexTradeServiceRaw.java
@@ -105,7 +105,9 @@ public class BittrexTradeServiceRaw extends BittrexBaseService {
 
     if (params != null && params instanceof OpenOrdersParamCurrencyPair) {
       CurrencyPair currencyPair = ((OpenOrdersParamCurrencyPair) params).getCurrencyPair();
-      ccyPair = BittrexUtils.toPairString(currencyPair);
+      if(currencyPair != null) {
+        ccyPair = BittrexUtils.toPairString(currencyPair);
+      }
     }
 
     BittrexOpenOrdersResponse response = bittrexAuthenticated.openorders(apiKey, signatureCreator, exchange.getNonceFactory(), ccyPair);


### PR DESCRIPTION
PR #1972 causes NullPointerExceptions for open order query if the default params object is used without setting a currency pair. (There is already a check for null in the trade history query.)