### PR TITLE
[kucoin] Allow to specify (optional) timespan on trade history params.

### DIFF
--- a/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/KucoinTradeHistoryParams.java
+++ b/xchange-kucoin/src/main/java/org/knowm/xchange/kucoin/service/KucoinTradeHistoryParams.java
@@ -3,12 +3,19 @@ package org.knowm.xchange.kucoin.service;
 import org.knowm.xchange.currency.CurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamCurrencyPair;
 import org.knowm.xchange.service.trade.params.TradeHistoryParamPaging;
+import org.knowm.xchange.service.trade.params.TradeHistoryParamsTimeSpan;
 
-public class KucoinTradeHistoryParams implements TradeHistoryParamCurrencyPair, TradeHistoryParamPaging {
+import java.util.Date;
+
+public class KucoinTradeHistoryParams implements
+  TradeHistoryParamCurrencyPair, TradeHistoryParamPaging, TradeHistoryParamsTimeSpan
+{
 
   private CurrencyPair currencyPair;
   private Integer pageLength;
   private Integer pageNumber;
+  private Date startTime;
+  private Date endTime;
 
   @Override
   public Integer getPageLength() {
@@ -43,6 +50,30 @@ public class KucoinTradeHistoryParams implements TradeHistoryParamCurrencyPair, 
   public void setCurrencyPair(CurrencyPair pair) {
 
     this.currencyPair = pair;
+  }
+
+  @Override
+  public Date getStartTime() {
+
+    return startTime;
+  }
+
+  @Override
+  public void setStartTime(Date startTime) {
+
+    this.startTime = startTime;
+  }
+
+  @Override
+  public Date getEndTime() {
+
+    return endTime;
+  }
+
+  @Override
+  public void setEndTime(Date endTime) {
+
+    this.endTime = endTime;
   }
 
 }


### PR DESCRIPTION
Actually a followup PR to support querying trade history with specific start- and end-time (see #2453).