### PR TITLE
[itbit] fix trade tid to matchNumber

### DIFF
--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/ItBitAdapters.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/ItBitAdapters.java
@@ -102,15 +102,15 @@ public final class ItBitAdapters {
   public static Trades adaptTrades(ItBitTrades trades, CurrencyPair currencyPair) throws InvalidFormatException {
 
     List<Trade> tradesList = new ArrayList<>(trades.getCount());
-    long lastTradeId = 0;
+    long lastMatchNumber = 0;
     for (int i = 0; i < trades.getCount(); i++) {
       ItBitTrade trade = trades.getTrades()[i];
-      long tradeId = trade.getTid();
-      if (tradeId > lastTradeId)
-        lastTradeId = tradeId;
+      long matchNumber = trade.getMatchNumber();
+      if (matchNumber > lastMatchNumber)
+        lastMatchNumber = matchNumber;
       tradesList.add(adaptTrade(trade, currencyPair));
     }
-    return new Trades(tradesList, lastTradeId, TradeSortType.SortByID);
+    return new Trades(tradesList, lastMatchNumber, TradeSortType.SortByID);
   }
 
   public static Trade adaptTrade(ItBitTrade trade, CurrencyPair currencyPair) throws InvalidFormatException {
@@ -123,9 +123,9 @@ public final class ItBitAdapters {
       timestamp = matcher.group(1) + "Z";
     }
     Date date = DateUtils.fromISODateString(timestamp);
-    final String tradeId = String.valueOf(trade.getTid());
+    final String matchNumber = String.valueOf(trade.getMatchNumber());
 
-    return new Trade(null, trade.getAmount(), currencyPair, trade.getPrice(), date, tradeId);
+    return new Trade(null, trade.getAmount(), currencyPair, trade.getPrice(), date, matchNumber);
   }
 
   public static List<LimitOrder> adaptOrders(List<BigDecimal[]> orders, CurrencyPair currencyPair, OrderType orderType) {

--- a/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/dto/marketdata/ItBitTrade.java
+++ b/xchange-itbit/src/main/java/org/knowm/xchange/itbit/v1/dto/marketdata/ItBitTrade.java
@@ -9,15 +9,15 @@ public class ItBitTrade {
   private final BigDecimal amount;
   private final String timestamp;
   private final BigDecimal price;
-  private final long tid;
+  private final long matchNumber;
 
   public ItBitTrade(@JsonProperty("amount") BigDecimal amount, @JsonProperty("timestamp") String timestamp, @JsonProperty("price") BigDecimal price,
-      @JsonProperty("tid") long tid) {
+      @JsonProperty("matchNumber") long matchNumber) {
 
     this.amount = amount;
     this.timestamp = timestamp;
     this.price = price;
-    this.tid = tid;
+    this.matchNumber = matchNumber;
   }
 
   public BigDecimal getAmount() {
@@ -35,9 +35,9 @@ public class ItBitTrade {
     return price;
   }
 
-  public long getTid() {
+  public long getMatchNumber() {
 
-    return tid;
+    return matchNumber;
   }
 
   @Override
@@ -50,8 +50,8 @@ public class ItBitTrade {
     builder.append(timestamp);
     builder.append(", price=");
     builder.append(price);
-    builder.append(", tid=");
-    builder.append(tid);
+    builder.append(", matchNumber=");
+    builder.append(matchNumber);
     builder.append("]");
     return builder.toString();
   }


### PR DESCRIPTION
Via https://api.itbit.com/docs#market-data-get-recent-trades-get:

```json
{
    count: 3,
    recentTrades: [
        {
            timestamp: "2015-05-22T17:45:34.7570000Z",
            matchNumber: 27475,
            price: "351.45000000",
            amount: "0.00010000"
        },
        {
            timestamp: "2015-05-22T17:01:08.4270000Z",
            matchNumber: 27474,
            price: "352.00000000",
            amount: "0.00010000"
        },
        {
            timestamp: "2015-05-22T17:01:04.8630000Z",
            matchNumber: 27473,
            price: "351.45000000",
            amount: "0.00010000"
        }
    ]
}
```