### PR TITLE
Add "open" to GDAX ticker

### DIFF
--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -95,6 +95,7 @@ public class GDAXAdapters {
   public static Ticker adaptTicker(GDAXProductTicker ticker, GDAXProductStats stats, CurrencyPair currencyPair) {
 
     BigDecimal last = ticker.getPrice();
+    BigDecimal open = stats.getOpen();
     BigDecimal high = stats.getHigh();
     BigDecimal low = stats.getLow();
     BigDecimal buy = ticker.getBid();
@@ -102,7 +103,17 @@ public class GDAXAdapters {
     BigDecimal volume = ticker.getVolume();
     Date date = parseDate(ticker.getTime());
 
-    return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(buy).ask(sell).volume(volume).timestamp(date).build();
+    return new Ticker.Builder()
+        .currencyPair(currencyPair)
+        .last(last)
+        .open(open)
+        .high(high)
+        .low(low)
+        .bid(buy)
+        .ask(sell)
+        .volume(volume)
+        .timestamp(date)
+        .build();
   }
 
   public static OrderBook adaptOrderBook(GDAXProductBook book, CurrencyPair currencyPair) {

--- a/xchange-gdax/src/test/java/org/knowm/xchange/gdax/GDAXAdaptersTest.java
+++ b/xchange-gdax/src/test/java/org/knowm/xchange/gdax/GDAXAdaptersTest.java
@@ -67,6 +67,7 @@ public class GDAXAdaptersTest {
     Ticker ticker = GDAXAdapters.adaptTicker(coinbaseExTicker, coinbaseExStats, CurrencyPair.BTC_USD);
 
     assertThat(ticker.getLast().toString()).isEqualTo("246.28000000");
+    assertThat(ticker.getOpen().toString()).isEqualTo("254.04000000");
     assertThat(ticker.getBid().toString()).isEqualTo("637");
     assertThat(ticker.getAsk().toString()).isEqualTo("637.11");
     assertThat(ticker.getHigh().toString()).isEqualTo("255.47000000");


### PR DESCRIPTION
The `open` field was not being populated for GDAX tickers, this change fixes that.