### PR TITLE
[CoinMate] fill currencyPair in the open orders result with real value returned from API instead of optional input parameters

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -157,7 +157,7 @@ public class CoinmateAdapters {
     return new UserTrades(trades, Trades.TradeSortType.SortByTimestamp);
   }
 
-  public static List<LimitOrder> adaptOpenOrders(CoinmateOpenOrders coinmateOpenOrders, CurrencyPair currencyPair) throws CoinmateException {
+  public static List<LimitOrder> adaptOpenOrders(CoinmateOpenOrders coinmateOpenOrders) throws CoinmateException {
 
     List<LimitOrder> ordersList = new ArrayList<>(coinmateOpenOrders.getData().size());
 
@@ -173,8 +173,8 @@ public class CoinmateAdapters {
         throw new CoinmateException("Unknown order type");
       }
 
-      LimitOrder limitOrder = new LimitOrder(orderType, entry.getAmount(), currencyPair, Long.toString(entry.getId()), new Date(entry.getTimestamp()),
-          entry.getPrice());
+      LimitOrder limitOrder = new LimitOrder(orderType, entry.getAmount(), CoinmateUtils.getPair(entry.getCurrencyPair()),
+          Long.toString(entry.getId()), new Date(entry.getTimestamp()), entry.getPrice());
 
       ordersList.add(limitOrder);
     }

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/trade/CoinmateOpenOrdersEntry.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/dto/trade/CoinmateOpenOrdersEntry.java
@@ -35,15 +35,17 @@ public class CoinmateOpenOrdersEntry {
   private final long id;
   private final long timestamp;
   private final String type;
+  private final String currencyPair;
   private final BigDecimal price;
   private final BigDecimal amount;
 
   public CoinmateOpenOrdersEntry(@JsonProperty("id") long id, @JsonProperty("timestamp") long timestamp, @JsonProperty("type") String type,
-      @JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount) {
+      @JsonProperty("currencyPair") String currencyPair, @JsonProperty("price") BigDecimal price, @JsonProperty("amount") BigDecimal amount) {
 
     this.id = id;
     this.timestamp = timestamp;
     this.type = type;
+    this.currencyPair = currencyPair;
     this.price = price;
     this.amount = amount;
   }
@@ -67,6 +69,13 @@ public class CoinmateOpenOrdersEntry {
    */
   public String getType() {
     return type;
+  }
+
+  /**
+   * @return the currency pair
+   */
+  public String getCurrencyPair() {
+    return currencyPair;
   }
 
   /**

--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeService.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/service/CoinmateTradeService.java
@@ -67,7 +67,7 @@ public class CoinmateTradeService extends CoinmateTradeServiceRaw implements Tra
 
     String currencyPairString = CoinmateUtils.getPair(currencyPair);
     CoinmateOpenOrders coinmateOpenOrders = getCoinmateOpenOrders(currencyPairString);
-    List<LimitOrder> orders = CoinmateAdapters.adaptOpenOrders(coinmateOpenOrders, currencyPair);
+    List<LimitOrder> orders = CoinmateAdapters.adaptOpenOrders(coinmateOpenOrders);
     return new OpenOrders(orders);
   }
 


### PR DESCRIPTION
It was causing that currencyPair was missing if input parameter currencyPair was null.
It don't allows return list of all pending transaction without limiting it to one type.