### PR TITLE
Fix for old guava-collections include from recent bitmex merge

### DIFF
--- a/xchange-bitmex/pom.xml
+++ b/xchange-bitmex/pom.xml
@@ -31,5 +31,10 @@
             <version>4.3.3-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/xchange-core/pom.xml
+++ b/xchange-core/pom.xml
@@ -44,10 +44,5 @@
             <artifactId>commons-lang3</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-    <groupId>com.google.guava</groupId>
-    <artifactId>guava-collections</artifactId>
-    <version>r03</version>
-</dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Moved guava-collections from xchange-core to xchange-bitmex (the only place it is used) and upgraded it to the latest version of guava. But I suggest that this dependency be removed, as it's a rather large one.