### PR TITLE
[ANX, binance] multiple changes

### DIFF
--- a/xchange-anx/pom.xml
+++ b/xchange-anx/pom.xml
@@ -30,5 +30,18 @@
             <version>4.3.4-SNAPSHOT</version>
         </dependency>
 
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${version.powermock}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <version>${version.powermock}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/ANXAdapters.java
+++ b/xchange-anx/src/main/java/org/knowm/xchange/anx/v2/ANXAdapters.java
@@ -251,7 +251,7 @@ public final class ANXAdapters {
     OrderType type = adaptSide(aNXTradeResult.getSide());
     // for fees, getWalletHistory should be used.
     return new UserTrade(type, tradedCurrencyFillAmount, currencyPair, price, aNXTradeResult.getTimestamp(), aNXTradeResult.getTradeId(),
-        aNXTradeResult.getOrderId(), null, (Currency) null);
+        aNXTradeResult.getOrderId(), null, null);
   }
 
   private static CurrencyPair adaptCurrencyPair(String currencyPairRaw) {
@@ -287,7 +287,7 @@ public final class ANXAdapters {
     }
   }
 
-  public static FundingRecord adaptFundingRecord(ANXWalletHistoryEntry entry) {
+  public static FundingRecord adaptFundingRecord(ANXWalletHistoryEntry entry, ANXWalletHistoryEntry feeEntry) {
       /*
       type can be can be any of:
 
@@ -312,6 +312,15 @@ public final class ANXAdapters {
     else
       throw new IllegalStateException("should not get here");
 
+    BigDecimal fee = null;
+    if (feeEntry != null) {
+      if (!feeEntry.getType().equalsIgnoreCase("fee")) {
+        throw new IllegalStateException("feeEntry not null and not of type fee " + feeEntry);
+      } else {
+        fee = feeEntry.getValue().getValue();
+      }
+    }
+
     Long rawDate = Long.valueOf(entry.getDate());
     //this date is not in utc, it's in HK time (I think) - for example: 1495759124000 should translate to 2017-05-26 09:38:44
 
@@ -332,7 +341,7 @@ public final class ANXAdapters {
         type,
         FundingRecord.Status.COMPLETE,
         balance == null ? null : balance.getValue(),
-        null,
+        fee,
         null
     );
   }

--- a/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/service/account/FundingRecordTest.java
+++ b/xchange-anx/src/test/java/org/knowm/xchange/anx/v2/service/account/FundingRecordTest.java
@@ -1,0 +1,72 @@
+package org.knowm.xchange.anx.v2.service.account;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.knowm.xchange.Exchange;
+import org.knowm.xchange.ExchangeSpecification;
+import org.knowm.xchange.anx.v2.ANXExchange;
+import org.knowm.xchange.anx.v2.ANXV2;
+import org.knowm.xchange.anx.v2.dto.account.ANXWalletHistoryWrapper;
+import org.knowm.xchange.anx.v2.service.ANXAccountService;
+import org.knowm.xchange.anx.v2.service.ANXV2Digest;
+import org.knowm.xchange.dto.account.FundingRecord;
+import org.knowm.xchange.service.account.AccountService;
+import org.mockito.internal.stubbing.answers.Returns;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import si.mazi.rescu.RestProxyFactory;
+
+/**
+ * @author ujjwal on 28/02/18.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({RestProxyFactory.class, ANXV2Digest.class})
+public class FundingRecordTest {
+  private ANXV2 anxv2;
+  private ANXV2Digest signatureCreator;
+  private AccountService accountService;
+  private Exchange exchange;
+  private ObjectMapper mapper;
+
+  @Before
+  public void setUp() {
+    mapper = new ObjectMapper();
+    mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    anxv2 = mock(ANXV2.class);
+    signatureCreator = mock(ANXV2Digest.class);
+    exchange = mock(ANXExchange.class);
+    mockStatic(RestProxyFactory.class);
+    when(RestProxyFactory.createProxy(eq(ANXV2.class), any(), any())).thenReturn(anxv2);
+    mockStatic(ANXV2Digest.class, new Returns(signatureCreator));
+    ExchangeSpecification mockExchangeSpecification = mock(ExchangeSpecification.class);
+    when(mockExchangeSpecification.getSslUri()).thenReturn("Non-null-ssl-uri");
+    when(exchange.getExchangeSpecification()).thenReturn(mockExchangeSpecification);
+    accountService = new ANXAccountService(exchange);
+  }
+
+  @Test
+  public void testGetFundingHistory() throws IOException {
+    InputStream is = getClass().getResourceAsStream("/v2/account/example-wallethistory-response.json");
+    ANXWalletHistoryWrapper walletHistoryWrapper = mapper.readValue(is, ANXWalletHistoryWrapper.class);
+    when(anxv2.getWalletHistory(any(), any(), any(), any(), any(), any(), any())).thenReturn(walletHistoryWrapper);
+    List<FundingRecord> fundingRecords = accountService.getFundingHistory(accountService.createFundingHistoryParams());
+    assertThat(fundingRecords.size()).isGreaterThan(0);
+    assertThat(fundingRecords.get(0).getFee()).isNotNull();
+  }
+}

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceCurrencyPairMetaData.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/meta/BinanceCurrencyPairMetaData.java
@@ -1,0 +1,34 @@
+package org.knowm.xchange.binance.dto.meta;
+
+import java.math.BigDecimal;
+
+import org.knowm.xchange.dto.meta.CurrencyPairMetaData;
+
+/**
+ * @author ujjwal on 26/02/18.
+ */
+public class BinanceCurrencyPairMetaData extends CurrencyPairMetaData {
+  private final BigDecimal minNotional;
+
+  /**
+   * Constructor
+   *
+   * @param tradingFee Trading fee (fraction)
+   * @param minimumAmount Minimum trade amount
+   * @param maximumAmount Maximum trade amount
+   * @param priceScale Price scale
+   */
+  public BinanceCurrencyPairMetaData(BigDecimal tradingFee, BigDecimal minimumAmount, BigDecimal maximumAmount, Integer priceScale, BigDecimal minNotional) {
+    super(tradingFee, minimumAmount, maximumAmount, priceScale);
+    this.minNotional = minNotional;
+  }
+
+  public BigDecimal getMinNotional() {
+    return minNotional;
+  }
+
+  @Override
+  public String toString() {
+    return "BinanceCurrencyPairMetaData{" + "minNotional=" + minNotional + "} " + super.toString();
+  }
+}


### PR DESCRIPTION
### [ANX] now populates fee in FundingRecord
Essentially, the walletHistory from ANX provides separate records for trades, deposits, withdrawals and fees. Fees can be matched to appropriate transactions using the transaction id.

### [binance] now has minNotional in currencyMetadata
binance has a minNotional order size filter, which blocks orders, even if they fall between the min and max order quantity. Adding a way to get this for using a CurrencyMetadata subclass.