### PR TITLE
Retrieve all tickers from CoinMarketCap by setting `limit=0` request param

### DIFF
--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataService.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataService.java
@@ -16,9 +16,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
-import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /**
@@ -59,8 +57,6 @@ public class CoinMarketCapMarketDataService extends CoinMarketCapMarketDataServi
 
     CoinMarketCapTicker cmcB = tickers.get(b.getCurrencyCode());
 
-    CoinMarketCapTicker BTC = tickers.get("BTC");
-
     CurrencyPair pair;
     BigDecimal price;
     BigDecimal volume;
@@ -87,46 +83,42 @@ public class CoinMarketCapMarketDataService extends CoinMarketCapMarketDataServi
       volume = null;
     }
 
-    Ticker.Builder builder = new Ticker.Builder();
-    builder
-        .currencyPair(pair)
-        .timestamp(cmcB.getLastUpdated())
-        .last(price)
-        .bid(price)
-        .ask(price)
-        .high(price)
-        .low(price)
-        .vwap(price)
-        .volume(volume);
-
-    return builder.build();
+    return new Ticker.Builder()
+            .currencyPair(pair)
+            .timestamp(cmcB.getLastUpdated())
+            .last(price)
+            .bid(price)
+            .ask(price)
+            .high(price)
+            .low(price)
+            .vwap(price)
+            .volume(volume)
+            .build();
   }
 
   @Override
-  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... objects) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public OrderBook getOrderBook(CurrencyPair currencyPair, Object... objects) {
     throw new NotAvailableFromExchangeException();
   }
 
   @Override
-  public Trades getTrades(CurrencyPair currencyPair, Object... objects) throws ExchangeException, NotAvailableFromExchangeException, NotYetImplementedForExchangeException, IOException {
+  public Trades getTrades(CurrencyPair currencyPair, Object... objects) {
     throw new NotAvailableFromExchangeException();
   }
 
   public List<Currency> getCurrencies() {
-    List<Currency> currencies = new ArrayList<Currency>();
-    try {
-      List<CoinMarketCapCurrency> cmcCurrencies = getCoinMarketCapCurrencies();
-      for (CoinMarketCapCurrency cmcCurrency : cmcCurrencies) {
-        currencies.add(cmcCurrency.getCurrency());
-      }
-    } catch (IOException e) {
-      e.printStackTrace();
+    List<Currency> currencies = new ArrayList<>();
+    List<CoinMarketCapCurrency> cmcCurrencies = getCoinMarketCapCurrencies();
+
+    for (CoinMarketCapCurrency cmcCurrency : cmcCurrencies) {
+      currencies.add(cmcCurrency.getCurrency());
     }
+
     return currencies;
   }
 
   @Override
-  public List<CoinMarketCapCurrency> getCoinMarketCapCurrencies() throws IOException {
+  public List<CoinMarketCapCurrency> getCoinMarketCapCurrencies() {
     Collection<CoinMarketCapTicker> tickers = this.tickers.values();
     List<CoinMarketCapCurrency> currencies = new ArrayList<>();
     for (CoinMarketCapTicker ticker : tickers)

--- a/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
+++ b/xchange-coinmarketcap/src/main/java/org/knowm/xchange/coinmarketcap/service/CoinMarketCapMarketDataServiceRaw.java
@@ -27,7 +27,7 @@ class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements B
     this.coinmarketcap = RestProxyFactory.createProxy(CoinMarketCap.class, exchange.getExchangeSpecification().getSslUri(), getClientConfig());
   }
 
-  public CoinMarketCapTicker getCoinMarketCapTicker(CurrencyPair pair) throws IOException {
+  public CoinMarketCapTicker getCoinMarketCapTicker(CurrencyPair pair) {
 
     return coinmarketcap.getTicker(new CoinMarketCap.Pair(pair));
   }
@@ -40,15 +40,25 @@ class CoinMarketCapMarketDataServiceRaw extends BaseExchangeService implements B
    */
   public List<CoinMarketCapCurrency> getCoinMarketCapCurrencies() throws IOException {
 
-    List<CoinMarketCapTicker> tickers = coinmarketcap.getTickers();
+    List<CoinMarketCapTicker> tickers = getCoinMarketCapTickers();
     List<CoinMarketCapCurrency> currencies = new ArrayList<>();
     for (CoinMarketCapTicker ticker : tickers)
       currencies.add(ticker.getBaseCurrency());
     return currencies;
   }
 
+  /**
+   * Retrieves all tickers from CoinMarketCap
+   */
   public List<CoinMarketCapTicker> getCoinMarketCapTickers() throws IOException {
+    return getCoinMarketCapTickers(0);
+  }
 
-    return coinmarketcap.getTickers();
+  /**
+   * Retrieves limited amount of tickers from CoinMarketCap
+   * @param limit count of tickers to be retrieved
+   */
+  public List<CoinMarketCapTicker> getCoinMarketCapTickers(final int limit) throws IOException {
+    return coinmarketcap.getTickers(limit);
   }
 }


### PR DESCRIPTION
Fixing CoinMarketCap ticker retrieval.
Only the first 200 results are returned by using `/tickers` endpoint without `limit` request parameter and that leads to missing currency pairs in loaded tickers.

Please review my fix, I am open to your thoughts, thanks.