### PR TITLE
[Cex IO] Adding a remote init to get the correct minimumAmounts

### DIFF
--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIO.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIO.java
@@ -11,6 +11,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
 import org.knowm.xchange.cexio.dto.marketdata.CexIODepth;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTicker;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTrade;
@@ -38,5 +39,9 @@ public interface CexIO {
   @Path("trade_history/{ident}/{currency}/")
   CexIOTrade[] getTradesSince(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency,
       @DefaultValue("1") @FormParam("since") long since) throws IOException;
+
+  @GET
+  @Path("currency_limits")
+  CexIOCurrencyLimits getCurrencyLimits() throws IOException;
 
 }

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAuthenticated.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOAuthenticated.java
@@ -20,6 +20,7 @@ import org.knowm.xchange.cexio.dto.CexioSingleOrderIdRequest;
 import org.knowm.xchange.cexio.dto.PlaceOrderRequest;
 import org.knowm.xchange.cexio.dto.account.CexIOBalanceInfo;
 import org.knowm.xchange.cexio.dto.account.CexIOCryptoAddress;
+import org.knowm.xchange.cexio.dto.account.CexIOFeeInfo;
 import org.knowm.xchange.cexio.dto.account.GHashIOHashrate;
 import org.knowm.xchange.cexio.dto.account.GHashIOWorkers;
 import org.knowm.xchange.cexio.dto.trade.CexIOArchivedOrder;
@@ -34,6 +35,10 @@ import si.mazi.rescu.ParamsDigest;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public interface CexIOAuthenticated extends CexIO {
+
+  @POST
+  @Path("get_myfee")
+  CexIOFeeInfo getMyFee(@HeaderParam("signature") ParamsDigest signer, CexIORequest cexIORequest) throws IOException;
 
   @POST
   @Path("balance/")

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOExchange.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/CexIOExchange.java
@@ -3,12 +3,18 @@ package org.knowm.xchange.cexio;
 import org.knowm.xchange.BaseExchange;
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
 import org.knowm.xchange.cexio.service.CexIOAccountService;
 import org.knowm.xchange.cexio.service.CexIOMarketDataService;
 import org.knowm.xchange.cexio.service.CexIOTradeService;
+import org.knowm.xchange.currency.CurrencyPair;
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.utils.nonce.AtomicLongIncrementalTime2014NonceFactory;
-
 import si.mazi.rescu.SynchronizedValueFactory;
+
+import java.io.IOException;
+import java.util.Map;
 
 public class CexIOExchange extends BaseExchange implements Exchange {
 
@@ -32,6 +38,31 @@ public class CexIOExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setExchangeDescription("Cex.IO is a virtual commodities exchange registered in United Kingdom.");
 
     return exchangeSpecification;
+  }
+
+  @Override
+  public void remoteInit() throws IOException, ExchangeException {
+    logger.info("Attempting remoteInit for {}", getExchangeSpecification().getExchangeName());
+    final CexIOCurrencyLimits currencyLimits = ((CexIOMarketDataService) this.marketDataService).getCurrencyLimits();
+    //Working with the live map so the changes reflect
+    final Map<CurrencyPair, CurrencyPairMetaData> currencyPairs = getExchangeMetaData().getCurrencyPairs();
+
+    for (CexIOCurrencyLimits.Pair pair : currencyLimits.getData().getPairs()) {
+      CurrencyPair currencyPair = new CurrencyPair(pair.getSymbol1(), pair.getSymbol2());
+      CurrencyPairMetaData metaData = new CurrencyPairMetaData(null, pair.getMinLotSize(),
+              pair.getMaxLotSize(), null);
+      currencyPairs.merge(currencyPair, metaData, (oldMetaData, newMetaData) ->
+              new CurrencyPairMetaData(
+                      // trading fee is not present in this response. using the previous values.
+                      oldMetaData.getTradingFee(),
+                      newMetaData.getMinimumAmount(),
+                      // some maximumAmount's in the currency_limits api response are null - using the json values
+                      newMetaData.getMaximumAmount() != null ? newMetaData.getMaximumAmount() : oldMetaData.getMaximumAmount(),
+                      oldMetaData.getPriceScale()
+              )
+      );
+    }
+    logger.info("remoteInit successful for {}", getExchangeSpecification().getExchangeName());
   }
 
   @Override

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexIOApiResponse.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexIOApiResponse.java
@@ -3,13 +3,13 @@ package org.knowm.xchange.cexio.dto;
 /**
  * @author ujjwal on 13/02/18.
  */
-public abstract class CexIOApiResponse {
+public abstract class CexIOApiResponse<T> {
   private final String e;
-  private final Object data;
+  private final T data;
   private final String ok;
   private final String error;
 
-  protected CexIOApiResponse(String e, Object data, String ok, String error) {
+  protected CexIOApiResponse(String e, T data, String ok, String error) {
     this.e = e;
     this.data = data;
     this.ok = ok;
@@ -20,7 +20,7 @@ public abstract class CexIOApiResponse {
     return e;
   }
 
-  public Object getData() {
+  public T getData() {
     return data;
   }
 

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexIOApiResponse.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/CexIOApiResponse.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.cexio.dto;
+
+/**
+ * @author ujjwal on 13/02/18.
+ */
+public abstract class CexIOApiResponse {
+  private final String e;
+  private final Object data;
+  private final String ok;
+  private final String error;
+
+  protected CexIOApiResponse(String e, Object data, String ok, String error) {
+    this.e = e;
+    this.data = data;
+    this.ok = ok;
+    this.error = error;
+  }
+
+  public String getE() {
+    return e;
+  }
+
+  public Object getData() {
+    return data;
+  }
+
+  public String getOk() {
+    return ok;
+  }
+
+  public String getError() {
+    return error;
+  }
+}

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/account/CexIOFeeInfo.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/account/CexIOFeeInfo.java
@@ -1,0 +1,66 @@
+package org.knowm.xchange.cexio.dto.account;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import org.knowm.xchange.cexio.dto.CexIOApiResponse;
+import org.knowm.xchange.currency.CurrencyPair;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.KeyDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * @author ujjwal on 14/02/18.
+ */
+public class CexIOFeeInfo extends CexIOApiResponse<Map<CurrencyPair, CexIOFeeInfo.FeeDetails>> {
+
+  public CexIOFeeInfo(@JsonProperty("e") String e, @JsonProperty("data") @JsonDeserialize(keyUsing = CurrencyPairKeyDeserializer.class)
+      Map<CurrencyPair,
+          FeeDetails> data,
+      @JsonProperty("ok")
+          String ok,
+      @JsonProperty("error") String error) {
+    super(e, data, ok, error);
+  }
+
+  public static class CurrencyPairKeyDeserializer extends KeyDeserializer {
+    @Override
+    public CurrencyPair deserializeKey(String value, DeserializationContext deserializationContext) {
+      String[] currencies = value.split(":");
+      return new CurrencyPair(currencies[0], currencies[1]);
+    }
+  }
+
+  public static class FeeDetails {
+    private final BigDecimal sell;
+    private final BigDecimal sellMaker;
+    private final BigDecimal buy;
+    private final BigDecimal buyMaker;
+
+    public FeeDetails(@JsonProperty("sell") BigDecimal sell, @JsonProperty("sellMaker") BigDecimal sellMaker, @JsonProperty("buy") BigDecimal buy,
+        @JsonProperty("buyMaker") BigDecimal buyMaker) {
+      this.sell = sell;
+      this.sellMaker = sellMaker;
+      this.buy = buy;
+      this.buyMaker = buyMaker;
+    }
+
+    public BigDecimal getSell() {
+      return sell;
+    }
+
+    public BigDecimal getSellMaker() {
+      return sellMaker;
+    }
+
+    public BigDecimal getBuy() {
+      return buy;
+    }
+
+    public BigDecimal getBuyMaker() {
+      return buyMaker;
+    }
+  }
+}

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
@@ -11,15 +11,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * @author ujjwal on 13/02/18.
  */
-public class CexIOCurrencyLimits extends CexIOApiResponse {
+public class CexIOCurrencyLimits extends CexIOApiResponse<CexIOCurrencyLimits.Data> {
 
   public CexIOCurrencyLimits(@JsonProperty("e") final String e, @JsonProperty("data") final Data data,
       @JsonProperty("ok") final String ok, @JsonProperty("error") final String error) {
     super(e, data, ok, error);
-  }
-
-  public Data getData() {
-    return (Data) super.getData();
   }
 
   public static class Data {

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
@@ -1,0 +1,101 @@
+package org.knowm.xchange.cexio.dto.marketdata;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.knowm.xchange.cexio.dto.CexIOApiResponse;
+import org.knowm.xchange.currency.Currency;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * @author ujjwal on 13/02/18.
+ */
+public class CexIOCurrencyLimits extends CexIOApiResponse {
+
+  public CexIOCurrencyLimits(@JsonProperty("e") final String e, @JsonProperty("data") final Data data,
+                             @JsonProperty("ok") final String ok, @JsonProperty("error") final String error) {
+    super(e, data, ok, error);
+  }
+
+  public Data getData() {
+    return (Data) super.getData();
+  }
+
+  public static class Data {
+    private final List<Pair> pairs;
+
+    public Data(@JsonProperty("pairs") List<Pair> pairs) {
+      this.pairs = pairs;
+    }
+
+    public List<Pair> getPairs() {
+      return pairs;
+    }
+  }
+
+  public static class Pair {
+    private final Currency symbol1;
+    private final Currency symbol2;
+    private final BigDecimal minLotSize;
+    private final BigDecimal minLotSizeS2;
+    private final BigDecimal maxLotSize;
+    private final BigDecimal minPrice;
+    private final BigDecimal maxPrice;
+
+    public Pair(@JsonProperty("symbol1") Currency symbol1, @JsonProperty("symbol2") Currency symbol2,
+                @JsonProperty("minLotSize") BigDecimal minLotSize,
+                @JsonProperty("minLotSizeS2") BigDecimal minLotSizeS2,
+                @JsonProperty("maxLotSize") BigDecimal maxLotSize,
+                @JsonProperty("minPrice") BigDecimal minPrice, @JsonProperty("maxPrice") BigDecimal maxPrice) {
+      this.symbol1 = symbol1;
+      this.symbol2 = symbol2;
+      this.minLotSize = minLotSize;
+      this.minLotSizeS2 = minLotSizeS2;
+      this.maxLotSize = maxLotSize;
+      this.minPrice = minPrice;
+      this.maxPrice = maxPrice;
+    }
+
+    public Currency getSymbol1() {
+      return symbol1;
+    }
+
+    public Currency getSymbol2() {
+      return symbol2;
+    }
+
+    public BigDecimal getMinLotSize() {
+      return minLotSize;
+    }
+
+    public BigDecimal getMinLotSizeS2() {
+      return minLotSizeS2;
+    }
+
+    public BigDecimal getMaxLotSize() {
+      return maxLotSize;
+    }
+
+    public BigDecimal getMinPrice() {
+      return minPrice;
+    }
+
+    public BigDecimal getMaxPrice() {
+      return maxPrice;
+    }
+
+    @Override
+    public String toString() {
+      final StringBuilder sb = new StringBuilder("Pair{");
+      sb.append("symbol1=").append(symbol1);
+      sb.append(", symbol2=").append(symbol2);
+      sb.append(", minLotSize=").append(minLotSize);
+      sb.append(", minLotSizeS2=").append(minLotSizeS2);
+      sb.append(", maxLotSize=").append(maxLotSize);
+      sb.append(", minPrice=").append(minPrice);
+      sb.append(", maxPrice=").append(maxPrice);
+      sb.append('}');
+      return sb.toString();
+    }
+  }
+}

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimits.java
@@ -1,11 +1,12 @@
 package org.knowm.xchange.cexio.dto.marketdata;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
+import java.util.List;
+
 import org.knowm.xchange.cexio.dto.CexIOApiResponse;
 import org.knowm.xchange.currency.Currency;
 
-import java.math.BigDecimal;
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * @author ujjwal on 13/02/18.
@@ -13,7 +14,7 @@ import java.util.List;
 public class CexIOCurrencyLimits extends CexIOApiResponse {
 
   public CexIOCurrencyLimits(@JsonProperty("e") final String e, @JsonProperty("data") final Data data,
-                             @JsonProperty("ok") final String ok, @JsonProperty("error") final String error) {
+      @JsonProperty("ok") final String ok, @JsonProperty("error") final String error) {
     super(e, data, ok, error);
   }
 
@@ -43,10 +44,10 @@ public class CexIOCurrencyLimits extends CexIOApiResponse {
     private final BigDecimal maxPrice;
 
     public Pair(@JsonProperty("symbol1") Currency symbol1, @JsonProperty("symbol2") Currency symbol2,
-                @JsonProperty("minLotSize") BigDecimal minLotSize,
-                @JsonProperty("minLotSizeS2") BigDecimal minLotSizeS2,
-                @JsonProperty("maxLotSize") BigDecimal maxLotSize,
-                @JsonProperty("minPrice") BigDecimal minPrice, @JsonProperty("maxPrice") BigDecimal maxPrice) {
+        @JsonProperty("minLotSize") BigDecimal minLotSize,
+        @JsonProperty("minLotSizeS2") BigDecimal minLotSizeS2,
+        @JsonProperty("maxLotSize") BigDecimal maxLotSize,
+        @JsonProperty("minPrice") BigDecimal minPrice, @JsonProperty("maxPrice") BigDecimal maxPrice) {
       this.symbol1 = symbol1;
       this.symbol2 = symbol2;
       this.minLotSize = minLotSize;
@@ -86,16 +87,14 @@ public class CexIOCurrencyLimits extends CexIOApiResponse {
 
     @Override
     public String toString() {
-      final StringBuilder sb = new StringBuilder("Pair{");
-      sb.append("symbol1=").append(symbol1);
-      sb.append(", symbol2=").append(symbol2);
-      sb.append(", minLotSize=").append(minLotSize);
-      sb.append(", minLotSizeS2=").append(minLotSizeS2);
-      sb.append(", maxLotSize=").append(maxLotSize);
-      sb.append(", minPrice=").append(minPrice);
-      sb.append(", maxPrice=").append(maxPrice);
-      sb.append('}');
-      return sb.toString();
+      return "Pair{" + "symbol1=" + symbol1 +
+          ", symbol2=" + symbol2 +
+          ", minLotSize=" + minLotSize +
+          ", minLotSizeS2=" + minLotSizeS2 +
+          ", maxLotSize=" + maxLotSize +
+          ", minPrice=" + minPrice +
+          ", maxPrice=" + maxPrice +
+          '}';
     }
   }
 }

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOAccountServiceRaw.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange.cexio.service;
 
+import static org.knowm.xchange.cexio.dto.account.CexIOFeeInfo.FeeDetails;
+
 import java.io.IOException;
 import java.util.Map;
 
@@ -10,6 +12,7 @@ import org.knowm.xchange.cexio.dto.account.CexIOBalanceInfo;
 import org.knowm.xchange.cexio.dto.account.CexIOCryptoAddress;
 import org.knowm.xchange.cexio.dto.account.GHashIOHashrate;
 import org.knowm.xchange.cexio.dto.account.GHashIOWorker;
+import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.exceptions.ExchangeException;
 
 public class CexIOAccountServiceRaw extends CexIOBaseService {
@@ -27,10 +30,10 @@ public class CexIOAccountServiceRaw extends CexIOBaseService {
 
     return info;
   }
-  
+
   public CexIOCryptoAddress getCexIOCryptoAddress(String isoCode) throws IOException {
     CexIOCryptoAddress cryptoAddress = cexIOAuthenticated.getCryptoAddress(signatureCreator, new CexioCryptoAddressRequest(isoCode));
-    if ( cryptoAddress.getOk().equals("ok"))
+    if (cryptoAddress.getOk().equals("ok"))
       return cryptoAddress;
 
     throw new ExchangeException(cryptoAddress.getE() + ": " + cryptoAddress.getError());
@@ -42,6 +45,10 @@ public class CexIOAccountServiceRaw extends CexIOBaseService {
 
   public Map<String, GHashIOWorker> getWorkers() throws IOException {
     return cexIOAuthenticated.getWorkers(signatureCreator).getWorkers();
+  }
+
+  public Map<CurrencyPair, FeeDetails> getMyFee() throws IOException {
+    return cexIOAuthenticated.getMyFee(signatureCreator, new CexIORequest()).getData();
   }
 
 }

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
@@ -1,5 +1,7 @@
 package org.knowm.xchange.cexio.service;
 
+import java.io.IOException;
+
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.cexio.CexIO;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
@@ -7,9 +9,8 @@ import org.knowm.xchange.cexio.dto.marketdata.CexIODepth;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTicker;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTrade;
 import org.knowm.xchange.currency.CurrencyPair;
-import si.mazi.rescu.RestProxyFactory;
 
-import java.io.IOException;
+import si.mazi.rescu.RestProxyFactory;
 
 /**
  * @author timmolter

--- a/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
+++ b/xchange-cexio/src/main/java/org/knowm/xchange/cexio/service/CexIOMarketDataServiceRaw.java
@@ -1,15 +1,15 @@
 package org.knowm.xchange.cexio.service;
 
-import java.io.IOException;
-
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.cexio.CexIO;
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
 import org.knowm.xchange.cexio.dto.marketdata.CexIODepth;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTicker;
 import org.knowm.xchange.cexio.dto.marketdata.CexIOTrade;
 import org.knowm.xchange.currency.CurrencyPair;
-
 import si.mazi.rescu.RestProxyFactory;
+
+import java.io.IOException;
 
 /**
  * @author timmolter
@@ -55,6 +55,10 @@ public class CexIOMarketDataServiceRaw extends CexIOBaseService {
     }
 
     return trades;
+  }
+
+  public CexIOCurrencyLimits getCurrencyLimits() throws IOException {
+    return cexio.getCurrencyLimits();
   }
 
 }

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/dto/account/CexIOFeeInfoTest.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/dto/account/CexIOFeeInfoTest.java
@@ -1,0 +1,40 @@
+package org.knowm.xchange.cexio.dto.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.knowm.xchange.currency.Currency.GBP;
+import static org.knowm.xchange.currency.Currency.ZEC;
+import static org.knowm.xchange.currency.CurrencyPair.BCH_GBP;
+import static org.knowm.xchange.currency.CurrencyPair.ETH_USD;
+import static org.knowm.xchange.currency.CurrencyPair.ZEC_BTC;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Test;
+import org.knowm.xchange.currency.CurrencyPair;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author ujjwal on 14/02/18.
+ */
+public class CexIOFeeInfoTest {
+  @Test
+  public void jsonMapperTest() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/account/sample_get_myfee.json");
+    ObjectMapper mapper = new ObjectMapper();
+    final CexIOFeeInfo cexIOFeeInfo = mapper.readValue(is, CexIOFeeInfo.class);
+    assertThat(cexIOFeeInfo).isNotNull();
+    assertThat(cexIOFeeInfo.getE()).isEqualToIgnoringCase("get_myfee");
+    assertThat(cexIOFeeInfo.getOk()).isEqualToIgnoringCase("ok");
+    assertThat(cexIOFeeInfo.getData()).isNotEmpty()
+        .containsKeys(ETH_USD, BCH_GBP, ZEC_BTC, new CurrencyPair(ZEC, GBP));
+    final CexIOFeeInfo.FeeDetails feeDetails = cexIOFeeInfo.getData().get(ETH_USD);
+    assertThat(feeDetails).isNotNull();
+    assertThat(feeDetails.getBuy()).isNotNull();
+    assertThat(feeDetails.getBuyMaker()).isNotNull();
+    assertThat(feeDetails.getSell()).isNotNegative();
+    assertThat(feeDetails.getSellMaker()).isNotNegative();
+  }
+
+}

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimitsTest.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/dto/marketdata/CexIOCurrencyLimitsTest.java
@@ -1,4 +1,4 @@
-package org.knowm.xchange.cexio.service.marketdata;
+package org.knowm.xchange.cexio.dto.marketdata;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -6,16 +6,15 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.junit.Test;
-import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author ujjwal on 13/02/18.
  */
-public class RemoteInitTest {
+public class CexIOCurrencyLimitsTest {
   @Test
-  public void unitJsonMapperTest() throws IOException {
+  public void jsonMapperTest() throws IOException {
     InputStream is = getClass().getResourceAsStream("/marketdata/sample_currency_limits.json");
     ObjectMapper mapper = new ObjectMapper();
     final CexIOCurrencyLimits cexIOCurrencyLimits = mapper.readValue(is, CexIOCurrencyLimits.class);

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitIntegration.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitIntegration.java
@@ -1,0 +1,31 @@
+package org.knowm.xchange.cexio.service.marketdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.cexio.CexIOExchange;
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
+import org.knowm.xchange.cexio.service.CexIOMarketDataService;
+
+/**
+ * @author ujjwal on 14/02/18.
+ */
+public class RemoteInitIntegration {
+  @Test
+  public void integrationTest() throws IOException {
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
+
+    assertThat(exchange).isNotNull();
+    assertThat(exchange.getExchangeMetaData().getCurrencyPairs()).isNotEmpty();
+
+    final CexIOCurrencyLimits currencyLimits = ((CexIOMarketDataService) exchange.getMarketDataService()).getCurrencyLimits();
+    assertThat(currencyLimits.getE()).isEqualToIgnoringCase("currency_limits");
+    assertThat(currencyLimits.getError()).isNullOrEmpty();
+    assertThat(currencyLimits.getOk()).isEqualToIgnoringCase("ok");
+
+  }
+}

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitTest.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitTest.java
@@ -1,0 +1,49 @@
+package org.knowm.xchange.cexio.service.marketdata;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeFactory;
+import org.knowm.xchange.cexio.CexIOExchange;
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
+import org.knowm.xchange.cexio.service.CexIOMarketDataService;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author ujjwal on 13/02/18.
+ */
+public class RemoteInitTest {
+  @Test
+  public void unitJsonMapperTest() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/marketdata/sample_currency_limits.json");
+    ObjectMapper mapper = new ObjectMapper();
+    final CexIOCurrencyLimits cexIOCurrencyLimits = mapper.readValue(is, CexIOCurrencyLimits.class);
+    assertThat(cexIOCurrencyLimits).isNotNull();
+    assertThat(cexIOCurrencyLimits.getData().getPairs().size()).isBetween(1, 30);
+    assertThat(cexIOCurrencyLimits.getData().getPairs()).allSatisfy(pair -> {
+      assertThat(pair.getSymbol1()).isNotNull();
+      assertThat(pair.getSymbol2()).isNotNull();
+      assertThat(pair.getMinLotSize()).isPositive();
+      // we don't care about the other parameters for now.
+    });
+
+  }
+
+  @Test
+  public void integrationTest() throws IOException {
+    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
+
+    assertThat(exchange).isNotNull();
+    assertThat(exchange.getExchangeMetaData().getCurrencyPairs()).isNotEmpty();
+
+    final CexIOCurrencyLimits currencyLimits = ((CexIOMarketDataService) exchange.getMarketDataService()).getCurrencyLimits();
+    assertThat(currencyLimits.getE()).isEqualToIgnoringCase("currency_limits");
+    assertThat(currencyLimits.getError()).isNullOrEmpty();
+    assertThat(currencyLimits.getOk()).isEqualToIgnoringCase("ok");
+
+  }
+}

--- a/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitTest.java
+++ b/xchange-cexio/src/test/java/org/knowm/xchange/cexio/service/marketdata/RemoteInitTest.java
@@ -1,17 +1,14 @@
 package org.knowm.xchange.cexio.service.marketdata;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.knowm.xchange.Exchange;
-import org.knowm.xchange.ExchangeFactory;
-import org.knowm.xchange.cexio.CexIOExchange;
-import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
-import org.knowm.xchange.cexio.service.CexIOMarketDataService;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.knowm.xchange.cexio.dto.marketdata.CexIOCurrencyLimits;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * @author ujjwal on 13/02/18.
@@ -33,17 +30,4 @@ public class RemoteInitTest {
 
   }
 
-  @Test
-  public void integrationTest() throws IOException {
-    final Exchange exchange = ExchangeFactory.INSTANCE.createExchange(CexIOExchange.class);
-
-    assertThat(exchange).isNotNull();
-    assertThat(exchange.getExchangeMetaData().getCurrencyPairs()).isNotEmpty();
-
-    final CexIOCurrencyLimits currencyLimits = ((CexIOMarketDataService) exchange.getMarketDataService()).getCurrencyLimits();
-    assertThat(currencyLimits.getE()).isEqualToIgnoringCase("currency_limits");
-    assertThat(currencyLimits.getError()).isNullOrEmpty();
-    assertThat(currencyLimits.getOk()).isEqualToIgnoringCase("ok");
-
-  }
 }

--- a/xchange-cexio/src/test/resources/account/sample_get_myfee.json
+++ b/xchange-cexio/src/test/resources/account/sample_get_myfee.json
@@ -1,0 +1,30 @@
+{
+  "ok": "ok",
+  "e": "get_myfee",
+  "data": {
+    "ETH:USD": {
+      "sell": "0.15",
+      "buyMaker": "0",
+      "buy": "0.15",
+      "sellMaker": "0"
+    },
+    "BCH:GBP": {
+      "sell": "0.15",
+      "buyMaker": "0",
+      "buy": "0.15",
+      "sellMaker": "0"
+    },
+    "ZEC:BTC": {
+      "sell": "0.15",
+      "buyMaker": "0",
+      "buy": "0.15",
+      "sellMaker": "0"
+    },
+    "ZEC:GBP": {
+      "sell": "0.15",
+      "buyMaker": "0",
+      "buy": "0.15",
+      "sellMaker": "0"
+    }
+  }
+}

--- a/xchange-cexio/src/test/resources/marketdata/sample_currency_limits.json
+++ b/xchange-cexio/src/test/resources/marketdata/sample_currency_limits.json
@@ -1,0 +1,278 @@
+{
+  "e": "currency_limits",
+  "ok": "ok",
+  "data": {
+    "pairs": [
+      {
+        "symbol1": "BTC",
+        "symbol2": "USD",
+        "minLotSize": 0.002,
+        "minLotSizeS2": 20,
+        "maxLotSize": 30,
+        "minPrice": "1500",
+        "maxPrice": "35000"
+      },
+      {
+        "symbol1": "ETH",
+        "symbol2": "USD",
+        "minLotSize": 0.05,
+        "minLotSizeS2": 20,
+        "maxLotSize": 1000,
+        "minPrice": "70",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "BCH",
+        "symbol2": "USD",
+        "minLotSize": 0.02,
+        "minLotSizeS2": 20,
+        "maxLotSize": 30,
+        "minPrice": "150",
+        "maxPrice": "8192"
+      },
+      {
+        "symbol1": "BTG",
+        "symbol2": "USD",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "5",
+        "maxPrice": "2048"
+      },
+      {
+        "symbol1": "DASH",
+        "symbol2": "USD",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "100",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "XRP",
+        "symbol2": "USD",
+        "minLotSize": 40,
+        "minLotSizeS2": 10,
+        "maxLotSize": null,
+        "minPrice": "0.05",
+        "maxPrice": "50"
+      },
+      {
+        "symbol1": "XLM",
+        "symbol2": "USD",
+        "minLotSize": 70,
+        "minLotSizeS2": 10,
+        "maxLotSize": null,
+        "minPrice": "0.03",
+        "maxPrice": "50"
+      },
+      {
+        "symbol1": "ZEC",
+        "symbol2": "USD",
+        "minLotSize": 0.07,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "50",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "BTC",
+        "symbol2": "EUR",
+        "minLotSize": 0.002,
+        "minLotSizeS2": 20,
+        "maxLotSize": 30,
+        "minPrice": "1500",
+        "maxPrice": "35000"
+      },
+      {
+        "symbol1": "ETH",
+        "symbol2": "EUR",
+        "minLotSize": 0.05,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "70",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "BCH",
+        "symbol2": "EUR",
+        "minLotSize": 0.02,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "150",
+        "maxPrice": "8192"
+      },
+      {
+        "symbol1": "BTG",
+        "symbol2": "EUR",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "5",
+        "maxPrice": "2048"
+      },
+      {
+        "symbol1": "DASH",
+        "symbol2": "EUR",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "100",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "XRP",
+        "symbol2": "EUR",
+        "minLotSize": 40,
+        "minLotSizeS2": 10,
+        "maxLotSize": null,
+        "minPrice": "0.05",
+        "maxPrice": "50"
+      },
+      {
+        "symbol1": "XLM",
+        "symbol2": "EUR",
+        "minLotSize": 70,
+        "minLotSizeS2": 10,
+        "maxLotSize": null,
+        "minPrice": "0.03",
+        "maxPrice": "50"
+      },
+      {
+        "symbol1": "ZEC",
+        "symbol2": "EUR",
+        "minLotSize": 0.07,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "50",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "BTC",
+        "symbol2": "GBP",
+        "minLotSize": 0.002,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "1300",
+        "maxPrice": "30000"
+      },
+      {
+        "symbol1": "ETH",
+        "symbol2": "GBP",
+        "minLotSize": 0.05,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "60",
+        "maxPrice": "5128"
+      },
+      {
+        "symbol1": "BCH",
+        "symbol2": "GBP",
+        "minLotSize": 0.02,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "150",
+        "maxPrice": "8192"
+      },
+      {
+        "symbol1": "DASH",
+        "symbol2": "GBP",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "100",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "ZEC",
+        "symbol2": "GBP",
+        "minLotSize": 0.07,
+        "minLotSizeS2": 20,
+        "maxLotSize": null,
+        "minPrice": "40",
+        "maxPrice": "4096"
+      },
+      {
+        "symbol1": "BTC",
+        "symbol2": "RUB",
+        "minLotSize": 0.001,
+        "minLotSizeS2": 1000,
+        "maxLotSize": null,
+        "minPrice": "10000",
+        "maxPrice": "2000000"
+      },
+      {
+        "symbol1": "ETH",
+        "symbol2": "BTC",
+        "minLotSize": 0.025,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": 1000,
+        "minPrice": "0.025",
+        "maxPrice": "2"
+      },
+      {
+        "symbol1": "BCH",
+        "symbol2": "BTC",
+        "minLotSize": 0.007,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": 30,
+        "minPrice": "0.005",
+        "maxPrice": "2"
+      },
+      {
+        "symbol1": "BTG",
+        "symbol2": "BTC",
+        "minLotSize": 0.01,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": null,
+        "minPrice": "0.001",
+        "maxPrice": "2"
+      },
+      {
+        "symbol1": "DASH",
+        "symbol2": "BTC",
+        "minLotSize": 0.015,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": null,
+        "minPrice": "0.005",
+        "maxPrice": "2"
+      },
+      {
+        "symbol1": "XRP",
+        "symbol2": "BTC",
+        "minLotSize": 40,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": null,
+        "minPrice": "0.000003",
+        "maxPrice": "0.001"
+      },
+      {
+        "symbol1": "XLM",
+        "symbol2": "BTC",
+        "minLotSize": 70,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": null,
+        "minPrice": "0.000001",
+        "maxPrice": "0.0005"
+      },
+      {
+        "symbol1": "ZEC",
+        "symbol2": "BTC",
+        "minLotSize": 0.03,
+        "minLotSizeS2": 0.001,
+        "maxLotSize": null,
+        "minPrice": "0.005",
+        "maxPrice": "2"
+      },
+      {
+        "symbol1": "GHS",
+        "symbol2": "BTC",
+        "minLotSize": 100,
+        "minLotSizeS2": 0.00001,
+        "maxLotSize": null,
+        "minPrice": "0.000001",
+        "maxPrice": "0.01"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This irked me a bit - cex.io actually has a fairly varied set of limits, and the included json was static data, so needed to fix.