### PR TITLE
[bitmex] add pagination for getTrade requests with > 100 responses

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/Bitmex.java
@@ -61,7 +61,9 @@ public interface Bitmex {
 
   @GET
   @Path("trade")
-  BitmexPublicTrade[] getTrades(@QueryParam("symbol") String currencyPair, @QueryParam("reverse") Boolean reverse) throws IOException;
+  BitmexPublicTrade[] getTrades(@QueryParam("symbol") String currencyPair, @QueryParam("reverse") Boolean reverse,
+                                @Nullable @QueryParam("count") Integer count,
+                                @Nullable @QueryParam("start") Integer start) throws IOException;
 
   @GET
   @Path("orderBook/L2")

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexAdapters.java
@@ -67,14 +67,14 @@ public class BitmexAdapters {
 
   }
 
-  public static Trades adaptTrades(BitmexPublicTrade[] trades, CurrencyPair currencyPair) {
+  public static Trades adaptTrades(List<BitmexPublicTrade> trades, CurrencyPair currencyPair) {
 
-    List<Trade> tradeList = new ArrayList<>(trades.length);
-    for (int i = 0; i < trades.length; i++) {
-      BitmexPublicTrade trade = trades[i];
+    List<Trade> tradeList = new ArrayList<>(trades.size());
+    for (int i = 0; i < trades.size(); i++) {
+      BitmexPublicTrade trade = trades.get(i);
       tradeList.add(adaptTrade(trade, currencyPair));
     }
-    long lastTid = trades.length > 0 ? (trades[0].getTime().getTime()) : 0;
+    long lastTid = trades.size() > 0 ? (trades.get(0).getTime().getTime()) : 0;
     // long lastTid = 0L;
     return new Trades(tradeList, lastTid, TradeSortType.SortByTimestamp);
   }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceRaw.java
@@ -1,9 +1,7 @@
 package org.knowm.xchange.bitmex.service;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.bitmex.BitmexAdapters;
@@ -60,17 +58,24 @@ public class BitmexMarketDataServiceRaw extends BitmexBaseService {
 
   public Trades getBitmexTrades(CurrencyPair pair, BitmexPrompt prompt, Object... args) throws IOException {
 
+    List<BitmexPublicTrade> trades = new ArrayList<>();
+
     BitmexContract contract = new BitmexContract(pair, prompt);
     String bitmexSymbol = BitmexUtils.translateBitmexContract(contract);
-    BitmexPublicTrade[] result = bitmex.getTrades(bitmexSymbol, true);
 
-    if (pair != null && prompt != null)
-      return BitmexAdapters.adaptTrades(result, pair);
+    Integer limit = (Integer) args[0];
 
-    // return result;
+    for (int i = 0; trades.size() + 500 <= limit; i++) {
+      BitmexPublicTrade[] result = bitmex.getTrades(bitmexSymbol, true, 500, i * 500);
+      trades.addAll(Arrays.asList(result));
+    }
+
+    if (pair != null && prompt != null) {
+      List<BitmexPublicTrade> trimmed = trades.subList(0, Math.min(limit, trades.size()));
+      return BitmexAdapters.adaptTrades(trimmed, pair);
+    }
+
     return null;
-
-    // return checkResult(result);
   }
 
   public List<BitmexTicker> getTicker(String symbol) throws IOException {


### PR DESCRIPTION
This PR fixes an issue where getTrades() would be limited to 100 responses.