### PR TITLE
Unified MathContext

### DIFF
--- a/xchange-core/src/main/java/org/knowm/xchange/utils/MathUtils.java
+++ b/xchange-core/src/main/java/org/knowm/xchange/utils/MathUtils.java
@@ -1,0 +1,8 @@
+package org.knowm.xchange.utils;
+
+import java.math.MathContext;
+
+public class MathUtils {
+    
+    public static final MathContext DEFAULT_CONTEXT = new MathContext(8);
+}

--- a/xchange-empoex/src/main/java/org/knowm/xchange/empoex/EmpoExAdapters.java
+++ b/xchange-empoex/src/main/java/org/knowm/xchange/empoex/EmpoExAdapters.java
@@ -1,8 +1,6 @@
 package org.knowm.xchange.empoex;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -25,6 +23,7 @@ import org.knowm.xchange.empoex.dto.marketdata.EmpoExLevel;
 import org.knowm.xchange.empoex.dto.marketdata.EmpoExTicker;
 import org.knowm.xchange.empoex.dto.marketdata.EmpoExTrade;
 import org.knowm.xchange.empoex.dto.trade.EmpoExOpenOrder;
+import org.knowm.xchange.utils.MathUtils;
 
 public final class EmpoExAdapters {
 
@@ -37,7 +36,7 @@ public final class EmpoExAdapters {
     BigDecimal bid = new BigDecimal(raw.getBid().replace(",", ""));
     BigDecimal ask = new BigDecimal(raw.getAsk().replace(",", ""));
     BigDecimal counterVolume = new BigDecimal(raw.getBaseVolume24hr().replace(",", ""));
-    BigDecimal volume = counterVolume.divide(last, new MathContext(8, RoundingMode.HALF_UP));
+    BigDecimal volume = counterVolume.divide(last, MathUtils.DEFAULT_CONTEXT);
 
     return new Ticker.Builder().currencyPair(currencyPair).last(last).high(high).low(low).bid(bid).ask(ask).volume(volume).build();
   }

--- a/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
+++ b/xchange-gdax/src/main/java/org/knowm/xchange/gdax/GDAXAdapters.java
@@ -1,7 +1,6 @@
 package org.knowm.xchange.gdax;
 
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -43,6 +42,7 @@ import org.knowm.xchange.gdax.dto.marketdata.GDAXProductTicker;
 import org.knowm.xchange.gdax.dto.marketdata.GDAXTrade;
 import org.knowm.xchange.gdax.dto.trade.GDAXFill;
 import org.knowm.xchange.gdax.dto.trade.GDAXOrder;
+import org.knowm.xchange.utils.MathUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -173,7 +173,7 @@ public class GDAXAdapters {
     if (order.getFilledSize().signum() == 0) {
       averagePrice = BigDecimal.ZERO;
     } else {
-      averagePrice = order.getExecutedvalue().divide(order.getFilledSize(), new MathContext(8));
+      averagePrice = order.getExecutedvalue().divide(order.getFilledSize(), MathUtils.DEFAULT_CONTEXT);
     }
 
     if (order.getType().equals("market")) {

--- a/xchange-gdax/src/test/java/org/knowm/xchange/gdax/GDAXAdaptersTest.java
+++ b/xchange-gdax/src/test/java/org/knowm/xchange/gdax/GDAXAdaptersTest.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
 import java.math.BigDecimal;
-import java.math.MathContext;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -32,6 +31,7 @@ import org.knowm.xchange.gdax.dto.trade.GDAXOrder;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.knowm.xchange.utils.MathUtils;
 
 import si.mazi.rescu.serialization.jackson.DefaultJacksonObjectMapperFactory;
 import si.mazi.rescu.serialization.jackson.JacksonObjectMapperFactory;
@@ -133,7 +133,7 @@ public class GDAXAdaptersTest {
     assertThat(order.getType()).isEqualTo(OrderType.BID);
     assertThat(order.getTimestamp()).isEqualTo(new Date(1481227745508L));
     assertThat(order.getAveragePrice())
-        .isEqualByComparingTo(new BigDecimal("9.9750556620000000").divide(new BigDecimal("0.01291771"), new MathContext(8)));
+        .isEqualByComparingTo(new BigDecimal("9.9750556620000000").divide(new BigDecimal("0.01291771"), MathUtils.DEFAULT_CONTEXT));
   }
 
   @Test
@@ -158,7 +158,7 @@ public class GDAXAdaptersTest {
     assertThat(order.getType()).isEqualTo(OrderType.ASK);
     assertThat(order.getTimestamp()).isEqualTo(new Date(1515434144454L));
     assertThat(order.getAveragePrice())
-        .isEqualByComparingTo(new BigDecimal("1050.2618069699000000").divide(new BigDecimal("0.07060351"), new MathContext(8)));
+        .isEqualByComparingTo(new BigDecimal("1050.2618069699000000").divide(new BigDecimal("0.07060351"), MathUtils.DEFAULT_CONTEXT));
   }
 
   @Test
@@ -182,7 +182,7 @@ public class GDAXAdaptersTest {
     assertThat(order.getType()).isEqualTo(OrderType.ASK);
     assertThat(order.getTimestamp()).isEqualTo(new Date(1515434144454L));
     assertThat(order.getAveragePrice())
-        .isEqualByComparingTo(new BigDecimal("1050.2618069699000000").divide(new BigDecimal("0.07060351"), new MathContext(8)));
+        .isEqualByComparingTo(new BigDecimal("1050.2618069699000000").divide(new BigDecimal("0.07060351"), MathUtils.DEFAULT_CONTEXT));
   }
 
   @Test
@@ -322,7 +322,7 @@ public class GDAXAdaptersTest {
     assertThat(order.getType()).isEqualTo(OrderType.BID);
     assertThat(order.getTimestamp()).isEqualTo(new Date(1515434144454L));
     assertThat(order.getAveragePrice())
-        .isEqualByComparingTo(new BigDecimal("639.3107535312").divide(new BigDecimal("0.08871972"), new MathContext(8)));
+        .isEqualByComparingTo(new BigDecimal("639.3107535312").divide(new BigDecimal("0.08871972"), MathUtils.DEFAULT_CONTEXT));
 
     assertThat(StopOrder.class.isAssignableFrom(order.getClass())).isTrue();
     StopOrder stop = (StopOrder) order;

--- a/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroTradeServiceRaw.java
+++ b/xchange-vaultoro/src/main/java/org/knowm/xchange/vaultoro/service/VaultoroTradeServiceRaw.java
@@ -2,8 +2,6 @@ package org.knowm.xchange.vaultoro.service;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.math.MathContext;
-import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 
@@ -13,6 +11,7 @@ import org.knowm.xchange.dto.Order.OrderType;
 import org.knowm.xchange.dto.marketdata.OrderBook;
 import org.knowm.xchange.dto.trade.LimitOrder;
 import org.knowm.xchange.exceptions.ExchangeException;
+import org.knowm.xchange.utils.MathUtils;
 import org.knowm.xchange.vaultoro.VaultoroException;
 import org.knowm.xchange.vaultoro.dto.trade.VaultoroCancelOrderResponse;
 import org.knowm.xchange.vaultoro.dto.trade.VaultoroNewOrderResponse;
@@ -84,7 +83,7 @@ public class VaultoroTradeServiceRaw extends VaultoroBaseService {
           price = ds.getLast(currencyPair);
         }
       } else {
-        amount = price.multiply(amount, new MathContext(8, RoundingMode.HALF_DOWN));
+        amount = price.multiply(amount, MathUtils.DEFAULT_CONTEXT);
       }
       try {
         return vaultoro.buy(baseSymbol, type, exchange.getNonceFactory(), apiKey, amount, price, signatureCreator);


### PR DESCRIPTION
I think we should unify our MathContext for all BigDecimal operations where it makes sens and you would not want to see more then 8 digits after the decimal point. There is no point in constructing a new MathContext object for each operation.