### PR TITLE
[Hitbtc] implements HitbtcTradeService#getOrder

### DIFF
--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAdapters.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAdapters.java
@@ -2,6 +2,7 @@ package org.knowm.xchange.hitbtc.v2;
 
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.account.Balance;
 import org.knowm.xchange.dto.account.FundingRecord;
@@ -136,28 +137,37 @@ public class HitbtcAdapters {
 
     return new Trades(trades, lastTradeId, Trades.TradeSortType.SortByTimestamp);
   }
+  
+  public static LimitOrder adaptOrder(HitbtcOrder hitbtcOrder){
+    OrderType type = adaptOrderType(hitbtcOrder.side);
 
-  public static OpenOrders adaptOpenOrders(List<HitbtcOrder> openOrdersRaw) {
+    LimitOrder order =
+      new LimitOrder(
+        type,
+        hitbtcOrder.quantity,
+        adaptSymbol(hitbtcOrder.symbol),
+        hitbtcOrder.clientOrderId,
+        hitbtcOrder.getCreatedAt(),
+        hitbtcOrder.price,
+        null, // exchange does not provide average price
+        hitbtcOrder.cumQuantity,
+        convertOrderStatus(hitbtcOrder.status));
 
+    return order;
+  }
+
+  public static List<LimitOrder> adaptOrders(List<HitbtcOrder> openOrdersRaw){
     List<LimitOrder> openOrders = new ArrayList<>(openOrdersRaw.size());
 
     for (HitbtcOrder hitbtcOrder : openOrdersRaw) {
-
-      OrderType type = adaptOrderType(hitbtcOrder.side);
-
-      LimitOrder order =
-          new LimitOrder(
-              type,
-              hitbtcOrder.quantity,
-              adaptSymbol(hitbtcOrder.symbol),
-              hitbtcOrder.clientOrderId,
-              hitbtcOrder.getCreatedAt(),
-              hitbtcOrder.price);
-
-      openOrders.add(order);
+      openOrders.add(adaptOrder(hitbtcOrder));
     }
 
-    return new OpenOrders(openOrders);
+    return openOrders;
+  }
+
+  public static OpenOrders adaptOpenOrders(List<HitbtcOrder> openOrdersRaw) {
+    return new OpenOrders(adaptOrders(openOrdersRaw));
   }
 
   public static OrderType adaptOrderType(String side) {
@@ -287,6 +297,32 @@ public class HitbtcAdapters {
         return FundingRecord.Status.FAILED;
       case "success":
         return FundingRecord.Status.COMPLETE;
+      default:
+        throw new RuntimeException("Unknown HitBTC transaction status: " + status);
+    }
+  }
+
+  /**
+   * Decodes HitBTC Order status.
+   * 
+   * @return
+   * @see https://api.hitbtc.com/#order-model Order Model
+   * possible statuses: new, suspended, partiallyFilled, filled, canceled, expired
+   */
+  private static Order.OrderStatus convertOrderStatus(String status) {
+    switch (status) {
+      case "new":
+        return Order.OrderStatus.NEW;
+      case "suspended":
+        return Order.OrderStatus.STOPPED;
+      case "partiallyFilled":
+        return Order.OrderStatus.PARTIALLY_FILLED;
+      case "filled":
+        return Order.OrderStatus.FILLED;
+      case "canceled":
+        return Order.OrderStatus.CANCELED;
+      case "expired":
+        return Order.OrderStatus.EXPIRED;
       default:
         throw new RuntimeException("Unknown HitBTC transaction status: " + status);
     }

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAuthenticated.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/HitbtcAuthenticated.java
@@ -104,7 +104,7 @@ public interface HitbtcAuthenticated extends Hitbtc {
   @GET
   @Path("history/trades")
   List<HitbtcOwnTrade> getHitbtcTrades() throws IOException, HitbtcException;
-
+  
   //TODO add query params
 
   /**
@@ -117,6 +117,18 @@ public interface HitbtcAuthenticated extends Hitbtc {
   @GET
   @Path("history/order")
   List<HitbtcOrder> getHitbtcRecentOrders() throws IOException, HitbtcException;
+
+  /**
+   * Get an old order. The returning collection contains, at most, 1 element.
+   *
+   * @return
+   * @throws IOException
+   * @throws HitbtcException
+   */
+  @GET
+  @Path("history/order")
+  List<HitbtcOrder> getHitbtcOrder(@PathParam("symbol") String symbol, 
+                                   @PathParam("clientOrderId") String clientOrderId) throws IOException, HitbtcException;
 
   @GET
   @Path("/history/order/{id}/trades")

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeService.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.hitbtc.v2.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -110,8 +111,19 @@ public class HitbtcTradeService extends HitbtcTradeServiceRaw implements TradeSe
 
   @Override
   public Collection<Order> getOrder(String... orderIds) throws IOException {
+    if (orderIds == null || orderIds.length == 0){
+      return new ArrayList<>();
+    }
 
-    throw new NotYetImplementedForExchangeException();
+    Collection<Order> orders = new ArrayList<>();
+    for (String orderId : orderIds) {
+      HitbtcOrder rawOrder = getHitbtcOrder("BTCUSD", orderId);
+      
+      if (rawOrder != null)
+        orders.add(HitbtcAdapters.adaptOrder(rawOrder));
+    }
+    
+    return orders;
   }
 
   @Override

--- a/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
+++ b/xchange-hitbtc/src/main/java/org/knowm/xchange/hitbtc/v2/service/HitbtcTradeServiceRaw.java
@@ -58,10 +58,20 @@ public class HitbtcTradeServiceRaw extends HitbtcBaseService {
 
     return hitbtc.getHitbtcTrades();
   }
+  
+  public HitbtcOrder getHitbtcOrder(String symbol, String orderId) throws IOException{
+    List<HitbtcOrder> orders = hitbtc.getHitbtcOrder(symbol, orderId);
+    
+    if (orders == null || orders.size() == 0){
+      return null;
+    } else {
+      return orders.iterator().next();
+    }
+  }
+  
 
   public List<HitbtcBalance> getTradingBalance() throws IOException {
 
     return hitbtc.getTradingBalance();
   }
-
 }


### PR DESCRIPTION
This PR implements the `getOrder(String... orderIds)` method for `HitbtcTradeService`. A new remote method `getHitbtcOrder` has been implemented in `HitbtcAuthenticated`. This new method calls the `history/order` endpoint providing the `clientOrderId` of the order the user wants to retrieve.

Furthermore, a new order status adapter has been implemented, alongside some other minor refactors in `HitbtcAdapters` 