### PR TITLE
[gdax] Allow listing/checking open stop orders.

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
@@ -1,7 +1,10 @@
 package org.knowm.xchange.dto.trade;
 
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.List;
+
+import org.knowm.xchange.dto.Order;
 
 /**
  * <p>
@@ -14,6 +17,7 @@ import java.util.List;
 public final class OpenOrders implements Serializable {
 
   private final List<LimitOrder> openOrders;
+  private final List<Order> hiddenOrders;
 
   /**
    * Constructor
@@ -21,30 +25,55 @@ public final class OpenOrders implements Serializable {
    * @param openOrders The list of open orders
    */
   public OpenOrders(List<LimitOrder> openOrders) {
-
     this.openOrders = openOrders;
+    this.hiddenOrders = Collections.emptyList();
   }
 
-  public List<LimitOrder> getOpenOrders() {
+  /**
+   * Constructor
+   *
+   * @param openOrders The list of open orders
+   * @param hiddenOrders The list of orders which are active but hidden from the order book.
+   */
+  public OpenOrders(List<LimitOrder> openOrders, List<Order> hiddenOrders) {
+    this.openOrders = openOrders;
+    this.hiddenOrders = hiddenOrders;
+  }
 
+  /**
+   * @return Orders which are shown on the order book.
+   */
+  public List<LimitOrder> getOpenOrders() {
     return openOrders;
+  }
+
+  /**
+   * @return Orders which are not shown on the order book, such as untriggered stop orders.
+   */
+  public List<Order> getHiddenOrders() {
+    return hiddenOrders;
   }
 
   @Override
   public String toString() {
-
     StringBuilder sb = new StringBuilder();
-    if (getOpenOrders().isEmpty()) {
-      sb.append("No open orders!");
+    addToToString(sb, getOpenOrders(), "Open orders");
+    addToToString(sb, getHiddenOrders(), "Hidden orders");
+    return sb.toString();
+  }
+
+  private void addToToString(StringBuilder sb, List<? extends Order> orders, String description) {
+    sb.append(description);
+    sb.append(": ");
+    if (orders.isEmpty()) {
+      sb.append("None\n");
     } else {
-      sb.append("Open orders: \n");
-      for (LimitOrder order : getOpenOrders()) {
-        sb.append("[order=");
+      sb.append("\n");
+      for (Order order : orders) {
+        sb.append("  [order=");
         sb.append(order.toString());
         sb.append("]\n");
       }
     }
-    return sb.toString();
   }
-
 }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
@@ -17,7 +17,7 @@ import org.knowm.xchange.dto.Order;
 public final class OpenOrders implements Serializable {
 
   private final List<LimitOrder> openOrders;
-  private final List<Order> hiddenOrders;
+  private final List<? extends Order> hiddenOrders;
 
   /**
    * Constructor
@@ -50,7 +50,7 @@ public final class OpenOrders implements Serializable {
   /**
    * @return Orders which are not shown on the order book, such as untriggered stop orders.
    */
-  public List<Order> getHiddenOrders() {
+  public List<? extends Order> getHiddenOrders() {
     return hiddenOrders;
   }
 

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAX.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAX.java
@@ -80,6 +80,11 @@ public interface GDAX {
       @HeaderParam("CB-ACCESS-TIMESTAMP") SynchronizedValueFactory<Long> nonce, @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase) throws GDAXException, IOException;
 
   @GET
+  @Path("orders")
+  GDAXOrder[] getListOrders(@HeaderParam("CB-ACCESS-KEY") String apiKey, @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer,
+      @HeaderParam("CB-ACCESS-TIMESTAMP") SynchronizedValueFactory<Long> nonce, @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase) throws GDAXException, IOException;
+
+  @GET
   @Path("orders?status={status}")
   GDAXOrder[] getListOrders(@HeaderParam("CB-ACCESS-KEY") String apiKey, @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer,
       @HeaderParam("CB-ACCESS-TIMESTAMP") SynchronizedValueFactory<Long> nonce, @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase,
@@ -98,7 +103,7 @@ public interface GDAX {
   GDAXIdResponse placeMarketOrder(GDAXPlaceOrder placeOrder, @HeaderParam("CB-ACCESS-KEY") String apiKey,
       @HeaderParam("CB-ACCESS-SIGN") ParamsDigest signer, @HeaderParam("CB-ACCESS-TIMESTAMP") SynchronizedValueFactory<Long> nonce,
       @HeaderParam("CB-ACCESS-PASSPHRASE") String passphrase) throws GDAXException, IOException;
-  
+
   @POST
   @Path("orders")
   @Consumes(MediaType.APPLICATION_JSON)

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/dto/trade/GDAXOrder.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/dto/trade/GDAXOrder.java
@@ -19,13 +19,16 @@ public class GDAXOrder {
   private final String type;
   private final String doneReason;
   private final BigDecimal executedvalue;
+  private final String stop;
+  private final BigDecimal stopPrice;
 
 
   public GDAXOrder(@JsonProperty("id") String id, @JsonProperty("price") BigDecimal price, @JsonProperty("size") BigDecimal size,
       @JsonProperty("product_id") String productId, @JsonProperty("side") String side, @JsonProperty("created_at") String createdAt,
       @JsonProperty("done_at") String doneAt, @JsonProperty("filled_size") BigDecimal filledSize, @JsonProperty("fill_fees") BigDecimal fillFees,
       @JsonProperty("status") String status, @JsonProperty("settled") boolean settled, @JsonProperty("type") String type,
-                   @JsonProperty("done_reason") String doneReason, @JsonProperty("executed_value")  BigDecimal executedValue) {
+                   @JsonProperty("done_reason") String doneReason, @JsonProperty("executed_value") BigDecimal executedValue,
+                   @JsonProperty("stop") String stop, @JsonProperty("stop_price") BigDecimal stopPrice) {
     this.id = id;
     this.price = price;
     this.size = size;
@@ -40,6 +43,8 @@ public class GDAXOrder {
     this.type = type;
     this.doneReason = doneReason;
     this.executedvalue = executedValue;
+    this.stop = stop;
+    this.stopPrice = stopPrice;
   }
 
   public String getId() {
@@ -98,6 +103,14 @@ public class GDAXOrder {
     return executedvalue;
   }
 
+  public String getStop() {
+    return stop;
+  }
+
+  public BigDecimal getStopPrice() {
+    return stopPrice;
+  }
+
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
@@ -123,8 +136,11 @@ public class GDAXOrder {
     builder.append(status);
     builder.append(", settled=");
     builder.append(settled);
+    builder.append(", stop=");
+    builder.append(stop);
+    builder.append(", stopPrice=");
+    builder.append(stopPrice);
     builder.append("]");
     return builder.toString();
   }
-
 }

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeServiceRaw.java
@@ -32,7 +32,7 @@ public class GDAXTradeServiceRaw extends GDAXBaseService {
   public GDAXOrder[] getGDAXOpenOrders() throws IOException {
 
     try {
-      return gdax.getListOrders(apiKey, digest, nonceFactory, passphrase, "open");
+      return gdax.getListOrders(apiKey, digest, nonceFactory, passphrase);
     } catch (GDAXException e) {
       throw handleError(e);
     }

--- a/xchange-gdax/src/test/resources/order/example-stop-order-filled.json
+++ b/xchange-gdax/src/test/resources/order/example-stop-order-filled.json
@@ -1,0 +1,21 @@
+  {
+    "id": "a9098e25-9d4d-4e2c-ab5e-8c057cc4cbee",
+    "price": "7225.00000000",
+    "size": "0.08871972",
+    "product_id": "BTC-EUR",
+    "side": "buy",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2018-01-08T17:55:44.454112Z",
+    "done_at": "2018-02-10T00:47:38.259Z",
+    "done_reason": "filled",
+    "fill_fees": "1.5982768838280000",
+    "filled_size": "0.08871972",
+    "executed_value": "639.3107535312000000",
+    "status": "done",
+    "settled": true,
+    "stop": "entry",
+    "stop_price": "7205.00000000"
+  }

--- a/xchange-gdax/src/test/resources/order/example-stop-order-new.json
+++ b/xchange-gdax/src/test/resources/order/example-stop-order-new.json
@@ -1,0 +1,19 @@
+  {
+    "id": "853a9989-7dd9-40f8-9392-64237a9eccc4",
+    "price": "6300.00000000",
+    "size": "0.01000000",
+    "product_id": "BTC-EUR",
+    "side": "sell",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2018-01-08T17:55:44.454112Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "active",
+    "settled": false,
+    "stop": "loss",
+    "stop_price": "6364.31000000"
+  }

--- a/xchange-gdax/src/test/resources/order/example-stop-order-stopped.json
+++ b/xchange-gdax/src/test/resources/order/example-stop-order-stopped.json
@@ -1,0 +1,19 @@
+  {
+    "id": "853a9989-7dd9-40f8-9392-64237a9eccc4",
+    "price": "6300.00000000",
+    "size": "0.01000000",
+    "product_id": "BTC-EUR",
+    "side": "sell",
+    "stp": "dc",
+    "type": "limit",
+    "time_in_force": "GTC",
+    "post_only": false,
+    "created_at": "2018-01-08T17:55:44.454112Z",
+    "fill_fees": "0.0000000000000000",
+    "filled_size": "0.00000000",
+    "executed_value": "0.0000000000000000",
+    "status": "open",
+    "settled": false,
+    "stop": "loss",
+    "stop_price": "6364.31000000"
+  }


### PR DESCRIPTION
I figure that returning "non book" orders might represent a material change to the API of `OpenOrders` which might break existing clients, so I've suggested a new `OpenOrders.getHiddenOrders` method to expose those.  This could be used for other non book orders like hidden orders on BFX.

Implements #1865, #2177