### PR TITLE
[itbit, coinmate] fixes

### DIFF
--- a/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
+++ b/xchange-coinmate/src/main/java/org/knowm/xchange/coinmate/CoinmateAdapters.java
@@ -23,11 +23,6 @@
  */
 package org.knowm.xchange.coinmate;
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-
 import org.knowm.xchange.coinmate.dto.account.CoinmateBalance;
 import org.knowm.xchange.coinmate.dto.account.CoinmateBalanceData;
 import org.knowm.xchange.coinmate.dto.marketdata.CoinmateOrderBook;
@@ -53,6 +48,11 @@ import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.dto.trade.UserTrade;
 import org.knowm.xchange.dto.trade.UserTrades;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamsSorted;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
 
 /**
  * @author Martin Stachon
@@ -181,10 +181,14 @@ public class CoinmateAdapters {
           continue;
       }
 
-      switch (entry.getStatus()) {
+      switch (entry.getStatus().toUpperCase()) {
+        case "OK":
         case "COMPLETED":
           status = FundingRecord.Status.COMPLETE;
           break;
+        case "SENT":
+        case "CREATED":
+        case "WAITING":
         case "PENDING":
           status = FundingRecord.Status.PROCESSING;
           break;

--- a/xchange-itbit/pom.xml
+++ b/xchange-itbit/pom.xml
@@ -30,6 +30,11 @@
             <version>4.3.4-SNAPSHOT</version>
         </dependency>
 
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>19.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitTradeService.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/service/ItBitTradeService.java
@@ -97,14 +97,35 @@ public class ItBitTradeService extends ItBitTradeServiceRaw implements TradeServ
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
 
-    Integer page = ((TradeHistoryParamPaging) params).getPageNumber();
-    if (page != null) {
-      ++page;
+    Integer page = 0;
+    Integer pageLength = 50;
+    if (params instanceof TradeHistoryParamPaging) {
+      TradeHistoryParamPaging paramPaging = (TradeHistoryParamPaging) params;
+      page = paramPaging.getPageNumber();
+      pageLength = paramPaging.getPageLength();
     }
 
-    ItBitTradeHistory userTradeHistory = getUserTradeHistory(((TradeHistoryParamTransactionId) params).getTransactionId(), page,
-        ((TradeHistoryParamPaging) params).getPageLength(), ((TradeHistoryParamsTimeSpan) params).getStartTime(),
-        ((TradeHistoryParamsTimeSpan) params).getEndTime());
+    String transactionId = null;
+    if (params instanceof TradeHistoryParamTransactionId) {
+      transactionId = ((TradeHistoryParamTransactionId) params).getTransactionId();
+    }
+
+    Date startTime = null;
+    Date endTime = null;
+    if (params instanceof TradeHistoryParamsTimeSpan) {
+      TradeHistoryParamsTimeSpan tradeHistoryParamsTimeSpan = (TradeHistoryParamsTimeSpan) params;
+      startTime = tradeHistoryParamsTimeSpan.getStartTime();
+      endTime = tradeHistoryParamsTimeSpan.getEndTime();
+    }
+
+    ItBitTradeHistory userTradeHistory = getUserTradeHistory(
+        transactionId,
+        page,
+        pageLength,
+        startTime,
+        endTime
+    );
+
     return ItBitAdapters.adaptTradeHistory(userTradeHistory);
   }
 


### PR DESCRIPTION
[itbit] merges multiple fills for a single order into a single UserTrade and uses the order id to represent the trade id (because itbit doesn't have the concept of a trade id).

[itbit] translates XBT to BTC for the itbit response data.

[itbit] Added some checks in `getTradeHistory` to avoid potential invalid ClassCastExceptions  

[coinmate] more statuses for funding