### PR TITLE
Gemini ETH precision correction

### DIFF
--- a/xchange-gemini/src/main/resources/gemini.json
+++ b/xchange-gemini/src/main/resources/gemini.json
@@ -21,7 +21,7 @@
       "scale": 2
     },
     "ETH": {
-      "scale": 8
+      "scale": 6
     }
   }
 }


### PR DESCRIPTION
The following documentation for Gemini shows that the precision ("minimum increment) for ETH should be 6 not 8. 

https://docs.gemini.com/rest-api/#symbols-and-minimums



