### PR TITLE
Fix typo in Binance getFundingHistory

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceAccountService.java
@@ -79,7 +79,7 @@ public class BinanceAccountService extends BinanceAccountServiceRaw implements A
   @Override
   public List<FundingRecord> getFundingHistory(TradeHistoryParams params)
       throws IOException {
-    if (params instanceof TradeHistoryParamCurrency) {
+    if (!(params instanceof TradeHistoryParamCurrency)) {
       throw new RuntimeException("You must provide the currency in order to get the funding history (TradeHistoryParamCurrency).");
     }
     TradeHistoryParamCurrency cp = (TradeHistoryParamCurrency) params;


### PR DESCRIPTION
The Binance implementation commonly uses this pattern to check types when accepting an instance of `TradeHistoryParams`, but for `AccountService#getFundingHistory` there's a typo which causes all calls to `getFundingHistory` to either throw a (userland)`RuntimeException` or real `RuntimeException` when you can't cast params as a `TradeHistoryParamCurrency` (line 85).

See https://github.com/timmolter/XChange/blob/develop/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java#L96-L98 for intended behavior.