### PR TITLE
bitmex uses a lower-case 't' in XBT when getting deposit address and sandbox support

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -22,11 +22,34 @@ public class BitmexExchange extends BaseExchange implements Exchange {
   private SynchronizedValueFactory<Long> nonceFactory = new AtomicLongIncrementalTime2013NonceFactory();
 
   @Override
+  public void applySpecification(ExchangeSpecification exchangeSpecification) {
+	  
+    super.applySpecification(exchangeSpecification);
+    
+    concludeHostParams(exchangeSpecification);
+  }
+  
+  @Override
   protected void initServices() {
+	  
+	concludeHostParams(exchangeSpecification);
 
     this.marketDataService = new BitmexMarketDataService(this);
     this.accountService = new BitmexAccountService(this);
     this.tradeService = new BitmexTradeService(this);
+  }
+  
+  /**
+   * Adjust host parameters depending on exchange specific parameters
+   */
+  private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
+
+    if (exchangeSpecification.getExchangeSpecificParameters() != null) {
+      if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox").equals(true)) {
+    	  	exchangeSpecification.setSslUri("https://testnet.bitmex.com/");
+    	  	exchangeSpecification.setHost("testnet.bitmex.com");
+      }
+    }
   }
 
   @Override

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountService.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexAccountService.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.util.List;
 
 import org.knowm.xchange.Exchange;
+import org.knowm.xchange.bitmex.BitmexUtils;
 import org.knowm.xchange.bitmex.dto.account.BitmexAccount;
 import org.knowm.xchange.bitmex.dto.account.BitmexWallet;
 import org.knowm.xchange.currency.Currency;
@@ -55,7 +56,15 @@ public class BitmexAccountService extends BitmexAccountServiceRaw implements Acc
 
     @Override
     public String requestDepositAddress(Currency currency, String... args) throws IOException {
-        return requestDepositAddress(currency.getCurrencyCode());
+    		String currencyCode = currency.getCurrencyCode();
+    		
+    		// bitmex seems to use a lowercase 't' in XBT
+    		// can test this here - https://testnet.bitmex.com/api/explorer/#!/User/User_getDepositAddress
+    		// uppercase 'T' will return 'Unknown currency code'
+    		if (currencyCode.equals("XBT")) {
+    			currencyCode = "XBt";
+    		}
+        return requestDepositAddress(currencyCode);
     }
 
     @Override


### PR DESCRIPTION
Can't currently use requestDepositAddress for Bitmex due to issue with currency code. Fixed in pull request.