### PR TITLE
Limit parameter for bitbay trades history

### DIFF
--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/Bitbay.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/Bitbay.java
@@ -34,6 +34,7 @@ public interface Bitbay {
   BitbayTrade[] getBitbayTrades(
       @PathParam("currencyPair") String currencyPair,
       @QueryParam("since") long sinceId,
-      @QueryParam("sort") String sort)
+      @QueryParam("sort") String sort,
+      @QueryParam("limit") int limit)
       throws IOException;
 }

--- a/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayMarketDataServiceRaw.java
+++ b/xchange-bitbay/src/main/java/org/knowm/xchange/bitbay/service/BitbayMarketDataServiceRaw.java
@@ -39,12 +39,17 @@ public class BitbayMarketDataServiceRaw extends BitbayBaseService {
       since = ((Number) args[0]).longValue();
     }
     String sort = "asc";
-    if (args.length == 2) {
+    if (args.length >= 2) {
       sort = (String) args[1];
+    }
+    int limit = 50; // param works up to 150
+    if (args.length == 3) {
+      limit = ((Number) args[2]).intValue();
     }
     return bitbay.getBitbayTrades(
         currencyPair.base.getCurrencyCode().toUpperCase() + currencyPair.counter.getCurrencyCode(),
         since,
-        sort);
+        sort,
+        limit);
   }
 }


### PR DESCRIPTION
Lets you download up to 150 trades in one request instead of the default 50