### PR TITLE
[bitmex] fix exception and NPE

### DIFF
--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -27,8 +27,7 @@ public class BitmexExchange extends BaseExchange implements Exchange {
   private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
-      if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox") != null
-              && exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox").equals("true")) {
+      if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox").equals(true)) {
         exchangeSpecification.setSslUri("https://testnet.bitmex.com/");
         exchangeSpecification.setHost("testnet.bitmex.com");
       }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -27,7 +27,8 @@ public class BitmexExchange extends BaseExchange implements Exchange {
   private static void concludeHostParams(ExchangeSpecification exchangeSpecification) {
 
     if (exchangeSpecification.getExchangeSpecificParameters() != null) {
-      if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox").equals(true)) {
+      if (exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox") != null
+              && exchangeSpecification.getExchangeSpecificParametersItem("Use_Sandbox").equals("true")) {
         exchangeSpecification.setSslUri("https://testnet.bitmex.com/");
         exchangeSpecification.setHost("testnet.bitmex.com");
       }

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/BitmexExchange.java
@@ -61,6 +61,7 @@ public class BitmexExchange extends BaseExchange implements Exchange {
     exchangeSpecification.setPort(80);
     exchangeSpecification.setExchangeName("Bitmex");
     exchangeSpecification.setExchangeDescription("Bitmex is a bitcoin exchange");
+    exchangeSpecification.setExchangeSpecificParametersItem("Use_Sandbox", false);
     return exchangeSpecification;
   }
 

--- a/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceRaw.java
+++ b/xchange-bitmex/src/main/java/org/knowm/xchange/bitmex/service/BitmexMarketDataServiceRaw.java
@@ -124,7 +124,7 @@ public class BitmexMarketDataServiceRaw extends BitmexBaseService {
         if (promptSymbol != null && bitmexSymbolsToIntervalsMap.get(ticker.getSymbol()) != null
             && bitmexSymbolsToIntervalsMap.get(ticker.getSymbol()) != BitmexPrompt.PERPETUAL && !bitmexPromptsToSymbolsMap
             .containsKey(ticker.getSymbol()))
-          bitmexPromptsToSymbolsMap.put(bitmexSymbolsToIntervalsMap.get(ticker.getSymbol()), promptSymbol);
+          bitmexPromptsToSymbolsMap.forcePut(bitmexSymbolsToIntervalsMap.get(ticker.getSymbol()), promptSymbol);
 
         // bitmexTickersToIntervalsMap.put(ticker, bitmexSymbolsToIntervalsMap.get(ticker.getSymbol()));
       }


### PR DESCRIPTION
b47c580 fixes the 4.3.4 NPE was from "Use_Sandbox" not being initialized

92613a8 fixes the exception from remoteInit:  `IllegalArgumentException: value already present: H18`