### PR TITLE
[bitfinex] bugfixes

### DIFF
--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/BitfinexUtils.java
@@ -65,6 +65,8 @@ public final class BitfinexUtils {
         return "qtum";
       case "EDO":
         return "eidoo";
+        case "BTG":
+            return "bgold";
       default:
         throw new BitfinexException("Cannot determine withdrawal type.");
     }

--- a/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexAccountServiceRaw.java
+++ b/xchange-bitfinex/src/main/java/org/knowm/xchange/bitfinex/v1/service/BitfinexAccountServiceRaw.java
@@ -69,9 +69,12 @@ public class BitfinexAccountServiceRaw extends BitfinexBaseService {
 
   public String withdraw(String withdrawType, String walletSelected, BigDecimal amount, String address, String paymentId) throws IOException {
 
-    BitfinexWithdrawalResponse[] withdrawRepsonse = bitfinex.withdraw(apiKey, payloadCreator, signatureCreator, new BitfinexWithdrawalRequest(
+    BitfinexWithdrawalResponse[] withdrawResponse = bitfinex.withdraw(apiKey, payloadCreator, signatureCreator, new BitfinexWithdrawalRequest(
         String.valueOf(exchange.getNonceFactory().createValue()), withdrawType, walletSelected, amount, address, paymentId));
-    return withdrawRepsonse[0].getWithdrawalId();
+    if ("error".equalsIgnoreCase(withdrawResponse[0].getStatus())) {
+      throw new ExchangeException(withdrawResponse[0].getMessage());
+    }
+    return withdrawResponse[0].getWithdrawalId();
   }
 
   public BitfinexDepositAddressResponse requestDepositAddressRaw(String currency) throws IOException {
@@ -84,9 +87,11 @@ public class BitfinexAccountServiceRaw extends BitfinexBaseService {
       } else if (currency.equalsIgnoreCase("ETH")) {
         type = "ethereum";
       } else if (currency.equalsIgnoreCase("IOT")) {
-    	  type = "iota";
+        type = "iota";
       } else if (currency.equalsIgnoreCase("BCH")) {
         type = "bcash";
+      } else if (currency.equalsIgnoreCase("BTG")) {
+        type = "bgold";
       }
 
       BitfinexDepositAddressResponse requestDepositAddressResponse = bitfinex.requestDeposit(apiKey, payloadCreator, signatureCreator,


### PR DESCRIPTION
- Actually throw an ExchangeException, instead of just returning a 0 id
  in case of an error in the withdrawal response.
- Adding an undocumented, but tested to be working bgold 'type' for BTG
- variable name spelling error withdrawRepsonse => withdrawResponse