### PR TITLE
[BitFinex] Implemented XChange-side open orders filtering

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexTradeService.java
@@ -46,8 +46,22 @@ public class BitfinexTradeService extends BitfinexTradeServiceRaw implements Tra
     if (activeOrders.length <= 0) {
       return noOpenOrders;
     } else {
-      return BitfinexAdapters.adaptOrders(activeOrders);
+      return filterOrders(BitfinexAdapters.adaptOrders(activeOrders), params);
     }
+  }
+
+  /**
+   * Bitfinex API does not provide filtering option. So we should filter orders ourselves
+   */
+  private OpenOrders filterOrders(OpenOrders rawOpenOrders,
+                                  OpenOrdersParams params) {
+    if (params == null) {
+      return rawOpenOrders;
+    }
+
+    List<LimitOrder> openOrdersList = rawOpenOrders.getOpenOrders();
+    openOrdersList.removeIf(openOrder -> !params.accept(openOrder));
+    return new OpenOrders(openOrdersList);
   }
 
   @Override

--- a/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorOpenOrdersParams.java
+++ b/xchange-coinfloor/src/main/java/org/knowm/xchange/coinfloor/service/CoinfloorOpenOrdersParams.java
@@ -1,11 +1,12 @@
 package org.knowm.xchange.coinfloor.service;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParamMultiCurrencyPair;
+
+import java.util.Collection;
+import java.util.Collections;
 
 public class CoinfloorOpenOrdersParams implements OpenOrdersParamMultiCurrencyPair, OpenOrdersParamCurrencyPair {
   private Collection<CurrencyPair> pairs = Collections.emptySet();
@@ -29,5 +30,10 @@ public class CoinfloorOpenOrdersParams implements OpenOrdersParamMultiCurrencyPa
   @Override
   public void setCurrencyPair(CurrencyPair value) {
     pair = value;
+  }
+
+  @Override
+  public boolean accept(LimitOrder order) {
+    return OpenOrdersParamCurrencyPair.super.accept(order) || OpenOrdersParamMultiCurrencyPair.super.accept(order);
   }
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamCurrencyPair.java
@@ -1,8 +1,14 @@
 package org.knowm.xchange.service.trade.params.orders;
 
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
 
 public interface OpenOrdersParamCurrencyPair extends OpenOrdersParams {
+  @Override
+  default boolean accept(LimitOrder order) {
+    return order != null && getCurrencyPair() != null && getCurrencyPair().equals(order.getCurrencyPair());
+  }
+
   void setCurrencyPair(CurrencyPair pair);
 
   CurrencyPair getCurrencyPair();

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamMultiCurrencyPair.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParamMultiCurrencyPair.java
@@ -1,10 +1,15 @@
 package org.knowm.xchange.service.trade.params.orders;
 
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.trade.LimitOrder;
+
 import java.util.Collection;
 
-import org.knowm.xchange.currency.CurrencyPair;
-
 public interface OpenOrdersParamMultiCurrencyPair extends OpenOrdersParams {
+  @Override
+  default boolean accept(LimitOrder order) {
+    return order != null && getCurrencyPairs() != null && getCurrencyPairs().contains(order.getCurrencyPair());
+  }
 
   void setCurrencyPairs(Collection<CurrencyPair> pairs);
 

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParams.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/OpenOrdersParams.java
@@ -1,5 +1,6 @@
 package org.knowm.xchange.service.trade.params.orders;
 
+import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.service.trade.TradeService;
 
 /**
@@ -13,4 +14,10 @@ import org.knowm.xchange.service.trade.TradeService;
  * When suitable exchange params definition can extend from default classes, eg. {@link DefaultOpenOrdersParamCurrencyPair}.
  */
 public interface OpenOrdersParams {
+    /**
+     * Checks if passed order is suitable for open orders params. May be used for XChange side orders filtering
+     *
+     * @return true if order is ok
+     */
+    boolean accept(LimitOrder order);
 }


### PR DESCRIPTION
Bitfinex API does not provide filtering option. So we should filter orders ourselves