### PR TITLE
Make binance ticker dto constructor public

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceTicker24h.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/marketdata/BinanceTicker24h.java
@@ -37,7 +37,7 @@ public final class BinanceTicker24h {
   // The cached ticker
   private Ticker ticker;
 
-  BinanceTicker24h(@JsonProperty("priceChange") BigDecimal priceChange
+  public BinanceTicker24h(@JsonProperty("priceChange") BigDecimal priceChange
       , @JsonProperty("priceChangePercent") BigDecimal priceChangePercent
       , @JsonProperty("weightedAvgPrice") BigDecimal weightedAvgPrice
       , @JsonProperty("prevClosePrice") BigDecimal prevClosePrice


### PR DESCRIPTION
I'm trying to implement ticker subscriptions in xchange-streams and the market data DTOs are needed. The other DTOs in this package are public. Unsure if there's any reason this isn't already public