### PR TITLE
[abucoins] API was updated on abucoins, adding new methods

### DIFF
--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/Abucoins.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/Abucoins.java
@@ -9,6 +9,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import org.knowm.xchange.abucoins.dto.AbucoinsServerTime;
+import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsFullTicker;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsHistoricRates;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsOrderBook;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsProduct;
@@ -41,6 +42,10 @@ public interface Abucoins {
   @GET
   @Path("products/{product-id}/book?level={level}")
   AbucoinsOrderBook getBook(@PathParam("product-id") String product_id, @PathParam("level") String level) throws IOException;
+  
+  @GET
+  @Path("products/ticker")
+  AbucoinsFullTicker[] getTicker() throws IOException;
 
   @GET
   @Path("products/{product-id}/ticker")

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
@@ -211,8 +211,13 @@ public class AbucoinsAdapters {
   }
 
   public static LimitOrder createOrder(CurrencyPair currencyPair, AbucoinsOrderBook.LimitOrder priceAndAmount, OrderType orderType) {
-
-    return new LimitOrder(orderType, priceAndAmount.getSize(), currencyPair, "", null, priceAndAmount.getPrice()); //??
+    return new LimitOrder.Builder(orderType, currencyPair)
+    		.averagePrice(priceAndAmount.getPrice())
+    		.cumulativeAmount( priceAndAmount.getSize())
+    		.limitPrice(priceAndAmount.getPrice())
+    		.orderStatus(OrderStatus.NEW)
+    		.originalAmount(priceAndAmount.getSize())
+    		.build();
   }
   
   public static OpenOrders adaptOpenOrders(AbucoinsOrder[] orders) {
@@ -239,25 +244,28 @@ public class AbucoinsAdapters {
   }
   
   public static LimitOrder adaptLimitOrder(AbucoinsOrder order) {
-    return new LimitOrder( adaptOrderType(order.getSide()),
-                           order.getSize(),
-                           order.getFilledSize(),
-                           adaptCurrencyPair( order.getProductID() ),
-                           order.getId(),
-                           parseDate( order.getCreatedAt() ),
-                           order.getPrice());
+    return new LimitOrder.Builder(adaptOrderType(order.getSide()), adaptCurrencyPair( order.getProductID() ))
+            .averagePrice(order.getPrice())
+            .cumulativeAmount(order.getFilledSize())
+            .id(order.getId())
+            .limitPrice(order.getPrice())
+            .orderStatus(adaptOrderStatus(order.getStatus()))
+            .originalAmount(order.getSize())
+            .remainingAmount(order.getFilledSize().subtract(order.getSize()))
+            .timestamp(parseDate(order.getCreatedAt()))
+            .build();
   }
   
   public static MarketOrder adaptMarketOrder(AbucoinsOrder order) {
-    return new MarketOrder( adaptOrderType(order.getSide()),
-                            order.getSize(),
-                            adaptCurrencyPair( order.getProductID() ),
-                            order.getId(),
-                            parseDate( order.getCreatedAt() ),
-                            order.getPrice(),
-                            order.getFilledSize(),
-                            null,
-                            adaptOrderStatus(order.getStatus()));
+    return new MarketOrder.Builder(adaptOrderType(order.getSide()), adaptCurrencyPair( order.getProductID() ))
+            .averagePrice(order.getPrice())
+            .cumulativeAmount(order.getFilledSize())
+            .id(order.getId())
+            .orderStatus(adaptOrderStatus(order.getStatus()))
+            .originalAmount(order.getSize())
+            .remainingAmount(order.getFilledSize().subtract(order.getSize()))
+            .timestamp(parseDate(order.getCreatedAt()))
+            .build();
   }
   
   public static OrderType adaptOrderType(AbucoinsOrder.Side side) {

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
@@ -18,6 +18,7 @@ import org.knowm.xchange.abucoins.dto.account.AbucoinsDepositsHistory;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsHistory;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsWithdrawalHistory;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsWithdrawalsHistory;
+import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsFullTicker;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsOrderBook;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsTicker;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsTrade;
@@ -148,6 +149,16 @@ public class AbucoinsAdapters {
     return new Ticker.Builder().currencyPair(currencyPair).last(last).bid(bid).ask(ask).volume(volume).timestamp(timestamp)
         .build();
   }
+  
+  /**
+   * Adapts a AbucoinsFullTicker to a Ticker Object
+   *
+   * @param ticker       The exchange specific ticker
+   * @return The ticker
+   */
+  public static Ticker adaptTicker(AbucoinsFullTicker ticker) {
+    return adaptTicker(ticker, adaptCurrencyPair(ticker.getProductID()));
+  }
 
   /**
    * Adapts Cex.IO Depth to OrderBook Object
@@ -212,12 +223,12 @@ public class AbucoinsAdapters {
 
   public static LimitOrder createOrder(CurrencyPair currencyPair, AbucoinsOrderBook.LimitOrder priceAndAmount, OrderType orderType) {
     return new LimitOrder.Builder(orderType, currencyPair)
-    		.averagePrice(priceAndAmount.getPrice())
-    		.cumulativeAmount( priceAndAmount.getSize())
-    		.limitPrice(priceAndAmount.getPrice())
-    		.orderStatus(OrderStatus.NEW)
-    		.originalAmount(priceAndAmount.getSize())
-    		.build();
+                .averagePrice(priceAndAmount.getPrice())
+                .cumulativeAmount( priceAndAmount.getSize())
+                .limitPrice(priceAndAmount.getPrice())
+                .orderStatus(OrderStatus.NEW)
+                .originalAmount(priceAndAmount.getSize())
+                .build();
   }
   
   public static OpenOrders adaptOpenOrders(AbucoinsOrder[] orders) {
@@ -257,14 +268,14 @@ public class AbucoinsAdapters {
   }
   
   public static MarketOrder adaptMarketOrder(AbucoinsOrder order) {
-    return new MarketOrder.Builder(adaptOrderType(order.getSide()), adaptCurrencyPair( order.getProductID() ))
+    return ((MarketOrder.Builder) new MarketOrder.Builder(adaptOrderType(order.getSide()), adaptCurrencyPair( order.getProductID() ))
             .averagePrice(order.getPrice())
             .cumulativeAmount(order.getFilledSize())
             .id(order.getId())
             .orderStatus(adaptOrderStatus(order.getStatus()))
             .originalAmount(order.getSize())
             .remainingAmount(order.getFilledSize().subtract(order.getSize()))
-            .timestamp(parseDate(order.getCreatedAt()))
+            .timestamp(parseDate(order.getCreatedAt())))
             .build();
   }
   
@@ -308,8 +319,8 @@ public class AbucoinsAdapters {
       return OrderStatus.FILLED;
       
     case closed:
-    		// from chatting with Abucoins when describing closed
-    	    // "it’s mean that your order can be partially fulfilled but it’s closed"
+                // from chatting with Abucoins when describing closed
+            // "it’s mean that your order can be partially fulfilled but it’s closed"
         return OrderStatus.PARTIALLY_FILLED;
                   
     case rejected:

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAdapters.java
@@ -298,6 +298,11 @@ public class AbucoinsAdapters {
                   
     case done:
       return OrderStatus.FILLED;
+      
+    case closed:
+    		// from chatting with Abucoins when describing closed
+    	    // "it’s mean that your order can be partially fulfilled but it’s closed"
+        return OrderStatus.PARTIALLY_FILLED;
                   
     case rejected:
       return OrderStatus.REJECTED;

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAuthenticated.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/AbucoinsAuthenticated.java
@@ -19,8 +19,10 @@ import org.knowm.xchange.abucoins.dto.account.AbucoinsAccount;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsAccounts;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoDeposit;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoWithdrawal;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsDepositsHistory;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsFills;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsPaymentMethods;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsWithdrawalsHistory;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsCreateOrderResponse;
 import org.knowm.xchange.abucoins.dto.trade.AbucoinsOrder;
 import org.knowm.xchange.abucoins.dto.trade.AbucoinsOrders;
@@ -29,7 +31,6 @@ import si.mazi.rescu.ParamsDigest;
 
 @Path("/")
 @Produces(MediaType.APPLICATION_JSON)
-@Consumes(MediaType.APPLICATION_JSON)
 public interface AbucoinsAuthenticated extends Abucoins {
   @GET
   @Path("accounts")
@@ -65,6 +66,7 @@ public interface AbucoinsAuthenticated extends Abucoins {
   
   @POST
   @Path("orders")
+  @Consumes(MediaType.APPLICATION_JSON)
   AbucoinsCreateOrderResponse createOrder(@HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp, AbucoinsBaseCreateOrderRequest req) throws IOException;
   
   @DELETE
@@ -84,18 +86,23 @@ public interface AbucoinsAuthenticated extends Abucoins {
   
   @GET
   @Path("fills")
-  @Produces(MediaType.APPLICATION_JSON)
   AbucoinsFills getFills(@HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
   
   @POST
-  @Path("withdrawals/crypto")
-  @Produces(MediaType.APPLICATION_JSON)
+  @Path("withdrawals/make")
   @Consumes(MediaType.APPLICATION_JSON)
-  AbucoinsCryptoWithdrawal cryptoWithdrawal(AbucoinsCryptoWithdrawalRequest cryptoWithdrawalRequest, @HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
+  AbucoinsCryptoWithdrawal withdrawalsMake(AbucoinsCryptoWithdrawalRequest cryptoWithdrawalRequest, @HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
+  
+  @GET
+  @Path("withdrawals/history")
+  AbucoinsWithdrawalsHistory withdrawalsHistory(@HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
   
   @POST
-  @Path("deposits/crypto")
-  @Produces(MediaType.APPLICATION_JSON)
+  @Path("deposits/make")
   @Consumes(MediaType.APPLICATION_JSON)
-  AbucoinsCryptoDeposit cryptoDeposit(AbucoinsCryptoDepositRequest cryptoRequest, @HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
+  AbucoinsCryptoDeposit depositsMake(AbucoinsCryptoDepositRequest cryptoRequest, @HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
+  
+  @GET
+  @Path("deposits/history")
+  AbucoinsDepositsHistory depositsHistory(@HeaderParam("AC-ACCESS-KEY") String accessKey, @HeaderParam("AC-ACCESS-SIGN") ParamsDigest sign, @HeaderParam("AC-ACCESS-PASSPHRASE") String passphrase, @HeaderParam("AC-ACCESS-TIMESTAMP") String timestamp) throws IOException;
 }

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsDepositHistory.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsDepositHistory.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.abucoins.dto.account;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * <p>POJO representing the output JSON for the Abucoins
+ * <code>GET /deposits/history</code> endpoint.</p>
+ * 
+ * Example: <p/>
+ * <table>
+ * <thead>
+ * <th><td>Field</td><td>Description</td></th>
+ * </thead>
+ * <tbody>
+ * <tr><td>deposit_id</td><td>Deposit transaction ID</td></tr>
+ * <tr><td>currency</td><td>Deposit currency</td></tr>
+ * <tr><td>date</td><td>Date of deposit</td></tr>
+ * <tr><td>amount</td><td>Deposit amount</td></tr>
+ * <tr><td>fee</td><td>Deposit fee</td></tr>
+ * <tr><td>status</td><td>Deposit status</td></tr>
+ * <tr><td>url</td><td>blockchain explorer url (null if not available)</td></tr>
+ * </tbody>
+ * </table>
+ * @author bryant_harris
+ *
+ */
+public class AbucoinsDepositHistory extends AbucoinsHistory {
+  /** Deposit transaction ID */
+  String depositID;
+    
+  public AbucoinsDepositHistory(@JsonProperty("deposit_id") String depositID,
+                                @JsonProperty("currency") String currency,
+                                @JsonProperty("date") String date,
+                                @JsonProperty("amount") BigDecimal amount,
+                                @JsonProperty("fee") BigDecimal fee,
+                                @JsonProperty("status") String status,
+                                @JsonProperty("url") String url,
+                                @JsonProperty("message") String message) {
+    super(currency, date, amount, fee, status, url, message);
+    this.depositID = depositID;
+  }
+  
+  public String getDepositID() {
+    return depositID;
+  }
+
+  @Override
+  public String toString() {
+    return "AbucoinsDepositHistory [depositID=" + depositID + ", currency=" + currency + ", date=" + date + ", amount="
+        + amount + ", fee=" + fee + ", status=" + status + ", url=" + url + ", message=" + message + "]";
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsDepositsHistory.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsDepositsHistory.java
@@ -1,0 +1,51 @@
+package org.knowm.xchange.abucoins.dto.account;
+
+import org.knowm.xchange.abucoins.service.AbucoinsArrayOrMessageDeserializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * <p>POJO representing the output JSON for the Abucoins
+ * <code>GET /deposits/historycrypto</code> endpoint.</p>
+ * 
+ * Example: <p/>
+ * <table>
+ * <thead>
+ * <th><td>Field</td><td>Description</td></th>
+ * </thead>
+ * <tbody>
+ * <tr><td>deposit_id</td><td>Deposit transaction ID</td></tr>
+ * <tr><td>currency</td><td>Deposit currency</td></tr>
+ * <tr><td>date</td><td>Date of deposit</td></tr>
+ * <tr><td>amount</td><td>Deposit amount</td></tr>
+ * <tr><td>fee</td><td>Deposit fee</td></tr>
+ * <tr><td>status</td><td>Deposit status</td></tr>
+ * <tr><td>url</td><td>blockchain explorer url (null if not available)</td></tr>
+ * </tbody>
+ * </table>
+ * @author bryant_harris
+ *
+ */
+@JsonDeserialize(using = AbucoinsDepositsHistory.AbucoinsDepositsHistoryDeserializer.class)
+public class AbucoinsDepositsHistory {
+  AbucoinsDepositHistory[] history;
+        
+  public AbucoinsDepositsHistory(AbucoinsDepositHistory[] history) {
+    this.history = history;
+  }
+        
+  public AbucoinsDepositHistory[] getHistory() {
+    return history;
+  }
+        
+  /**
+   * Deserializer handles the success case (array json) as well as the error case
+   * (json object with <em>message</em> field).
+   * @author bryant_harris
+   */
+  static class AbucoinsDepositsHistoryDeserializer extends AbucoinsArrayOrMessageDeserializer<AbucoinsDepositHistory, AbucoinsDepositsHistory> {
+    public AbucoinsDepositsHistoryDeserializer() {
+      super(AbucoinsDepositHistory.class, AbucoinsDepositsHistory.class);
+    }
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsHistory.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsHistory.java
@@ -1,0 +1,125 @@
+package org.knowm.xchange.abucoins.dto.account;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Base class for the the history related API calls (withdrawals and deposits)
+ * 
+ * @author bryant_harris
+ *
+ */
+public abstract class AbucoinsHistory { 
+  /** Deposit currency */
+  String currency;
+
+  /** Date of deposit */
+  String date;
+        
+  /** Deposit amount */
+  BigDecimal amount;
+        
+  /** Deposit fee */
+  BigDecimal fee;
+
+  // Not directly storing status as a Status enum, doing so introduces
+  // risk of a parsing error due to a new, unrecognized status.
+  /** Deposit status */
+  String status;
+        
+  /** blockchain explorer url (null if not available) */
+  String url;   
+        
+  /** Error codes */
+  String message;
+
+  public AbucoinsHistory(@JsonProperty("currency") String currency,
+                         @JsonProperty("date") String date,
+                         @JsonProperty("amount") BigDecimal amount,
+                         @JsonProperty("fee") BigDecimal fee,
+                         @JsonProperty("status") String status,
+                         @JsonProperty("url") String url,
+                         @JsonProperty("message") String message) {
+    this.currency = currency;
+    this.date = date;
+    this.amount = amount;
+    this.fee = fee;
+    this.status = status;
+    this.url = url;
+    this.message = message;
+  }
+  
+  public String getCurrency() {
+    return currency;
+  }
+
+  public String getDate() {
+    return date;
+  }
+
+  public BigDecimal getAmount() {
+    return amount;
+  }
+
+  public BigDecimal getFee() {
+    return fee;
+  }
+
+  public Status getStatus() {
+    return Status.fromString(status);
+  }
+
+  /**
+   * Returns the raw string value of the status, useful if
+   * it's a newer status type
+   * @return
+   */
+  public String getStatusRaw() {
+    return status;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public enum Status {
+    /** Deposit wait for email confirmation */
+    awaitingEmailConfirmation, 
+          
+    /** Deposit is pending */
+    pending,
+          
+    /** Deposit is completed (documentation lists complete, api seems to return completed */
+    complete, completed,
+          
+    /** Deposit was sent */
+    sent,
+          
+    unknown; // we can't parse it
+    
+    public static Status fromString(String s) {
+      try {
+        return Status.valueOf(s);
+      }
+      catch (Exception e) {
+        if ( s.equals("awaiting-email-onfirmation"))
+          return awaitingEmailConfirmation;
+      }
+                  
+      return unknown;
+    }
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsWithdrawalHistory.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsWithdrawalHistory.java
@@ -1,0 +1,54 @@
+package org.knowm.xchange.abucoins.dto.account;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * <p>POJO representing the output JSON for the Abucoins
+ * <code>GET /withdrawals/history</code> endpoint.</p>
+ * 
+ * Example: <p/>
+ * <table>
+ * <thead>
+ * <th><td>Field</td><td>Description</td></th>
+ * </thead>
+ * <tbody>
+ * <tr><td>withdraw_id</td><td>Withdraw transaction ID</td></tr>
+ * <tr><td>currency</td><td>Withdraw currency</td></tr>
+ * <tr><td>date</td><td>Date of withdraw</td></tr>
+ * <tr><td>amount</td><td>Withdraw amount</td></tr>
+ * <tr><td>fee</td><td>Withdraw fee</td></tr>
+ * <tr><td>status</td><td>Withdraw status</td></tr>
+ * <tr><td>url</td><td>blockchain explorer url (null if not available)</td></tr>
+ * </tbody>
+ * </table>
+ * @author bryant_harris
+ *
+ */
+public class AbucoinsWithdrawalHistory extends AbucoinsHistory {
+  /** Deposit transaction ID */
+  String withdrawID;
+    
+  public AbucoinsWithdrawalHistory(@JsonProperty("withdraw_id") String withdrawID,
+                                   @JsonProperty("currency") String currency,
+                                   @JsonProperty("date") String date,
+                                   @JsonProperty("amount") BigDecimal amount,
+                                   @JsonProperty("fee") BigDecimal fee,
+                                   @JsonProperty("status") String status,
+                                   @JsonProperty("url") String url,
+                                   @JsonProperty("message") String message) {
+    super(currency, date, amount, fee, status, url, message);
+    this.withdrawID = withdrawID;
+  }
+  
+  public String getWithdrawID() {
+    return withdrawID;
+  }
+
+  @Override
+  public String toString() {
+    return "AbucoinsDepositHistory [withdrawID=" + withdrawID + ", currency=" + currency + ", date=" + date + ", amount="
+        + amount + ", fee=" + fee + ", status=" + status + ", url=" + url + ", message=" + message + "]";
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsWithdrawalsHistory.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/account/AbucoinsWithdrawalsHistory.java
@@ -1,0 +1,51 @@
+package org.knowm.xchange.abucoins.dto.account;
+
+import org.knowm.xchange.abucoins.service.AbucoinsArrayOrMessageDeserializer;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * <p>POJO representing the output JSON for the Abucoins
+ * <code>GET /withdrawals/history</code> endpoint.</p>
+ * 
+ * Example: <p/>
+ * <table>
+ * <thead>
+ * <th><td>Field</td><td>Description</td></th>
+ * </thead>
+ * <tbody>
+ * <tr><td>withdraw_id</td><td>Withdraw transaction ID</td></tr>
+ * <tr><td>currency</td><td>Withdraw currency</td></tr>
+ * <tr><td>date</td><td>Date of withdraw</td></tr>
+ * <tr><td>amount</td><td>Withdraw amount</td></tr>
+ * <tr><td>fee</td><td>Withdraw fee</td></tr>
+ * <tr><td>status</td><td>Withdraw status</td></tr>
+ * <tr><td>url</td><td>blockchain explorer url (null if not available)</td></tr>
+ * </tbody>
+ * </table>
+ * @author bryant_harris
+ *
+ */
+@JsonDeserialize(using = AbucoinsWithdrawalsHistory.AbucoinsWithdrawalsHistoryDeserializer.class)
+public class AbucoinsWithdrawalsHistory {
+  AbucoinsWithdrawalHistory[] history;
+        
+  public AbucoinsWithdrawalsHistory(AbucoinsWithdrawalHistory[] history) {
+    this.history = history;
+  }
+        
+  public AbucoinsWithdrawalHistory[] getHistory() {
+    return history;
+  }
+        
+  /**
+   * Deserializer handles the success case (array json) as well as the error case
+   * (json object with <em>message</em> field).
+   * @author bryant_harris
+   */
+  static class AbucoinsWithdrawalsHistoryDeserializer extends AbucoinsArrayOrMessageDeserializer<AbucoinsWithdrawalHistory, AbucoinsWithdrawalsHistory> {
+    public AbucoinsWithdrawalsHistoryDeserializer() {
+      super(AbucoinsWithdrawalHistory.class, AbucoinsWithdrawalsHistory.class);
+    }
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/marketdata/AbucoinsFullTicker.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/marketdata/AbucoinsFullTicker.java
@@ -1,0 +1,68 @@
+package org.knowm.xchange.abucoins.dto.marketdata;
+
+import java.math.BigDecimal;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * <p>POJO representing the output JSON for the Abucoins
+ * <code>GET /products/ticker</code> endpoint.</p>
+ *
+ * <p>This is essentially the {@link AbucoinsTicker} object
+ * plus a product ID.</p>
+ * Example:
+ * <code><pre>
+ * {
+ *     "product_id":"ETH-BTC",
+ *     "trade_id": "553612",
+ *     "price": "14160.85",
+ *     "size": "0.00053",
+ *     "bid": "14140.00000000",
+ *     "ask": "14181.70000000",
+ *     "volume": "1.09596639",
+ *     "time": "2017-09-21T10:26:58Z"
+ * }
+ * </pre></code>
+ * @author bryant_harris
+ */
+public class AbucoinsFullTicker extends AbucoinsTicker {
+  /** identifier of the market */
+  String productID;
+
+  /**
+   * Constructor
+   *
+   * 
+   * @param productID identifier of the market
+   * @param tradeID identifier of the last trade
+   * @param price last price
+   * @param size size of the last trade
+   * @param bid the best bid
+   * @param ask the best ask
+   * @param volume 24 hour volume
+   * @param time time in UTC
+   */
+  public AbucoinsFullTicker(
+                  @JsonProperty("product_id") String productID,
+                  @JsonProperty("trade_id") String tradeID,
+                  @JsonProperty("price") BigDecimal price,
+                  @JsonProperty("size") BigDecimal size,
+                  @JsonProperty("bid") BigDecimal bid,
+                  @JsonProperty("ask") BigDecimal ask,
+                  @JsonProperty("volume") BigDecimal volume,
+                  @JsonProperty("time") String time) {
+        super(tradeID, price, size, bid, ask, volume, time);
+    this.productID = productID;
+  }
+  
+  /** identifier of the market */
+  public String getProductID() {
+    return productID;
+  }
+
+  @Override
+  public String toString() {
+    return "AbucoinsFullTicker [productID=" + productID + ", tradeID=" + tradeID + ", price=" + price + ", size=" + size
+        + ", bid=" + bid + ", ask=" + ask + ", volume=" + volume + ", time=" + time + "]";
+  }
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/trade/AbucoinsOrder.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/trade/AbucoinsOrder.java
@@ -50,11 +50,11 @@ public class AbucoinsOrder {
   String productID;
   Side side;
   Type type;
-  TimeInForce timeInForce;
+  String timeInForce;
   boolean postOnly;
   String createdAt;
   BigDecimal filledSize;
-  Status status;
+  String status;
   boolean settled;
   String message;
         
@@ -64,11 +64,11 @@ public class AbucoinsOrder {
                        @JsonProperty("product_id") String productID,
                        @JsonProperty("side") Side side,
                        @JsonProperty("type") Type type,
-                       @JsonProperty("time_in_force") TimeInForce timeInForce,
+                       @JsonProperty("time_in_force") String timeInForce,
                        @JsonProperty("post_only") boolean postOnly,
                        @JsonProperty("created_at") String createdAt,
                        @JsonProperty("filled_size") BigDecimal filledSize,
-                       @JsonProperty("status") Status status,
+                       @JsonProperty("status") String status,
                        @JsonProperty("settled") boolean settled,
                        @JsonProperty("message") String message) {
     this.id = id;
@@ -109,9 +109,19 @@ public class AbucoinsOrder {
   public Type getType() {
     return type;
   }
+  
+  /**
+   * Returns the raw time in force string, we obtain the time in force as a string in case new
+   * status are added.  We don't want the new string causing the json to fail to
+   * parse.
+   * @return the raw time in force string
+   */
+  public String getTimeInForceRaw() {
+    return timeInForce;
+  }
 
   public TimeInForce getTimeInForce() {
-    return timeInForce;
+    return TimeInForce.fromString(timeInForce);
   }
 
   public boolean isPostOnly() {
@@ -125,9 +135,19 @@ public class AbucoinsOrder {
   public BigDecimal getFilledSize() {
     return filledSize;
   }
+  
+  /**
+   * Returns the raw status string, we obtain the status as a string in case new
+   * status are added.  We don't want the new string causing the json to fail to
+   * parse.
+   * @return the raw status string
+   */
+  public String getStatusRaw() {
+    return status;
+  }
 
   public Status getStatus() {
-    return status;
+    return Status.fromString(status);
   }
 
   public boolean isSettled() {
@@ -155,7 +175,18 @@ public class AbucoinsOrder {
   }
 
   public enum TimeInForce {
-    GTC, GTT, IOC, FOK;
+    GTC, GTT, IOC, FOK,
+    
+    Unknown; // added by us to avoid a string parsing error occurs.
+          
+    public static TimeInForce fromString(String s) {
+      try {
+        return TimeInForce.valueOf(s);
+      }
+      catch (Exception e) {
+        return Unknown;
+      }
+    }
     
     public String toDescription() {
       switch (this) {
@@ -170,12 +201,26 @@ public class AbucoinsOrder {
                 
       case FOK:
         return "Fill or kill";
+        
+      case Unknown:
+                return "An unrecognized time in force value was returned";
       }
       return ""; // dead code path
     }
   }
   
   public enum Status {
-    pending, open, done, rejected;
+    pending, open, done, rejected,
+    
+    unknown; // added by us to avoid a string parsing error occurs.
+          
+    public static Status fromString(String s) {
+      try {
+        return Status.valueOf(s);
+      }
+      catch (Exception e) {
+        return unknown;
+      }
+    }
   }
 }

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/trade/AbucoinsOrder.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/dto/trade/AbucoinsOrder.java
@@ -210,7 +210,7 @@ public class AbucoinsOrder {
   }
   
   public enum Status {
-    pending, open, done, rejected,
+    pending, open, done, closed, rejected,
     
     unknown; // added by us to avoid a string parsing error occurs.
           

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountService.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountService.java
@@ -2,6 +2,8 @@ package org.knowm.xchange.abucoins.service;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
@@ -11,9 +13,12 @@ import org.knowm.xchange.abucoins.dto.AbucoinsCryptoWithdrawalRequest;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsAccount;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoDeposit;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoWithdrawal;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsDepositsHistory;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsWithdrawalsHistory;
 import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.FundingRecord;
+import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.account.AccountService;
@@ -43,9 +48,9 @@ public class AbucoinsAccountService extends AbucoinsAccountServiceRaw implements
   @Override
   public String requestDepositAddress(Currency currency, String... arguments) throws IOException {
     String method = abucoinsPaymentMethodForCurrency(currency.getCurrencyCode());
-    AbucoinsCryptoDeposit cryptoDeposit = abucoinsCryptoDeposit(new AbucoinsCryptoDepositRequest(currency.getCurrencyCode(), method));
+    AbucoinsCryptoDeposit cryptoDeposit = abucoinsDepositMake(new AbucoinsCryptoDepositRequest(currency.getCurrencyCode(), method));
     if ( cryptoDeposit.getMessage() != null )
-      throw new IOException(cryptoDeposit.getMessage());
+      throw new ExchangeException(cryptoDeposit.getMessage());
           
     return cryptoDeposit.getAddress();
   }
@@ -56,7 +61,7 @@ public class AbucoinsAccountService extends AbucoinsAccountServiceRaw implements
       DefaultWithdrawFundsParams defParams = (DefaultWithdrawFundsParams) params;
                  
       String method = abucoinsPaymentMethodForCurrency(defParams.currency.getCurrencyCode());
-      AbucoinsCryptoWithdrawal withdrawal = abucoinsWithdraw( new AbucoinsCryptoWithdrawalRequest(defParams.amount,
+      AbucoinsCryptoWithdrawal withdrawal = abucoinsWithdrawalsMake( new AbucoinsCryptoWithdrawalRequest(defParams.amount,
                                                                                                   defParams.currency.getCurrencyCode(),
                                                                                                   method,
                                                                                                   defParams.address,
@@ -67,21 +72,37 @@ public class AbucoinsAccountService extends AbucoinsAccountServiceRaw implements
     if ( params == null )
       throw new IllegalArgumentException("Requires a DefaultWithdrawFundsParams object to describe the withdrawal");
          
-    throw new IOException("Abucoins only understands DefaultWithdrawFundsParams not " + params.getClass().getName());
+    throw new IllegalArgumentException("Abucoins only understands DefaultWithdrawFundsParams not " + params.getClass().getName());
   }
 
   @Override
   public String withdrawFunds(Currency currency, BigDecimal amount, String address) throws IOException {
     return withdrawFunds(new DefaultWithdrawFundsParams(address, currency, amount));
   }
-
+  
   @Override
   public TradeHistoryParams createFundingHistoryParams() {
-    throw new NotAvailableFromExchangeException();
+    return new AbucoinsTradeHistoryParams();
   }
 
   @Override
-  public List<FundingRecord> getFundingHistory(TradeHistoryParams params) throws IOException {
-    throw new NotYetImplementedForExchangeException();
+  public List<FundingRecord> getFundingHistory(TradeHistoryParams param) throws IOException {
+    AbucoinsDepositsHistory depositHistory = abucoinsDepositHistory();
+    AbucoinsWithdrawalsHistory withdrawHistory = abucoinsWithdrawalsHistory();
+    
+    List<FundingRecord> retVal = new ArrayList<>();
+    List<FundingRecord> some;
+    some = AbucoinsAdapters.adaptFundingRecordsFromDepositsHistory(depositHistory);
+    retVal.addAll(some);
+    
+    some = AbucoinsAdapters.adaptFundingRecords(withdrawHistory);
+    retVal.addAll(some);
+    
+    // interleave the records based on time, newest first
+    Collections.sort(retVal, (FundingRecord r1, FundingRecord r2)-> {
+      return r2.getDate().compareTo(r1.getDate());
+    });
+    
+    return retVal;
   }
 }

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountServiceRaw.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountServiceRaw.java
@@ -9,8 +9,10 @@ import org.knowm.xchange.abucoins.dto.account.AbucoinsAccount;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsAccounts;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoDeposit;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsCryptoWithdrawal;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsDepositsHistory;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsPaymentMethod;
 import org.knowm.xchange.abucoins.dto.account.AbucoinsPaymentMethods;
+import org.knowm.xchange.abucoins.dto.account.AbucoinsWithdrawalsHistory;
 import org.knowm.xchange.exceptions.ExchangeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,8 +25,10 @@ import org.slf4j.LoggerFactory;
  * <li>{@link #getAbucoinsAccounts GET /accounts}</li>
  * <li>{@link #getAbucoinsAccount(String) GET /accounts/&lt;account-id&gt;}</li>
  * <li>{@link #getPaymentMethods() GET /payment-methods}</li>
- * <li>{@link #abucoinsWithdraw POST withdrawals/crypto}</li>
- * <li>{@link #abucoinsCryptoDeposit POST deposits/crypto}</li>
+ * <li>{@link #abucoinsWithdrawalsMake POST withdrawals/make}</li>
+ * <li>{@link #abucoinsWithdrawalsHistory POST withdrawals/history}</li>
+ * <li>{@link #abucoinsDepositMake POST deposits/make}</li>
+ * <li>{@link #abucoinsDepositHistory POST deposits/history}</li>
  * <ol>
  * @author bryant_harris
  */
@@ -91,26 +95,62 @@ public class AbucoinsAccountServiceRaw extends AbucoinsBaseService {
    * @return
    * @throws IOException
    */
-  public AbucoinsCryptoWithdrawal abucoinsWithdraw(AbucoinsCryptoWithdrawalRequest withdrawRequest) throws IOException {
-    return abucoinsAuthenticated.cryptoWithdrawal(withdrawRequest,
+  public AbucoinsCryptoWithdrawal abucoinsWithdrawalsMake(AbucoinsCryptoWithdrawalRequest withdrawRequest) throws IOException {
+    return abucoinsAuthenticated.withdrawalsMake(withdrawRequest,
                                                   exchange.getExchangeSpecification().getApiKey(),
                                                   signatureCreator,
                                                   exchange.getExchangeSpecification().getPassword(),
                                                   timestamp());
   }
-
+  
   /**
-   * Corresponds to <code>POST deposits/crypto</code>
+   * Corresponds to <code>GET withdrawals/history</code>
    * @param cryptoRequest
    * @return
    * @throws IOException
    */
-  public AbucoinsCryptoDeposit abucoinsCryptoDeposit(AbucoinsCryptoDepositRequest cryptoRequest) throws IOException {
-    return abucoinsAuthenticated.cryptoDeposit(cryptoRequest,
-                                               exchange.getExchangeSpecification().getApiKey(),
-                                               signatureCreator,
-                                               exchange.getExchangeSpecification().getPassword(),
-                                               timestamp());
+  public AbucoinsWithdrawalsHistory abucoinsWithdrawalsHistory() throws IOException {
+    AbucoinsWithdrawalsHistory history =  abucoinsAuthenticated.withdrawalsHistory(
+                                                                                   exchange.getExchangeSpecification().getApiKey(),
+                                                                                   signatureCreator,
+                                                                                   exchange.getExchangeSpecification().getPassword(),
+                                                                                   timestamp());
+    if ( history.getHistory().length > 0 && history.getHistory()[0].getMessage() != null )
+      throw new ExchangeException(history.getHistory()[0].getMessage());
+          
+    return history;
+  }
+
+  /**
+   * Corresponds to <code>POST deposits/make</code>
+   * @param cryptoRequest
+   * @return
+   * @throws IOException
+   */
+  public AbucoinsCryptoDeposit abucoinsDepositMake(AbucoinsCryptoDepositRequest cryptoRequest) throws IOException {
+    return abucoinsAuthenticated.depositsMake(cryptoRequest,
+                                              exchange.getExchangeSpecification().getApiKey(),
+                                              signatureCreator,
+                                              exchange.getExchangeSpecification().getPassword(),
+                                              timestamp());
+  }
+  
+  /**
+   * Corresponds to <code>GET deposits/history</code>
+   * @param cryptoRequest
+   * @return
+   * @throws IOException
+   */
+  public AbucoinsDepositsHistory abucoinsDepositHistory() throws IOException {
+    AbucoinsDepositsHistory history =  abucoinsAuthenticated.depositsHistory(
+                                                                             exchange.getExchangeSpecification().getApiKey(),
+                                                                             signatureCreator,
+                                                                             exchange.getExchangeSpecification().getPassword(),
+                                                                             timestamp());
+    if ( history.getHistory().length > 0 && history.getHistory()[0].getMessage() != null )
+      throw new ExchangeException(history.getHistory()[0].getMessage());
+          
+    return history;
   }
   
   /**

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsMarketDataService.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsMarketDataService.java
@@ -10,6 +10,7 @@ import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.marketdata.Ticker;
 import org.knowm.xchange.dto.marketdata.Trades;
+import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.service.marketdata.MarketDataService;
 
 /**
@@ -27,12 +28,7 @@ public class AbucoinsMarketDataService extends AbucoinsMarketDataServiceRaw impl
 
   @Override
   public Ticker getTicker(CurrencyPair currencyPair, Object... args) throws IOException {
-    try {
-      return AbucoinsAdapters.adaptTicker(getAbucoinsTicker(AbucoinsAdapters.adaptCurrencyPairToProductID(currencyPair)), currencyPair);
-    }
-    catch (Exception e) {
-      throw new IOException("Unable to get ticker for " + currencyPair, e);
-    }
+    return AbucoinsAdapters.adaptTicker(getAbucoinsTicker(AbucoinsAdapters.adaptCurrencyPairToProductID(currencyPair)), currencyPair);
   }
 
   @Override

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsMarketDataServiceRaw.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsMarketDataServiceRaw.java
@@ -7,6 +7,7 @@ import java.util.TimeZone;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.abucoins.dto.AbucoinsServerTime;
+import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsFullTicker;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsHistoricRate;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsHistoricRates;
 import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsOrderBook;
@@ -27,6 +28,7 @@ import org.knowm.xchange.exceptions.ExchangeException;
  * <li>{@link #getAbucoinsProduct() GET /products/&#123;product-id&#125;}</li>
  * <li>{@link #getAbucoinsOrderBook GET /products/&#123;product-id&#125;/book}</li>
  * <li>{@link #getAbucoinsOrderBook(String, AbucoinsOrderBookLevel) GET /products/&#123;product-id&#125;/book?level=&#123;level&#125;}</li>
+ * <li>{@link #getAbucoinsTickers GET /products/ticker}</li>
  * <li>{@link #getAbucoinsTicker GET /products/&#123;product-id&#125;/ticker}</li>
  * <li>{@link #getAbucoinsTrades(String) GET /products/&#123;product-id&#125;/trades}</li>
  * <li>{@link #getAbucoinsHistoricRates GET /products/&#123;product-id&#125;/candles?granularity=[granularity]&start=[UTC time of start]&end=[UTC time of end]}</li>
@@ -87,6 +89,18 @@ public class AbucoinsMarketDataServiceRaw extends AbucoinsBaseService {
    */
   public AbucoinsOrderBook getAbucoinsOrderBook(String productID, AbucoinsOrderBookLevel level) throws IOException {
     return abucoins.getBook(productID, level.name());
+  }
+  
+  /**
+   * Corresponds to <code>GET /products/ticker</code>
+   * @return
+   * @throws IOException
+   */
+  public AbucoinsFullTicker[] getAbucoinsTickers() throws IOException {
+
+    AbucoinsFullTicker[] abucoinsTickers = abucoins.getTicker();
+
+    return abucoinsTickers;
   }
 
   /**

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeHistoryParams.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeHistoryParams.java
@@ -1,0 +1,13 @@
+package org.knowm.xchange.abucoins.service;
+
+import org.knowm.xchange.service.trade.params.TradeHistoryParams;
+
+/**
+ * Trade history parameters (when paging is fleshed out this will have
+ * fields).
+ * @author bryant_harris
+ *
+ */
+public class AbucoinsTradeHistoryParams implements TradeHistoryParams {
+
+}

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeService.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeService.java
@@ -14,6 +14,7 @@ import org.knowm.xchange.abucoins.dto.marketdata.AbucoinsCreateOrderResponse;
 import org.knowm.xchange.abucoins.dto.trade.AbucoinsOrder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.*;
+import org.knowm.xchange.exceptions.ExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
@@ -62,7 +63,7 @@ public class AbucoinsTradeService extends AbucoinsTradeServiceRaw implements Tra
     AbucoinsCreateMarketOrderRequest req = AbucoinsAdapters.adaptAbucoinsCreateMarketOrderRequest(marketOrder); 
     AbucoinsCreateOrderResponse resp = createAbucoinsOrder(req);
     if ( resp.getMessage() != null )
-      throw new IOException(resp.getMessage());
+      throw new ExchangeException(resp.getMessage());
     return resp.getId();
   }
 
@@ -71,7 +72,7 @@ public class AbucoinsTradeService extends AbucoinsTradeServiceRaw implements Tra
     AbucoinsCreateLimitOrderRequest req = AbucoinsAdapters.adaptAbucoinsCreateLimitOrderRequest(limitOrder);
     AbucoinsCreateOrderResponse resp = createAbucoinsOrder(req);
     if ( resp.getMessage() != null )
-      throw new IOException(resp.getMessage());
+      throw new ExchangeException(resp.getMessage());
     return resp.getId();
   }
 


### PR DESCRIPTION
Also replacing deprecated calls with current naming convetion.

Also, ran into a situation where a value that was modeled as an enum
was returned with a new value that I hadn't seen in the documentation.
This causes the mapping to fail during the json marshalling.

To improve the failure behavior in this case, I internally switched the
field to be a String so that json parsing would succeed.  I do however
continue to use the enum at the Pojo API level, it just treats strings
it doesn't recognized as 'unknown'.  This seems like more desirable
behavior as the API continues to work, it may just be that your status
isn't mapped to a known value.  If you aren't using the status, has no
impact, if you need the status, then there's a raw method for obtaining
the string value.  It made debugging much easier.