### PR TITLE
added support for newly implemented getOrder to gdax and getOpenOrders without currency to binance

### DIFF
--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -87,11 +87,18 @@ public class BinanceAdapters {
     return isBuyer ? OrderType.BID : OrderType.ASK;
   }
 
+  public static CurrencyPair adaptSymbol(String symbol){
+    int pairLength = symbol.length();
+    if (symbol.endsWith("USDT")) {
+      return new CurrencyPair(symbol.substring(0, pairLength - 4), "USDT");
+    } else {
+      return new CurrencyPair(symbol.substring(0, pairLength - 3), symbol.substring(pairLength - 3));
+    }
+  }
+
   public static Order adaptOrder(BinanceOrder order) {
     OrderType type = convert(order.side);
-    String currency = order.symbol;
-    int pairLength = currency.length();
-    CurrencyPair currencyPair;
+    CurrencyPair currencyPair = adaptSymbol(order.symbol);
 
     Order.OrderStatus orderStatus = adaptOrderStatus(order.status);
     final BigDecimal averagePrice;
@@ -99,12 +106,6 @@ public class BinanceAdapters {
       averagePrice = BigDecimal.ZERO;
     } else {
       averagePrice = order.price;
-    }
-
-    if (currency.endsWith("USDT")) {
-      currencyPair = new CurrencyPair(currency.substring(0, pairLength - 4), "USDT");
-    } else {
-      currencyPair = new CurrencyPair(currency.substring(0, pairLength - 3), currency.substring(pairLength - 3));
     }
 
     if (order.type.equals(org.knowm.xchange.binance.dto.trade.OrderType.MARKET)) {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAdapters.java
@@ -120,7 +120,6 @@ public class BinanceAdapters {
               orderStatus
       );
     } else if (order.type.equals(org.knowm.xchange.binance.dto.trade.OrderType.LIMIT)) {
-      if (order.stopPrice.signum() == 0) {
         return new LimitOrder(
                 type,
                 order.origQty,
@@ -144,7 +143,5 @@ public class BinanceAdapters {
                 order.executedQty,
                 orderStatus);
       }
-    }
-    return null;
   }
 }

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/BinanceAuthenticated.java
@@ -160,7 +160,7 @@ public interface BinanceAuthenticated extends Binance {
   @Path("api/v3/openOrders")
   /**
    * Get all open orders on a symbol.
-   * @param symbol
+   * @param symbol            optional
    * @param recvWindow        optional
    * @param timestamp
    * @return

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/OrderType.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/dto/trade/OrderType.java
@@ -3,7 +3,7 @@ package org.knowm.xchange.binance.dto.trade;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 public enum OrderType {
-  LIMIT, MARKET;
+  LIMIT, MARKET, TAKE_PROFIT_LIMIT, STOP_LOSS_LIMIT;
 
   @JsonCreator
   public static OrderType getOrderType(String s) {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeService.java
@@ -40,8 +40,21 @@ public class BinanceTradeService extends BinanceTradeServiceRaw implements Trade
   }
 
   @Override
-  public OpenOrders getOpenOrders() {
-    throw new ExchangeException("You need to provide the currency pair to get the list of open orders.");
+  public OpenOrders getOpenOrders() throws IOException {
+      Long recvWindow = (Long) exchange.getExchangeSpecification().getExchangeSpecificParametersItem("recvWindow");
+      List<BinanceOrder> binanceOpenOrders = super.openOrders(recvWindow, getTimestamp());
+      List<LimitOrder> limitOrders = new ArrayList<>();
+      List<Order> otherOrders = new ArrayList<>();
+      binanceOpenOrders.forEach(binanceOrder->{
+              Order order = BinanceAdapters.adaptOrder(binanceOrder);
+              if(order instanceof LimitOrder){
+                limitOrders.add((LimitOrder) order);
+              }
+              else{
+                otherOrders.add(order);
+              }
+      });
+      return new OpenOrders(limitOrders, otherOrders);
   }
 
   public OpenOrders getOpenOrders(CurrencyPair pair) throws IOException {

--- a/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
+++ b/xchange-binance/src/main/java/org/knowm/xchange/binance/service/BinanceTradeServiceRaw.java
@@ -23,6 +23,10 @@ public class BinanceTradeServiceRaw extends BinanceBaseService {
     super(exchange);
   }
 
+  public List<BinanceOrder> openOrders(Long recvWindow, long timestamp) throws BinanceException, IOException {
+    return binance.openOrders(null, recvWindow, timestamp, super.apiKey, super.signatureCreator);
+  }
+
   public List<BinanceOrder> openOrders(CurrencyPair pair, Long recvWindow, long timestamp) throws BinanceException, IOException {
     return binance.openOrders(BinanceAdapters.toSymbol(pair), recvWindow, timestamp, super.apiKey, super.signatureCreator);
   }

--- a/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/dto/trade/OpenOrders.java
@@ -1,6 +1,7 @@
 package org.knowm.xchange.dto.trade;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -41,10 +42,19 @@ public final class OpenOrders implements Serializable {
   }
 
   /**
-   * @return Orders which are shown on the order book.
+   * @return LimitOrders which are shown on the order book.
    */
   public List<LimitOrder> getOpenOrders() {
     return openOrders;
+  }
+
+  /**
+   * @return All Orders which are shown on the order book.
+   */
+  public List<Order> getAllOpenOrders() {
+    List<Order> allOpenOrders = new ArrayList<>(openOrders);
+    allOpenOrders.addAll(hiddenOrders);
+    return allOpenOrders;
   }
 
   /**

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultCancelOrderParamId.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/DefaultCancelOrderParamId.java
@@ -1,0 +1,15 @@
+package org.knowm.xchange.service.trade.params;
+
+public class DefaultCancelOrderParamId implements CancelOrderByIdParams {
+
+  private String orderId;
+
+  public DefaultCancelOrderParamId(String orderId){
+    this.orderId = orderId;
+  }
+
+  @Override
+  public String getOrderId() {
+    return orderId;
+  }
+}

--- a/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParam.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/service/trade/params/orders/DefaultQueryOrderParam.java
@@ -1,0 +1,20 @@
+package org.knowm.xchange.service.trade.params.orders;
+
+
+public class DefaultQueryOrderParam implements OrderQueryParams{
+    private String orderId;
+
+    public DefaultQueryOrderParam(String orderId){
+        this.orderId = orderId;
+    }
+
+    @Override
+    public void setOrderId(String orderId) {
+        this.orderId = orderId;
+    }
+
+    @Override
+    public String getOrderId() {
+        return orderId;
+    }
+}

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/service/GDAXTradeService.java
@@ -2,12 +2,15 @@ package org.knowm.xchange.gdax.service;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import org.knowm.xchange.Exchange;
 import org.knowm.xchange.dto.Order;
 import org.knowm.xchange.dto.trade.*;
 import org.knowm.xchange.exceptions.FundsExceededException;
+import org.knowm.xchange.exceptions.NotAvailableFromExchangeException;
 import org.knowm.xchange.gdax.GDAXAdapters;
 import org.knowm.xchange.gdax.dto.trade.GDAXFill;
 import org.knowm.xchange.gdax.dto.trade.GDAXIdResponse;
@@ -19,6 +22,7 @@ import org.knowm.xchange.service.trade.params.CancelOrderParams;
 import org.knowm.xchange.service.trade.params.TradeHistoryParams;
 import org.knowm.xchange.service.trade.params.orders.DefaultOpenOrdersParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.orders.OpenOrdersParams;
+import org.knowm.xchange.service.trade.params.orders.OrderQueryParams;
 
 public class GDAXTradeService extends GDAXTradeServiceRaw implements TradeService {
 
@@ -102,5 +106,11 @@ public class GDAXTradeService extends GDAXTradeServiceRaw implements TradeServic
     }
 
     return orders;
+  }
+
+  @Override
+  public Collection<Order> getOrder(
+    OrderQueryParams... orderQueryParams) throws IOException {
+    return getOrder(Arrays.stream(orderQueryParams).map(OrderQueryParams::getOrderId).toArray(String[]::new));
   }
 }


### PR DESCRIPTION
added gdax support for new getOrder function implemented in pr #2361
added support for getOpenOrders without currency mentioned in issue #2287