### PR TITLE
Bug fix for KucoinAdapter.adaptUserTrade

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/KucoinAdapters.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/dto/KucoinAdapters.java
@@ -99,7 +99,8 @@ public class KucoinAdapters {
 
   private static UserTrade adaptUserTrade(KucoinDealtOrder order) {
 
-    return new UserTrade.Builder().currencyPair(new CurrencyPair(order.getCoinType(), order.getCoinTypePair())).orderId(order.getOid())
+    return new UserTrade.Builder().currencyPair(new CurrencyPair(order.getCoinType(), order.getCoinTypePair()))
+                                  .orderId(order.getOrderOid()).id(order.getOid())
                                   .originalAmount(order.getAmount()).price(order.getDealPrice()).timestamp(new Date(order.getCreatedAt()))
                                   .type(order.getDirection().getOrderType()).feeAmount(order.getFee()).feeCurrency(
             order.getDirection().equals(KucoinOrderType.BUY) ?


### PR DESCRIPTION
Converting KucoinDealtOrder to UserTrade, orderOid is the orderId, oid is the id. Fixes https://github.com/timmolter/XChange/issues/2457