### PR TITLE
BitMEX client

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.bitmex;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -16,6 +17,7 @@ import org.knowm.xchange.bitmex.dto.account.BitmexMarginAccount;
 import org.knowm.xchange.bitmex.dto.account.BitmexTicker;
 import org.knowm.xchange.bitmex.dto.account.BitmexWallet;
 import org.knowm.xchange.bitmex.dto.account.BitmexWalletTransaction;
+import org.knowm.xchange.bitmex.dto.marketdata.BitmexPrivateOrder;
 import org.knowm.xchange.bitmex.dto.marketdata.BitmexPublicOrder;
 import org.knowm.xchange.bitmex.dto.marketdata.BitmexPublicTrade;
 import org.knowm.xchange.bitmex.dto.marketdata.results.BitmexSymbolsAndPromptsResult;
@@ -95,4 +97,17 @@ public interface Bitmex {
   @GET
   @Path("instrument/activeIntervals")
   BitmexSymbolsAndPromptsResult getPromptsAndSymbols() throws IOException, BitmexException;
+`
+  @GET
+  @Path("order")
+  List<BitmexPrivateOrder> getOrders(@HeaderParam("api-key") String apiKey,
+                                     @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce,
+                                     @HeaderParam("api-signature") ParamsDigest paramsDigest,
+                                     @Nullable @QueryParam("symbol") String symbol,
+                                     @Nullable @QueryParam("filter") String filter,
+                                     @Nullable @QueryParam("count") Integer count,
+                                     @Nullable @QueryParam("start") Integer start,
+                                     @Nullable @QueryParam("reverse") Boolean reverse,
+                                     @Nullable @QueryParam("startTime") Date startTime,
+                                     @Nullable @QueryParam("endTime") Date endTime);
 }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -80,7 +80,9 @@ public interface Bitmex {
 
   @GET
   @Path("instrument")
-  List<BitmexTicker> getTickers() throws IOException, BitmexException;
+  List<BitmexTicker> getTickers(@Nullable @QueryParam("count") Integer count,
+                                @Nullable @QueryParam("start") Integer start,
+                                @Nullable @QueryParam("reverse") Boolean reverse) throws IOException, BitmexException;
 
   @GET
   @Path("instrument")

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -97,7 +97,7 @@ public interface Bitmex {
   @GET
   @Path("instrument/activeIntervals")
   BitmexSymbolsAndPromptsResult getPromptsAndSymbols() throws IOException, BitmexException;
-`
+
   @GET
   @Path("order")
   List<BitmexPrivateOrder> getOrders(@HeaderParam("api-key") String apiKey,

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -30,35 +30,35 @@ public interface Bitmex {
 
   @GET
   @Path("user")
-  BitmexAccount getAccount(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce, @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest)
+  BitmexAccount getAccount(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce, @HeaderParam("api-signature") ParamsDigest paramsDigest)
       throws IOException;
 
   @GET
   @Path("user/wallet")
-  BitmexWallet getWallet(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce, @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest,
+  BitmexWallet getWallet(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce, @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("currency") String currency) throws IOException;
 
   // Get a history of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
   @Path("user/walletHistory")
-  List<BitmexWalletTransaction> getWalletHistory(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
+  List<BitmexWalletTransaction> getWalletHistory(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("api-signature") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   // Get a summary of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
   @Path("user/walletSummary")
-  List<BitmexWalletTransaction> getWalletSummary(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
+  List<BitmexWalletTransaction> getWalletSummary(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("api-signature") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   @GET
   @Path("user/margin")
-  BitmexMarginAccount getMarginAccountStatus(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
+  BitmexMarginAccount getMarginAccountStatus(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("api-signature") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   @GET
   @Path("user/margin?currency=all")
-  List<BitmexMarginAccount> getMarginAccountsStatus(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest) throws IOException;
+  List<BitmexMarginAccount> getMarginAccountsStatus(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce,
+      @HeaderParam("api-signature") ParamsDigest paramsDigest) throws IOException;
 
   @GET
   @Path("trade")
@@ -70,12 +70,12 @@ public interface Bitmex {
 
   @GET
   @Path("position")
-  List<BitmexPosition> getPositions(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce, @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest)
+  List<BitmexPosition> getPositions(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce, @HeaderParam("api-signature") ParamsDigest paramsDigest)
       throws IOException;
 
   @GET
   @Path("position")
-  List<BitmexPosition> getPositions(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce, @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest,
+  List<BitmexPosition> getPositions(@HeaderParam("api-key") String apiKey, @HeaderParam("api-nonce") SynchronizedValueFactory<Long> nonce, @HeaderParam("api-signature") ParamsDigest paramsDigest,
       @Nullable @QueryParam("symbol") String symbol, @Nullable @QueryParam("filter") String filter) throws IOException;
 
   @GET

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -7,7 +7,6 @@ import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
@@ -37,24 +36,24 @@ public interface Bitmex {
   @GET
   @Path("user/wallet")
   BitmexWallet getWallet(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce, @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest,
-      @Nullable @PathParam("currency") String currency) throws IOException;
+      @Nullable @QueryParam("currency") String currency) throws IOException;
 
   // Get a history of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
   @Path("user/walletHistory")
   List<BitmexWalletTransaction> getWalletHistory(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @PathParam("currency") String currency) throws IOException;
+      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   // Get a summary of all of your wallet transactions (deposits, withdrawals, PNL)
   @GET
   @Path("user/walletSummary")
   List<BitmexWalletTransaction> getWalletSummary(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @PathParam("currency") String currency) throws IOException;
+      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   @GET
   @Path("user/margin")
   BitmexMarginAccount getMarginAccountStatus(@HeaderParam("API-KEY") String apiKey, @HeaderParam("API-NONCE") SynchronizedValueFactory<Long> nonce,
-      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @PathParam("currency") String currency) throws IOException;
+      @HeaderParam("API-SIGNATURE") ParamsDigest paramsDigest, @Nullable @QueryParam("currency") String currency) throws IOException;
 
   @GET
   @Path("user/margin?currency=all")
@@ -85,7 +84,7 @@ public interface Bitmex {
 
   @GET
   @Path("instrument")
-  List<BitmexTicker> getTicker(@PathParam("symbol") String symbol) throws IOException, BitmexException;
+  List<BitmexTicker> getTicker(@QueryParam("symbol") String symbol) throws IOException, BitmexException;
 
   @GET
   @Path("instrument/active")

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -37,7 +37,7 @@ public class BitmexExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setHost("bitmex.com");
     exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("Bitmex");
-    exchangeSpecification.setExchangeDescription("Bitmex is a bitcoin exchang");
+    exchangeSpecification.setExchangeDescription("Bitmex is a bitcoin exchange");
     return exchangeSpecification;
   }
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexUtils.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexUtils.java
@@ -35,22 +35,19 @@ public class BitmexUtils {
 
   public static void setBitmexAssetPairs(List<BitmexTicker> tickers) {
 
-    if (assetPairMap.isEmpty() || assetsMap.isEmpty()) {
-      for (BitmexTicker ticker : tickers) {
-        String quote = ticker.getQuoteCurrency();
-        String base = ticker.getRootSymbol();
-        Currency baseCurrencyCode = Currency.getInstance(base);
-        Currency quoteCurrencyCode = Currency.getInstance(quote);
+    for (BitmexTicker ticker : tickers) {
+      String quote = ticker.getQuoteCurrency();
+      String base = ticker.getRootSymbol();
+      Currency baseCurrencyCode = Currency.getInstance(base);
+      Currency quoteCurrencyCode = Currency.getInstance(quote);
 
-        CurrencyPair pair = new CurrencyPair(base, quote);
-        if (!assetPairMap.containsKey(ticker.getSymbol()) && !assetPairMap.containsValue(pair))
-          assetPairMap.put(ticker.getSymbol(), pair);
-        if (!assetsMap.containsKey(quote) && !assetsMap.containsValue(quoteCurrencyCode))
-          assetsMap.put(quote, quoteCurrencyCode);
-        if (!assetsMap.containsKey(base) && !assetsMap.containsValue(baseCurrencyCode))
-          assetsMap.put(base, baseCurrencyCode);
-
-      }
+      CurrencyPair pair = new CurrencyPair(base, quote);
+      if (!assetPairMap.containsKey(ticker.getSymbol()) && !assetPairMap.containsValue(pair))
+        assetPairMap.put(ticker.getSymbol(), pair);
+      if (!assetsMap.containsKey(quote) && !assetsMap.containsValue(quoteCurrencyCode))
+        assetsMap.put(quote, quoteCurrencyCode);
+      if (!assetsMap.containsKey(base) && !assetsMap.containsValue(baseCurrencyCode))
+        assetsMap.put(base, baseCurrencyCode);
 
     }
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/marketdata/BitmexPrivateOrder.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/dto/marketdata/BitmexPrivateOrder.java
@@ -1,0 +1,95 @@
+package org.knowm.xchange.bitmex.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.bitmex.dto.trade.BitmexOrderStatus;
+import org.knowm.xchange.bitmex.dto.trade.BitmexOrderType;
+import org.knowm.xchange.bitmex.dto.trade.BitmexSide;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+public class BitmexPrivateOrder {
+
+  private final BigDecimal price;
+  private final BigDecimal size;
+  private final String symbol;
+  private final String id;
+  private final BitmexSide side;
+  private final Date timestamp;
+  private final OrderStatus orderStatus;
+  private final String currency;
+  private final String settleCurrency;
+
+  public enum OrderStatus {
+    New, Partially_filled, Filled, Canceled
+  }
+
+  public BitmexPrivateOrder(@JsonProperty("price") BigDecimal price, @JsonProperty("orderID") String id,
+                            @JsonProperty("orderQty") BigDecimal size, @JsonProperty("side") BitmexSide side,
+                            @JsonProperty("symbol") String symbol, @JsonProperty("timestamp") Date timestamp,
+                            @JsonProperty("ordStatus") OrderStatus orderStatus,
+                            @JsonProperty("currency") String currency,
+                            @JsonProperty("settlCurrency") String settleCurrency) {
+
+    this.symbol = symbol;
+    this.id = id;
+    this.side = side;
+    this.size = size;
+    this.price = price;
+    this.timestamp = timestamp;
+    this.orderStatus = orderStatus;
+    this.currency = currency;
+    this.settleCurrency = settleCurrency;
+  }
+
+  public BigDecimal getPrice() {
+
+    return price;
+  }
+
+  public BigDecimal getVolume() {
+
+    return size;
+  }
+
+  public BitmexSide getSide() {
+
+    return side;
+  }
+
+  public String getId() {
+
+    return id;
+  }
+
+  public String getSymbol() {
+
+    return symbol;
+  }
+
+  public Date getTimestamp() {
+
+    return timestamp;
+  }
+
+  public OrderStatus getOrderStatus() {
+
+    return orderStatus;
+  }
+
+  public String getCurrency() {
+    return currency;
+  }
+
+  public String getSettleCurrency() {
+    return settleCurrency;
+  }
+
+  @Override
+  public String toString() {
+
+    return "BitmexOrder [price=" + price + ", volume=" + size + ", symbol=" + symbol + ", side=" + side +
+            ", timestamp=" + timestamp + "]";
+  }
+
+}

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountService.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bitmex.dto.account.BitmexAccount;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.FundingRecord;
@@ -26,9 +27,9 @@ public class BitmexAccountService extends BitmexAccountServiceRaw implements Acc
   }
 
   @Override
-  public AccountInfo getAccountInfo() {
-    AccountInfo accountInfo = getAccountInfo();
-    return new AccountInfo(accountInfo.getUsername());
+  public AccountInfo getAccountInfo() throws IOException {
+    BitmexAccount account = super.getBitmexAccountInfo();
+    return new AccountInfo(account.getUsername());
   }
 
   @Override

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountServiceRaw.java
@@ -13,7 +13,7 @@ import org.knowm.xchange.currency.Currency;
 
 public class BitmexAccountServiceRaw extends BitmexBaseService {
 
-  String apiKey = null;
+  String apiKey = exchange.getExchangeSpecification().getApiKey();
 
   /**
    * Constructor

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
@@ -1,12 +1,10 @@
 package org.knowm.xchange.bitmex.service;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
-import javax.crypto.Mac;
-import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
 
+import org.apache.commons.codec.binary.Hex;
 import org.knowm.xchange.service.BaseParamsDigest;
 
 import si.mazi.rescu.RestInvocation;
@@ -18,13 +16,12 @@ public class BitmexDigest extends BaseParamsDigest {
   /**
    * Constructor
    *
-   * @param secretKeyBase64
-   * @param apiKey @throws IllegalArgumentException if key is invalid (cannot be base-64-decoded or the decoded key is invalid).
+   * @param secretKeyBase64 the secret key to sign requests
    */
 
   private BitmexDigest(byte[] secretKeyBase64) {
 
-    super(secretKeyBase64, HMAC_SHA_512);
+    super(Base64.getUrlEncoder().withoutPadding().encodeToString(secretKeyBase64), HMAC_SHA_256);
   }
 
   public static BitmexDigest createInstance(String secretKeyBase64) {
@@ -38,21 +35,10 @@ public class BitmexDigest extends BaseParamsDigest {
   @Override
   public String digestParams(RestInvocation restInvocation) {
 
-    MessageDigest sha256;
-    try {
-      sha256 = MessageDigest.getInstance("SHA-256");
-    } catch (NoSuchAlgorithmException e) {
-      throw new RuntimeException("Illegal algorithm for post body digest. Check the implementation.");
-    }
-    sha256.update(restInvocation.getParamValue(FormParam.class, "nonce").toString().getBytes());
-    sha256.update(restInvocation.getRequestBody().getBytes());
+      String nonce = restInvocation.getParamValue(HeaderParam.class, "api-nonce").toString();
+      String payload = restInvocation.getHttpMethod() + "/" + restInvocation.getPath() + nonce + restInvocation.getRequestBody();
 
-    Mac mac512 = getMac();
-    mac512.update(("/" + restInvocation.getPath()).getBytes());
-    mac512.update(sha256.digest());
-
-    return Base64.getUrlEncoder().encodeToString(mac512.doFinal()).trim();
-
+      return new String(Hex.encodeHex(getMac().doFinal(payload.getBytes())));
   }
 
   private BitmexDigest(String secretKeyBase64, String apiKey) {

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
@@ -1,15 +1,14 @@
 package org.knowm.xchange.bitmex.service;
 
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 
 import javax.crypto.Mac;
 import javax.ws.rs.FormParam;
 
 import org.knowm.xchange.service.BaseParamsDigest;
 
-import net.iharder.Base64;
 import si.mazi.rescu.RestInvocation;
 
 public class BitmexDigest extends BaseParamsDigest {
@@ -30,11 +29,8 @@ public class BitmexDigest extends BaseParamsDigest {
 
   public static BitmexDigest createInstance(String secretKeyBase64) {
 
-    try {
-      if (secretKeyBase64 != null)
-        return new BitmexDigest(Base64.decode(secretKeyBase64.getBytes()));
-    } catch (IOException e) {
-      throw new IllegalArgumentException("Could not decode Base 64 string", e);
+    if (secretKeyBase64 != null) {
+      return new BitmexDigest(Base64.getUrlDecoder().decode(secretKeyBase64.getBytes()));
     }
     return null;
   }
@@ -55,7 +51,7 @@ public class BitmexDigest extends BaseParamsDigest {
     mac512.update(("/" + restInvocation.getPath()).getBytes());
     mac512.update(sha256.digest());
 
-    return Base64.encodeBytes(mac512.doFinal()).trim();
+    return Base64.getUrlEncoder().encodeToString(mac512.doFinal()).trim();
 
   }
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexDigest.java
@@ -3,6 +3,7 @@ package org.knowm.xchange.bitmex.service;
 import java.util.Base64;
 
 import javax.ws.rs.HeaderParam;
+import javax.ws.rs.QueryParam;
 
 import org.apache.commons.codec.binary.Hex;
 import org.knowm.xchange.service.BaseParamsDigest;
@@ -35,10 +36,14 @@ public class BitmexDigest extends BaseParamsDigest {
   @Override
   public String digestParams(RestInvocation restInvocation) {
 
-      String nonce = restInvocation.getParamValue(HeaderParam.class, "api-nonce").toString();
-      String payload = restInvocation.getHttpMethod() + "/" + restInvocation.getPath() + nonce + restInvocation.getRequestBody();
+    String nonce = restInvocation.getParamValue(HeaderParam.class, "api-nonce").toString();
 
-      return new String(Hex.encodeHex(getMac().doFinal(payload.getBytes())));
+    String params = restInvocation.getParamsMap().get(QueryParam.class).toString();
+    String query = params.isEmpty() ? "" : "?" + params;
+
+    String payload = restInvocation.getHttpMethod() + "/" + restInvocation.getPath() + query + nonce + restInvocation.getRequestBody();
+
+    return new String(Hex.encodeHex(getMac().doFinal(payload.getBytes())));
   }
 
   private BitmexDigest(String secretKeyBase64, String apiKey) {

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataService.java
@@ -1,17 +1,22 @@
 package org.knowm.xchange.bitmex.service;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
+import java.util.List;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitmex.BitmexAdapters;
 import org.knowm.xchange.bitmex.BitmexPrompt;
+import org.knowm.xchange.bitmex.dto.account.BitmexTicker;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
 import org.knowm.xchange.exceptions.ExchangeException;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /**
@@ -37,7 +42,25 @@ public class BitmexMarketDataService extends BitmexMarketDataServiceRaw implemen
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
 
-    throw new NotYetImplementedForExchangeException();
+    List<BitmexTicker> bitmexTickers = getTicker(currencyPair.base.toString() + currencyPair.counter.toString());
+    BitmexTicker bitmexTicker = bitmexTickers.get(0);
+
+    DateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+    Ticker ticker = null;
+
+    try {
+      ticker = new Ticker.Builder().currencyPair(currencyPair).open(bitmexTicker.getOpenValue())
+              .last(bitmexTicker.getLastPrice()).bid(bitmexTicker.getBidPrice()).ask(bitmexTicker.getAskPrice())
+              .high(bitmexTicker.getHighPrice()).low(bitmexTicker.getLowPrice())
+              .vwap(new BigDecimal(bitmexTicker.getVwap())).volume(bitmexTicker.getVolume()).quoteVolume(null)
+              .timestamp(format.parse(bitmexTicker.getTimestamp())).build();
+    } catch (ParseException e) {
+
+      return null;
+    }
+
+    return ticker;
   }
 
   @Override

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeService.java
@@ -1,9 +1,14 @@
 package org.knowm.xchange.bitmex.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bitmex.dto.marketdata.BitmexPrivateOrder;
+import org.knowm.xchange.bitmex.dto.trade.BitmexSide;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.MarketOrder;
@@ -29,7 +34,25 @@ public class BitmexTradeService extends BitmexTradeServiceRaw implements TradeSe
 
   @Override
   public OpenOrders getOpenOrders() throws IOException {
-    throw new NotYetImplementedForExchangeException();
+
+    List<BitmexPrivateOrder> bitmexOrders = super.getBitmexOrders();
+
+    List<LimitOrder> limitOrders = new ArrayList<>();
+
+    for (BitmexPrivateOrder order : bitmexOrders) {
+      if (order.getOrderStatus() == BitmexPrivateOrder.OrderStatus.Filled || order.getOrderStatus() == BitmexPrivateOrder.OrderStatus.Canceled) {
+        continue;
+      }
+
+      Order.OrderType type = order.getSide() == BitmexSide.BUY ? Order.OrderType.BID : Order.OrderType.ASK;
+      CurrencyPair pair = new CurrencyPair(order.getCurrency(), order.getSettleCurrency());
+
+      LimitOrder limitOrder = new LimitOrder(type, order.getVolume(), pair, order.getId(), order.getTimestamp(),
+              order.getPrice());
+      limitOrders.add(limitOrder);
+    }
+
+    return new OpenOrders(limitOrders);
   }
 
   @Override

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexTradeServiceRaw.java
@@ -1,10 +1,12 @@
 package org.knowm.xchange.bitmex.service;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitmex.BitmexException;
+import org.knowm.xchange.bitmex.dto.marketdata.BitmexPrivateOrder;
 import org.knowm.xchange.bitmex.dto.trade.BitmexPosition;
 
 public class BitmexTradeServiceRaw extends BitmexBaseService {
@@ -14,7 +16,7 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
    *
    * @param exchange
    */
-  String apiKey = null;
+  String apiKey = exchange.getExchangeSpecification().getApiKey();
 
   public BitmexTradeServiceRaw(Exchange exchange) {
 
@@ -37,5 +39,17 @@ public class BitmexTradeServiceRaw extends BitmexBaseService {
     } catch (BitmexException e) {
       throw handleError(e);
     }
+  }
+
+  public List<BitmexPrivateOrder> getBitmexOrders() throws IOException {
+    ArrayList<BitmexPrivateOrder> orders = new ArrayList<>();
+
+    for (int i = 0; orders.size() % 500 == 0; i++) {
+      List<BitmexPrivateOrder> orderResponse = bitmex.getOrders(apiKey, exchange.getNonceFactory(), signatureCreator,
+              null, null, 500, i * 500, true, null, null);
+      orders.addAll(orderResponse);
+    }
+
+    return orders;
   }
 }


### PR DESCRIPTION
This PR fixes a couple issues with the BitMEX adapter:
- BitMEX's API key scheme is URL-encoded.
- BitMEX allows testing via `testnet.bitmex.com`. Testnet lists different instruments than the production site, but the currency pairs were locked in from first connecting to the live site. Connecting to testnet would not update the currency pairs, and raise an exception.