### PR TITLE
[Bitfinex] Floats don't have enough precision to store timestamps.

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/marketdata/BitfinexTicker.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/dto/marketdata/BitfinexTicker.java
@@ -13,7 +13,7 @@ public class BitfinexTicker {
   private final BigDecimal low;
   private final BigDecimal last;
   private final BigDecimal volume;
-  private final float timestamp;
+  private final double timestamp;
 
   /**
    * @param mid
@@ -27,7 +27,7 @@ public class BitfinexTicker {
    */
   public BitfinexTicker(@JsonProperty("mid") BigDecimal mid, @JsonProperty("bid") BigDecimal bid, @JsonProperty("ask") BigDecimal ask,
       @JsonProperty("low") BigDecimal low, @JsonProperty("high") BigDecimal high, @JsonProperty("last_price") BigDecimal last,
-      @JsonProperty("timestamp") float timestamp, @JsonProperty("volume") BigDecimal volume) {
+      @JsonProperty("timestamp") double timestamp, @JsonProperty("volume") BigDecimal volume) {
 
     this.mid = mid;
     this.bid = bid;
@@ -74,7 +74,7 @@ public class BitfinexTicker {
     return volume;
   }
 
-  public float getTimestamp() {
+  public double getTimestamp() {
 
     return timestamp;
   }


### PR DESCRIPTION
When using xchange-stream's Bitfinex implementation it fakes the timestamp because Bitfinex somehow forgot to include one in their Ticker payload. It runs `System.currentTimeMillis() / 1000` which, when stored as a float, was giving me times that were sometimes as much as 90 seconds in the future. Fixing the `BitfinexTicker` to use a double instead has made the math work properly and my timestamps are now all in the past, where they're supposed to be.