### PR TITLE
[CoinMate] added BCH support and fixed API rate limit

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateUtils.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateUtils.java
@@ -46,6 +46,8 @@ public class CoinmateUtils {
       return CurrencyPair.BTC_CZK;
     } else if ("LTC_BTC".equals(currencyPair)) {
       return CurrencyPair.LTC_BTC;
+    } else if ("BCH_BTC".equals(currencyPair)) {
+      return CurrencyPair.BCH_BTC;
     } else {
       return null;
     }

--- a/xchange-coinmate/src/main/resources/coinmate.json
+++ b/xchange-coinmate/src/main/resources/coinmate.json
@@ -1,13 +1,20 @@
 {
   "currency_pairs": {
     "BTC/EUR": {
-      "price_scale": 2
+      "price_scale": 2,
+      "min_amount": 0.0002
     },
     "BTC/CZK": {
-      "price_scale": 2
+      "price_scale": 2,
+      "min_amount": 0.0002
     },
     "LTC/BTC": {
-      "price_scale": 5
+      "price_scale": 5,
+      "min_amount": 0.01
+    },
+    "BCH/BTC": {
+      "price_scale": 5,
+      "min_amount": 0.0002
     }
   },
   "currencies": {
@@ -22,11 +29,14 @@
     },
     "LTC": {
       "scale": 8
+    },
+    "BCH": {
+      "scale": 8
     }
   },
   "private_rate_limits": [
     {
-      "calls": 600,
+      "calls": 100,
       "time_unit": "minutes"
     }
   ],


### PR DESCRIPTION
API rate limit is based on
https://coinmate.docs.apiary.io/#reference/request-limits/get