### PR TITLE
Removed broken GDAX order status implementation. 

### DIFF
--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
@@ -22,6 +22,7 @@ import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderByIdParams;
 import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
 
 public class GDAXTradeService extends GDAXTradeServiceRaw implements TradeService {
@@ -91,12 +92,6 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements TradeServic
 
   @Override
   public Collection<Order> getOrder(String... orderIds) throws IOException {
-    Collection<Order> orders = new ArrayList<>(orderIds.length);
-
-    for (String orderId : orderIds) {
-      orders.add(GDAXAdapters.adaptOrder(orderId, super.getOrder(orderId)));
-    }
-
-    return orders;
+    throw new NotYetImplementedForExchangeException();
   }
 }


### PR DESCRIPTION
The order status returned from the current GDAXTradeService implementation is completely bogus (always returned as a LimitOrder, even if it's a MarketOrder. And it never includes a status other than Pending_New). See Issue #1860

Intend to fix in the future. But we need the implementation to fail gracefully, rather than return bogus
statuses just for GDAX.



