### PR TITLE
[Livecoin] Support parsing of numbers in exponential notation

### DIFF
--- a/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
+++ b/xchange-livecoin/src/main/java/org/knowm/xchange/livecoin/LivecoinAdapters.java
@@ -175,7 +175,7 @@ public class LivecoinAdapters {
         remainingQuantity,
         new CurrencyPair(ccyA, ccyB),
         map.get("id").toString(),
-        DateUtils.fromUnixTime(Long.valueOf(map.get("issueTime").toString())),
+        DateUtils.fromUnixTime(Double.valueOf(map.get("issueTime").toString()).longValue()),
         new BigDecimal(map.get("price").toString()),
         null,
         null,


### PR DESCRIPTION
Fixed:
`java.lang.NumberFormatException: For input string: "1.519321274396496E12"
	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
	at java.lang.Long.parseLong(Long.java:589)
	at java.lang.Long.valueOf(Long.java:803)
	at org.knowm.xchange.livecoin.LivecoinAdapters.adaptOpenOrder(LivecoinAdapters.java:178)`