### PR TITLE
[abucoins] Abucoins doesn't support stop orders

### DIFF
--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountService.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsAccountService.java
@@ -19,8 +19,6 @@ import org.knowm.xchange.currency.Currency;
 import org.knowm.xchange.dto.account.AccountInfo;
 import org.knowm.xchange.dto.account.FundingRecord;
 import org.knowm.xchange.exceptions.ExchangeException;
-import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
-import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.account.AccountService;
 import org.knowm.xchange.service.trade.params.DefaultWithdrawFundsParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;

--- a/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeService.java
+++ b/xchange-abucoins/src/main/java/org/knowm/xchange/abucoins/service/AbucoinsTradeService.java
@@ -15,6 +15,7 @@ import org.knowm.xchange.abucoins.dto.trade.AbucoinsOrder;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.exceptions.NotYetImplementedForExchangeException;
 import org.knowm.xchange.service.trade.TradeService;
 import org.knowm.xchange.service.trade.params.CancelOrderByCurrencyPair;
@@ -78,7 +79,7 @@ public class AbucoinsTradeService extends AbucoinsTradeServiceRaw implements Tra
 
   @Override
   public String placeStopOrder(StopOrder stopOrder) throws IOException {
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
@@ -101,12 +102,12 @@ public class AbucoinsTradeService extends AbucoinsTradeServiceRaw implements Tra
 
   @Override
   public UserTrades getTradeHistory(TradeHistoryParams params) throws IOException {
-    throw new NotYetImplementedForExchangeException();
+    throw new NotAvailableFromExchangeException();
   }
 
   @Override
   public TradeHistoryParams createTradeHistoryParams() {
-    throw new NotYetImplementedForExchangeException();
+    return new AbucoinsTradeHistoryParams();
   }
 
   @Override


### PR DESCRIPTION
I sat down to update the Abucoins implementation to support the last generic API call (for creating stop orders).

It turns out their API doesn't support this, so I corrected the exception.